### PR TITLE
Re-enable throwing elec pod / swarmers

### DIFF
--- a/actors/Items/Powerups/SpecialPowerups.dec
+++ b/actors/Items/Powerups/SpecialPowerups.dec
@@ -281,7 +281,7 @@ ACTOR ElecPod : CustomInventory
    Use:
 	  TNT1 A 0 A_GiveInventory("DoElecPod", 1)
 	  TNT1 A 0 A_GiveInventory("ElecPod", 1)//Weird work around I'm doing because I don't have time to put a lot of thought into things. DON'T JUDGE ME.
-     // ELPD A 0 A_ThrowGrenade("ElectricPodSet",4,16,3,0)
+          ELPD A 0 A_ThrowGrenade("ElectricPodSet",4,16,3,0)
       Stop
    } 
 }
@@ -500,7 +500,7 @@ ACTOR Swarmers : CustomInventory
    Use:
 	  TNT1 A 0 A_GiveInventory("DoSwarmPod", 1)
 	  TNT1 A 0 A_GiveInventory("Swarmers", 1)
-      //TNT1 A 0 A_ThrowGrenade("SwarmerPodSet",4,16,3,0)
+          TNT1 A 0 A_ThrowGrenade("SwarmerPodSet",4,16,3,0)
       Stop
    } 
 }


### PR DESCRIPTION
Not sure why the inventory toggle/throwing for swarmers and electro pods were disabled to begin with, but hopefully it was just a human error.

issues #59 #167