### PR TITLE
Feature: increase doomguy fatality speeds

### DIFF
--- a/CVARINFO
+++ b/CVARINFO
@@ -66,6 +66,9 @@ server int cl_regen = 0;
 server int cl_regenamount = 35;
 server int sv_forceregen = 0;
 
+//Fatalities
+server float cl_fatalityspeed = 1.0;
+
 //Footsteps
 user float cl_step_volmul = 7.0;
 user float cl_step_delaymul = 1.0;

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -306,6 +306,10 @@ OptionMenu "GameplaySettings"
 	StaticText " "
 	StaticText " "	
 	
+	Slider "Doomguy Fatalities Speed",				"cl_fatalityspeed", 1.0, 3.0, 0.05, 2
+	StaticText "Increases the speed of Doomguy's fatalities (higher is faster)."
+	StaticText " "
+	StaticText " "	
 }
 
 OptionMenu "SmartScavengerMenu"

--- a/actors/Player/NEWPLAYE.dec
+++ b/actors/Player/NEWPLAYE.dec
@@ -588,16 +588,16 @@ FatalityChecker:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FR32 A 5
+        FR32 A 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		FR32 A 5 A_PlaySound("skeleton/pain")
-		FR32 A 5
+		FR32 A 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAAAAA 0 A_CustomMissile ("CeilBloodLauncher", 40, 0, random (0, 360), 2, random (50, 130))
          NULL AAAA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
 		 NULL AA 0 A_CustomMissile ("XDeath2", 40, 0, random (0, 360), 2, random (0, 160))
 		 NULL AA 0 A_CustomMissile ("XDeath3", 40, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-        FR32 BCDEFGGGGG 6 
+        FR32 BCDEFGGGGG 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -616,17 +616,17 @@ FatalityChecker:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		FSP7 A 4
+		FSP7 A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 	
 		FSP7 B 3 A_PlaySound("grunt/pain")
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-		FSP7 CDE 3
+		FSP7 CDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		FSP7 F 3 A_PlaySound("CLAP",4)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 		TNT1 A 0 A_PlaySound("grunt/pain", 1)
-		FSP7 GGHHH 3
+		FSP7 GGHHH 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/pistol", 3)
 		TNT1 AAAA 0 A_CustomMissile ("XDeath1", 9, -2, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile("YellowFlareSpawn",12,5,0,0)
@@ -634,7 +634,7 @@ FatalityChecker:
 		TNT1 A 0 A_CustomMissile("MonsterTracer", 10, 5, 60, CMF_AIMDIRECTION, -19)
 		TNT1 A 0 A_CustomMissile("GunFireSmoke", 10, 5, 60, CMF_AIMDIRECTION, -19)
 		TNT1 A 0 A_CustomMissile ("ZombiemanHeadExplode", 8, -6, random (0, 360), 2, random (0, 160))
-		FSP7 I 6
+		FSP7 I 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
 		FSP7 JJJJJJ 2 A_CustomMissile ("Brutal_LiquidBlood2", 12, 0, random (0, 360), 2, random (60, 120))
         //////////////////////////////////////////////////////
@@ -653,25 +653,25 @@ FatalityChecker:
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
 		
-		FSP6 A 4
+		FSP6 A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 	
 		FSP6 B 3 A_PlaySound("grunt/pain")
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-		FSP6 CDE 3
+		FSP6 CDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		FSP6 F 3 A_PlaySound("CLAP",4)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 		TNT1 A 0 A_PlaySound("grunt/pain", 1)
-		FSP6 GGG 3
-		FSP6 HHII 3
+		FSP6 GGG 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FSP6 HHII 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0  A_PlaySound("weapons/fistwhoosh")
-		FSP6 H 3
+		FSP6 H 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("barrel/pain", 4)
 		TNT1 AAAA 0 A_CustomMissile ("XDeath1", 9, -2, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("ShotgunguyHeadExplode", 8, -4, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-		FSP6 J 9
+		FSP6 J 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 		FSP6 KKKKKK 2 A_CustomMissile ("Brutal_LiquidBlood2", 12, 0, random (0, 360), 2, random (60, 120))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("RiotSergeantFatality1",1)
@@ -688,7 +688,7 @@ FatalityChecker:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		AVF3 A 7
+		AVF3 A 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		AVF3 A 6 A_Playsound("EYEPULL1")
 		NULL AAAA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
@@ -696,8 +696,8 @@ FatalityChecker:
 		NULL AAA 0 A_CustomMissile ("XDeath3", 40, 0, random (0, 360), 2, random (0, 160))
          NULL AAA 0 A_CustomMissile ("Instestin", 30, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAAAAAAA 0 A_CustomMissile ("BloodMist", 42, 0, random (0, 360), 2, random (20, 90))
-		AVF3 BCDEFG 6
-		AVF3 H 13
+		AVF3 BCDEFG 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		AVF3 H 13 A_SetTics(13 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("HellionFatality",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -716,7 +716,7 @@ FatalityChecker:
 		NULL A 0 ACS_ExecuteAlways(477, 0, 0, 0, 0)//Start Camera
         FD3M L 5 A_PlaySound("demon/pain")
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-        FD3M L 9
+        FD3M L 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 		NULL AAAA 0 A_CustomMissile ("Green_Blood", 10, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAAAAA 0 A_CustomMissile ("GreenBloodMistBig", 40, 0, random (0, 360), 2, random (50, 130))
          NULL AAAA 0 A_CustomMissile ("XDeath1Green", 10, 0, random (0, 360), 2, random (0, 160))
@@ -724,8 +724,8 @@ FatalityChecker:
          NULL AAA 0 A_CustomMissile ("XDeath3Green", 10, 0, random (0, 360), 2, random (0, 160))
          NULL AAAA 0 A_CustomMissile ("Green_Instestin", 50, 0, random (0, 360), 2, random (0, 160))
 		 NULL A 0 A_CustomMissile ("XDeathStomachGreen", 32, 0, random (0, 360), 2, random (0, 160))
-        FD3M MN 6
-		FD3M OO 3
+        FD3M MN 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		FD3M OO 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("VoidSpectreFatality",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -742,13 +742,13 @@ FatalityChecker:
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
 		TNT1 A 0 A_PlaySound("OHSNAP4")
-		BHF2 AB 7
+		BHF2 AB 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("superbaron/pain")
-		BHF2 C 8
+		BHF2 C 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		
-		BHF2 B 6
+		BHF2 B 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("OHSNAP6")
-		BHF2 AB 7
+		BHF2 AB 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		BHF2 C 8 A_PlaySound("superbaron/pain")
 		
 		BHF2 BABC 6 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -761,9 +761,9 @@ FatalityChecker:
 		TNT1 A 0 A_CustomMissile ("SuperWallGreenBlood", 62, 0, random (170, 190), 2, random (0, 40))
 		TNT1 AA 0 A_CustomMissile ("XDeath1Green", 60, 0, random (0, 360), 2, random (0, 160))
 		
-		BHF2 DEE 7
+		BHF2 DEE 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0  A_PlaySound("weapons/fistwhoosh")
-		BHF2 F 6
+		BHF2 F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("EYEPULL1")
 	    TNT1 AAAAA 0 A_CustomMissile ("GreenBloodMistBig", 60, 0, random (0, 360), 2, random (30, 90))
 		TNT1 AAAA 0 A_CustomMissile ("Green_FlyingBlood", 58, 0, random (0, 360), 2, random (30, 90))
@@ -772,7 +772,7 @@ FatalityChecker:
 		TNT1 AAAA 0 A_CustomMissile ("XDeath1Green", 60, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("XDeath2Green", 57, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath3bGreen", 60, 0, random (0, 360), 2, random (50, 80))
-		BHF2 G 8
+		BHF2 G 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		BHF2 H 1 //A_Playsound("superbaron/death")
 		BHF2 HHHHHHHH 2 A_CustomMissile ("Green_LiquidBlood", 62, 0, random (0, 360), 2, random (30, 110))
         //////////////////////////////////////////////////////
@@ -791,11 +791,11 @@ FatalityChecker:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        5KF2 AB 6
+        5KF2 AB 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("BONEBRK3")
-        5KF2 AB 5
+        5KF2 AB 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("BONEBRK3")
-        5KF2 AB 5
+        5KF2 AB 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("BONEBRK3")
         5KF2 ABAB 3 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("misc/xdeath4")
@@ -810,8 +810,8 @@ FatalityChecker:
         5KF2 DDDDD 2 A_CustomMissile ("Brutal_LiquidBlood2", 57, -10, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
         TNT1 A 0 A_PlaySound("CLAP")
-		5KF2 E 6
-		5KF2 FGHGFH 4
+		5KF2 E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		5KF2 FGHGFH 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		5KF2 IJKLM 3 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_Playsound("EYEPULL1")
         TNT1 AA 0 A_CustomMissile ("SmallLSPart1", 55, 0, random (0, 360), 2, random (0, 360))
@@ -834,7 +834,7 @@ FatalityChecker:
 		TNT1 AA 0 A_CustomMissile ("VolcabusEyeballs", 44, 0, random (0, 360), 2, random (0, 360))
 		TNT1 AAA 0 A_CustomMissile ("RevenantDust", 40, 0, random (0, 360), 2, random (0, 360))
 		TNT1 AAAA 0 A_CustomMissile ("RevenantDust2", 40, 0, random (0, 360), 2, random (0, 360))
-		5KF2 P 9
+		5KF2 P 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
 		 NULL A 0 A_TakeInventory("DraugrFatality",1)
 		 NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -851,29 +851,29 @@ FatalityChecker:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        4TYZ AB 4
+        4TYZ AB 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
         NULL A 0  A_PlaySound("grunt/pain")
-        4TYZ BC 3
-        4TYZ DEF 3
+        4TYZ BC 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+        4TYZ DEF 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		
         NULL A 0 A_PlaySound("BURNZOM", 3)
 		
 		//The actor ShakeShakeShake makes the screen shake near the player, improving the overal felling of the fatalities
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		4TYZ FG 2
+		4TYZ FG 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound ("misc/xdeath", 1)
-		4TYZ FG 2
+		4TYZ FG 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound ("misc/xdeath", 1)
-		4TYZ F 2
+		4TYZ F 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-        4TYZ H 4
+        4TYZ H 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
         NULL AA 0 A_CustomMissile ("FatalityBlood", 50, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-        4TYZ I 4
+        4TYZ I 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
         NULL AAAA 0 A_CustomMissile ("FatalityBlood", 50, 0, random (0, 360), 2, random (0, 160))
         NULL AA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 		 
@@ -892,8 +892,8 @@ FatalityChecker:
          NULL AAAA 0 A_CustomMissile ("XDeath3", 60, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAAAA 0 A_CustomMissile ("Instestin", 50, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-		 FTYZ K 2
-         FTYZ L 15
+		 FTYZ K 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+         FTYZ L 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
 		 NULL A 0 A_TakeInventory("HelmetZombieManFatality",1)
 		 NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -909,7 +909,7 @@ FatalityChecker:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        4PZ2 AB 4
+        4PZ2 AB 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -920,9 +920,9 @@ FatalityChecker:
         NULL AA 0 A_CustomMissile ("XDeath2", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AA 0 A_CustomMissile ("XDeath3", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-        4PZ2 C 10
+        4PZ2 C 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("imp/melee")
-        4PZ2 D 10
+        4PZ2 D 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		NULL AAAAA 0 A_CustomMissile ("Instestin2", 32, 0, random (0, 360), 2, random (0, 160))
 		NULL AAA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
 		NULL AAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
@@ -930,9 +930,9 @@ FatalityChecker:
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(582, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
-		4PZ2 EF 3
+		4PZ2 EF 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("grunt/death")
-		4PZ2 G 6
+		4PZ2 G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("HelmetZombieManFatality2",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -951,14 +951,14 @@ FatalityChecker:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        4PZ3 A 6
+        4PZ3 A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 ACS_ExecuteAlways(477, 0, 0, 0, 0)//Start Camera
-		4PZ3 BCDE 3
+		4PZ3 BCDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_PlaySound("grunt/pain", 1)
-		FPZ3 FGGGG 2
+		FPZ3 FGGGG 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         
-		4PZ3 HHHIIIIIIIIHJJJ 1
+		4PZ3 HHHIIIIIIIIHJJJ 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -968,7 +968,7 @@ FatalityChecker:
         NULL AA 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
 		TNT1 A 0 A_SpawnItemEx("SplatteredSmall")
 		
-		4PZ3 KKKLLLLLLKJJJ 1
+		4PZ3 KKKLLLLLLKJJJ 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -978,7 +978,7 @@ FatalityChecker:
         NULL AA 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
 		
         
-		4PZ3 MMMNNNNNNNMOOO 1
+		4PZ3 MMMNNNNNNNMOOO 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -986,7 +986,7 @@ FatalityChecker:
 		NULL A 0 A_PlaySound("player/cyborg/fist", 4)
 		NULL AA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AA 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
-		4PZ3 MMMNNNNNNNMOOO 1
+		4PZ3 MMMNNNNNNNMOOO 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1002,7 +1002,7 @@ FatalityChecker:
 		NULL AAAAAAAA 0 A_CustomMissile ("SmallBrainPiece", 5, 0, random (0, 360), 2, random (0, 160))
 		
 		
-        FPZ3 PPPQQQQQQQPRRR 1
+        FPZ3 PPPQQQQQQQPRRR 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1010,14 +1010,14 @@ FatalityChecker:
 		NULL A 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
 		
-		FPZ3 PPPQQQQQQPRRR 1
+		FPZ3 PPPQQQQQQPRRR 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 A_PlaySound("player/cyborg/fist", 4)
 		NULL A 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
-		FPZ3 RP 3
+		FPZ3 RP 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -1036,14 +1036,14 @@ FatalityHelmetZMan4:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        4PZ4 AB 2
+        4PZ4 AB 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_PlaySound("grunt/pain", 1)
 		NULL A 0 A_PlaySound("player/cyborg/fist", 4)
-		4PZ4 CDEEE 3
-		4PZ4 FGH 2
+		4PZ4 CDEEE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		4PZ4 FGH 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         
-		4PZ4 HHI 2
+		4PZ4 HHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1053,9 +1053,9 @@ FatalityHelmetZMan4:
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_SpawnItemEx("SplatteredSmall", 0, 20)
-		4PZ4 JJJIH 2
+		4PZ4 JJJIH 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
-		4PZ4 HHI 2
+		4PZ4 HHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1064,9 +1064,9 @@ FatalityHelmetZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		4PZ4 JJJIH 2
+		4PZ4 JJJIH 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
-		4PZ4 HHI 2
+		4PZ4 HHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1075,10 +1075,10 @@ FatalityHelmetZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		4PZ4 OOOMN 2
+		4PZ4 OOOMN 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		
-		4PZ4 NNM 2
+		4PZ4 NNM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1087,9 +1087,9 @@ FatalityHelmetZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		4PZ4 OOOMN 2
+		4PZ4 OOOMN 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
-		4PZ4 NNM 2
+		4PZ4 NNM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1098,11 +1098,11 @@ FatalityHelmetZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		4PZ4 OOOMN 2
+		4PZ4 OOOMN 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		
 		
-		4PZ4 NNM 2
+		4PZ4 NNM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1128,8 +1128,8 @@ FatalityHelmetZMan4:
 		NULL A 0 A_CustomMissile ("Brains5", 5, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_SpawnItem("SplatteredLarge")
 		NULL AAAAAAAA 0 A_CustomMissile ("SmallBrainPiece", 5, 0, random (0, 360), 2, random (0, 160))
-		FPZ4 P 7
-		FPZ4 L 6
+		FPZ4 P 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
+		FPZ4 L 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("HelmetZombieManFatality4",1)
@@ -1148,15 +1148,15 @@ FatalityHelmetZMan4:
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
         FT7S A 6 A_PlaySound("grunt/pain")
-        FT7S BC 6
+        FT7S BC 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("BURNZOM", 3)
 
         NULL A 0 A_PlaySound("misc/xdeath")
-        FT7S DE 4
+        FT7S DE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("misc/xdeath")
-		FT7S DE 3
+		FT7S DE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("misc/xdeath")
-		FT7S DEE 2
+		FT7S DEE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -1169,9 +1169,9 @@ FatalityHelmetZMan4:
 		TNT1 AAAAAA 0 A_CustomMissile ("BloodMist", 30, 0, random (0, 360), 2, random (20, 90))
         FT7S FGHIIPPP 2 A_CustomMissile ("Blood", 1, 0, random (0, 360), 2, random (0, 160))
 
-        FT7S QR 5 
+        FT7S QR 5 A_SetTics(5 / GetCVar("cl_fatalityspeed")) 
         NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
-        FT7S R 15
+        FT7S R 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_GiveInventory("ShotgunguyHead", 1)
         ///////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -1188,11 +1188,11 @@ FatalityHelmetZMan4:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FT7S J 3
+        FT7S J 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         FT7S J 1 A_PlaySound("BURNZOM")
-		FT7S JJJJ 3
+		FT7S JJJJ 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		FT7S J 1 A_PlaySound("grunt/death")
-		FT7S K 4
+		FT7S K 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -1203,8 +1203,8 @@ FatalityHelmetZMan4:
 		NULL AA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAAAAAAA 0 A_CustomMissile ("BloodMist", 50, 0, random (0, 360), 2, random (20, 90))
 		NULL A 0 A_CustomMissile ("RipHelmetSergeant", 0, 0, random (0, 360), 2, random (0, 160))
-        FTYS LMNO 3
-        FTYS O 10
+        FTYS LMNO 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+        FTYS O 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
         ///////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("HelmetSergeantFatality2",1)
@@ -1222,14 +1222,14 @@ FatalityHelmetZMan4:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FSP5 A 4
+        FSP5 A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
 		FSP5 B 4 A_PlaySound("grunt/pain")
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-		FSP5 CDE 2
-		FSP5 E 6
+		FSP5 CDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		FSP5 E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
-		FSP5 FG 3
+		FSP5 FG 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("grunt/death")		
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -1241,7 +1241,7 @@ FatalityHelmetZMan4:
 		//NULL AA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
 		 TNT1 AAA 0 A_CustomMissile ("BloodMistSmall", 30, 0, random (0, 360), 2, random (20, 90))
 		
-        FSP5 HIIIIII 3
+        FSP5 HIIIIII 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 	   
 	   NULL A 0 A_PlaySound("weapons/sg")	
 	   XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1258,8 +1258,8 @@ FatalityHelmetZMan4:
 		
 		
 		FSP5 L 3 BRIGHT
-		FSP5 K 3
-		FSP5 J 10
+		FSP5 K 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FSP5 J 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		///////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("HelmetSergeantFatality3",1)
@@ -1275,24 +1275,24 @@ FatalityHelmetZMan4:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        CF1A AAABCDE 2
+        CF1A AAABCDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
           NULL A 0 A_PlaySound("grunt/pain")
 NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
           NULL A 0 A_PlaySound("CLAP")
-        CF1A EFF 7
-        CF1A GHIJK 2
+        CF1A EFF 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
+        CF1A GHIJK 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
           NULL A 0 A_PlaySound("grunt/pain")
 NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
 NULL A 0 A_CustomMissile ("ShakeShakeShake", 50, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 A_CustomMissile ("GoreSound", 22, 0, random (0, 360), 2, random (0, 160))
-         CF1A L 7
+         CF1A L 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 	    
-        CF1A M 15
-        CF1A OPQR 4
+        CF1A M 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
+        CF1A OPQR 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
          NULL A 0 A_PlaySound("grunt/pain")
           NULL A 0 A_PlaySound("grunt/death")
-       CF1A R 15
+       CF1A R 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
 NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(582, 0, 0, 0, 0)
@@ -1304,7 +1304,7 @@ NULL A 0 A_CustomMissile ("ShakeShakeShake", 50, 0, random (0, 360), 2, random (
          NULL AAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
          NULL AAA 0 A_CustomMissile ("XDeath3", 10, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-        CF1A S 25
+        CF1A S 25 A_SetTics(25 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("HelmetComandoFatality1",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -1322,11 +1322,11 @@ NULL A 0 A_CustomMissile ("ShakeShakeShake", 50, 0, random (0, 360), 2, random (
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        CF1C A 1
+        CF1C A 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         CF1C A 1 A_PlaySound("BURNZOM")
-		CF1C AAAA 5
+		CF1C AAAA 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		CFTC B 1 A_PlaySound("grunt/death")
-		CFTC B 6
+		CFTC B 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -1340,8 +1340,8 @@ NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 
 		NULL A 0 A_CustomMissile ("XdeathChainArm", 42, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 A_CustomMissile ("XdeathChainLeg", 42, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 A_CustomMissile ("XdeathGuts", 42, 0, random (0, 360), 2, random (0, 160))
-        CFTC CDEF 4
-        CFTC F 15
+        CFTC CDEF 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+        CFTC F 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("HelmetComandoFatality2",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -1357,7 +1357,7 @@ FatalitySpiderMastermind:
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		SPFD DE 7
+		SPFD DE 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_Playsound("NECK_BRK")
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, -19, random (0, 360), 2, random (0, 160))
@@ -1367,13 +1367,13 @@ FatalitySpiderMastermind:
 		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, -20, random (170, 190), 2, random (0, 40))
 		TNT1 AA 0 A_CustomMissile ("BloodMistBig", 40, -25, random (0, 360), 2, random (30, 90))
 		TNT1 AAAAAA 0 A_CustomMissile ("Teeth", 15, -20, random (0, 360), 2, random (0, 160))
-		SPFD F 10
+		SPFD F 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("misc/gibbed")
-		SPFD G 10
+		SPFD G 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		
-		SPFD H 8
+		SPFD H 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		
-		SPFD I 9
+		SPFD I 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("EYEPULL1")
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1404,7 +1404,7 @@ FatalitySpiderMastermind:
 		SPFD K 3 A_CustomMissile ("GreenFlareSpawnJustSmaller", 16, -20, random (0, 360), 2, random (30, 90))
 		
         TNT1 A 0 A_PlaySound("BFG_FIRE", 1)
-		SPFD L 1
+		SPFD L 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 Radius_Quake(4,34,0,12,0)
         TNT1 A 0 A_PlaySound("BFGEXPLO", 9)
 		TNT1 A 0 Bright A_SpawnItem("GreenShockWave",0,0,0)
@@ -1419,7 +1419,7 @@ FatalitySpiderMastermind:
 		TNT1 AAAAAA 0 A_CustomMissile ("UltraGoreSpawner", 30, 0, random (0, 360), 2, random (0, 180))
 		TNT1 AAAAAAAA 0 A_CustomMissile ("BloodMistXXBig", 30, 0, random (0, 360), 2, random (70, 90))
 		 TNT1 AAAAAAAAAAAAAAA 0 A_CustomMissile ("BloodMistXXBig", 100, 0, random (0, 360), 2, random (20, 90))
-		SPFD MMMMMMM 5
+		SPFD MMMMMMM 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_SpawnItem("BrutalizedSpiderMastermind")
 		TNT1 A 0 A_GiveInventory("SoulSphere",1)
 		TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -1469,20 +1469,20 @@ FatalityLabGuy1: //Face kicker
         TNT1 A 0 ACS_Execute(477,0,0,0,0)
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		FSF1 A 6
-		FSF1 B 4
+		FSF1 A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		FSF1 B 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		 TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
         TNT1 A 0 A_PlaySound("grunt/pain", 1)
 		TNT1 A 0 A_PlaySound("marine/superfist1", 3)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		FSF1 C 8
+		FSF1 C 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Custommissile("DropedBrutalAxe", 32, 0, random (0, 360), 2, random (50, 130))
-		FSF1 DE 5
+		FSF1 DE 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("FUCK1", 4)
-		FSF1 F 30
-		FSF1 G 3
+		FSF1 F 30 A_SetTics(30 / GetCVar("cl_fatalityspeed"))
+		FSF1 G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		 TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1492,11 +1492,11 @@ FatalityLabGuy1: //Face kicker
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-		FSF1 H 4
-		FSF1 M 4
-		FSF1 G 6
+		FSF1 H 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FSF1 M 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FSF1 G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		/////// Kick
-		FSF1 G 3
+		FSF1 G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		 TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1506,11 +1506,11 @@ FatalityLabGuy1: //Face kicker
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-		FSF1 H 4
-		FSF1 M 4
-		FSF1 G 6
+		FSF1 H 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FSF1 M 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FSF1 G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		/////// Kick
-		FSF1 G 3
+		FSF1 G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		 TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1520,11 +1520,11 @@ FatalityLabGuy1: //Face kicker
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-		FSF1 H 4
-		FSF1 M 4
-		FSF1 G 6
+		FSF1 H 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FSF1 M 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FSF1 G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		/////// Kick
-		FSF1 G 3
+		FSF1 G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		 TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1534,11 +1534,11 @@ FatalityLabGuy1: //Face kicker
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-		FSF1 H 4
-		FSF1 M 4
-		FSF1 G 6
+		FSF1 H 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FSF1 M 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FSF1 G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		/////// Kick
-		FSF1 G 3
+		FSF1 G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1548,13 +1548,13 @@ FatalityLabGuy1: //Face kicker
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-		FSF1 H 4
-		FSF1 M 4
+		FSF1 H 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FSF1 M 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("DSSALUTE", 4)
-		FSF1 G 6		
+		FSF1 G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))		
 		/////// FINISH HIM!
-		FSF1 F 35
-		FSF1 G 3
+		FSF1 F 35 A_SetTics(35 / GetCVar("cl_fatalityspeed"))
+		FSF1 G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -1564,9 +1564,9 @@ FatalityLabGuy1: //Face kicker
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-		FSF1 I 5
-		FSF1 J 8
-		FSF1 K 11
+		FSF1 I 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
+		FSF1 J 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
+		FSF1 K 11 A_SetTics(11 / GetCVar("cl_fatalityspeed"))
 		//////////////////////////////////////////////////////
 		TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("LabGuyToken1",1)
@@ -1580,17 +1580,17 @@ FatalityLabGuy2: // axe mutilator
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FSF2 ABC 4
+        FSF2 ABC 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
         TNT1 A 0 A_PlaySound("grunt/pain", 1)
 		TNT1 A 0 A_PlaySound("marine/superfist1", 4)
 		 TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		FSF2 D 5
+		FSF2 D 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
-		FSF2 E 5
-		FSF2 F 15
+		FSF2 E 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
+		FSF2 F 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
@@ -1601,11 +1601,11 @@ FatalityLabGuy2: // axe mutilator
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("misc/xdeath4c", 4)
-		FSF2 G 12
+		FSF2 G 12 A_SetTics(12 / GetCVar("cl_fatalityspeed"))
 		
-		FSF2 H 10
+		FSF2 H 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("LabGuyHead", 1, 0, random (0, 360), 2, random (0, 160))
-		FSF2 P 2
+		FSF2 P 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4a", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 AAA 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
@@ -1616,8 +1616,8 @@ FatalityLabGuy2: // axe mutilator
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
-		FSF2 P 2
-        FSF2 IPJ 4
+		FSF2 P 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+        FSF2 IPJ 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath2", 15, 0, random (0, 360), 2, random (0, 160))
@@ -1627,8 +1627,8 @@ FatalityLabGuy2: // axe mutilator
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		//XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
-		FSF2 P 2
-        FSF2 IPJ 4
+		FSF2 P 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+        FSF2 IPJ 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4a", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 AAA 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
@@ -1638,8 +1638,8 @@ FatalityLabGuy2: // axe mutilator
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
-		FSF2 P 2
-        FSF2 KQL 4
+		FSF2 P 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+        FSF2 KQL 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
@@ -1649,8 +1649,8 @@ FatalityLabGuy2: // axe mutilator
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		//XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
-		FSF2 Q 2
-		 FSF2 KQL 4
+		FSF2 Q 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		 FSF2 KQL 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4a", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
@@ -1661,8 +1661,8 @@ FatalityLabGuy2: // axe mutilator
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
-		 FSF2 Q 2
-		 FSF2 MRN 4
+		 FSF2 Q 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		 FSF2 MRN 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		 TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 AAAA 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
@@ -1672,8 +1672,8 @@ FatalityLabGuy2: // axe mutilator
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		//XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
-		 FSF2 R 2
-		 FSF2 MRN 4
+		 FSF2 R 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		 FSF2 MRN 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4a", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 AA 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
@@ -1684,8 +1684,8 @@ FatalityLabGuy2: // axe mutilator
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
-		 FSF2 R 2
-		 FSF2 MRN 4
+		 FSF2 R 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		 FSF2 MRN 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4a", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
@@ -1696,8 +1696,8 @@ FatalityLabGuy2: // axe mutilator
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		//XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
-		FSF2 R 2
-		FSF2 O 15
+		FSF2 R 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		FSF2 O 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Custommissile("DropedBrutalAxe", 32, 0, random (0, 360), 2, random (50, 130))
         //////////////////////////////////////////////////////
         TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -1712,9 +1712,9 @@ FatalityLabGuy3: //axe - face
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 		 TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		FSF3 AB 4
+		FSF3 AB 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("grunt/sight7",2)
-		FSF3 CD 4
+		FSF3 CD 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 180))
 		TNT1 A 0 A_Playsound("misc/xdeath4c",1)
 		TNT1 AA 0 A_CustomMissile ("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
@@ -1724,7 +1724,7 @@ FatalityLabGuy3: //axe - face
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-		FSF3 EFGH 5
+		FSF3 EFGH 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Custommissile("DropedBrutalAxe", 32, 0, random (0, 360), 2, random (50, 130))
 		//////////////////////////////////////////////////////
         TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -1739,26 +1739,26 @@ FatalityChainsawZombie:
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 		 TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FSF4 ABC 3
-		FSF4 DEEEE 2
-		FSF4 F 2
+        FSF4 ABC 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FSF4 DEEEE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		FSF4 F 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
         TNT1 A 0 A_PlaySound("monsters/zombie/pain",1)
 		TNT1 A 0 A_PlaySound("marine/superfist1", 3)
 		TNT1 AAA 0 A_CustomMissile ("PB_BloodmistSmall", 49, 5, random (0, 360), 2, random (0, 160))
-		FSF4 G 6
-		FSF4 HI 3
+		FSF4 G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		FSF4 HI 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("sawswing", 6)
-		FSF4 J 4
+		FSF4 J 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAA 0 A_CustomMissile ("BloodMistSmall", 32, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 AAAA 0 A_CustomMissile ("XDeath1", 30, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("PB_MuchBlood", 32, 5, random (0, 360), 2, random (0, 160))
-		FSF4 KLM 3 
+		FSF4 KLM 3 A_SetTics(3 / GetCVar("cl_fatalityspeed")) 
 		XXXX A 0 A_CustomMissile ("PB_XDeathChainsawZombieHead", 1, 0, random (0, 360), 2, random (0, 160))
-		FSF4 NOP 3 
+		FSF4 NOP 3 A_SetTics(3 / GetCVar("cl_fatalityspeed")) 
 		FSF4 OPPPP 2 A_CustomMissile ("Brutal_LiquidBlood2", 18, 10, random (0, 360), 2, random (60, 120))
 		FSF4 Q 3 A_PlaySound("sawswing", 5)
-		FSF4 R 3
+		FSF4 R 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/chainsaw/loop", 3, 1, 1)
 		FSF4 SSSSTTTTUUUUVVVV 3 {
 			A_PlaySound("Machete/Yum",4);
@@ -1809,18 +1809,18 @@ FatalityHellTrooper2: //Headbanger Helmet
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 		 TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		HTF2 A 6
+		HTF2 A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("SwingWave1",3)
-		HTF2 BC 3
+		HTF2 BC 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("grunt/sight7",2)
 		TNT1 A 0 A_Playsound("marine/superfist5",4)
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
-		HTF2 DEF 4
+		HTF2 DEF 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 40, 0, 90, 2, random (0, 160))
-		HTF2 G 6
+		HTF2 G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("grunt/sight",1) //random speech (interupted)
-		HTF2 H 6
-		HTF2 IJ 3
+		HTF2 H 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		HTF2 IJ 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_Playsound("misc/xdeath4b",1)
 		TNT1 AA 0 A_CustomMissile ("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
@@ -1830,12 +1830,12 @@ FatalityHellTrooper2: //Headbanger Helmet
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-		HTF2 K 6
+		HTF2 K 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("ZOSCRE",1)
-		HTF2 LM 6
-		HTF2 N 14
+		HTF2 LM 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		HTF2 N 14 A_SetTics(14 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("SwingWave1",3)
-		HTF2 OP 2
+		HTF2 OP 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("misc/xdeath4c",1)
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
@@ -1845,9 +1845,9 @@ FatalityHellTrooper2: //Headbanger Helmet
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-		HTF2 Q 6
-		HTF2 RSTU 4
-		HTF2 V 10
+		HTF2 Q 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		HTF2 RSTU 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		HTF2 V 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		//////////////////////////////////////////////////////
 		TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("HellTrooperFatality2",1)
@@ -1862,37 +1862,37 @@ FatalityHellTrooper3: //chest ripper
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 		 TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        HTF3 AB 6
+        HTF3 AB 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("ZOSCRE", 1)
 		TNT1 A 0 A_PlaySound("marine/superfist1", 4)
         TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		HTF3 C 15
+		HTF3 C 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		TNT1 A 0 A_PlaySound("marine/superfist1", 4)
-		HTF3 D 16
+		HTF3 D 16 A_SetTics(16 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		TNT1 A 0 A_PlaySound("marine/superfist1", 4)
-		HTF3 E 18
+		HTF3 E 18 A_SetTics(18 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAAA 0 A_CustomMissile ("INSTESTIN", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		HTF3 F 8
+		HTF3 F 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4c", 4)
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		HTF3 G 18
-		HTF3 HI 6		
+		HTF3 G 18 A_SetTics(18 / GetCVar("cl_fatalityspeed"))
+		HTF3 HI 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))		
         //////////////////////////////////////////////////////
         TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("HellTrooperFatality3",1)
@@ -1941,7 +1941,7 @@ FatalityAfrit3:
 		 TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
 		AFF3 A 10 A_PlaySound("player/comehere", 1)
-		AFF3 BCDE 2
+		AFF3 BCDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -1950,9 +1950,9 @@ FatalityAfrit3:
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		AFF3 F 5 A_PlaySound("baron/pain", 3)
 		TNT1 A 0 A_Playsound("CLAP",2)
-		AFF3 GHI 2
+		AFF3 GHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		AFF3 J 4 A_Playsound("SwingWave2",1)
-		AFF3 KLM 2
+		AFF3 KLM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -1962,7 +1962,7 @@ FatalityAfrit3:
 		AFF3 N 5 A_PlaySound("DSKNTDTH", 3)
 		TNT1 A 0 A_Playsound("CLAP",2)
 		AFF3 O 2 A_Playsound("SwingWave1",1)
-		AFF3 BCDE 2
+		AFF3 BCDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -1971,9 +1971,9 @@ FatalityAfrit3:
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		AFF3 F 5 A_PlaySound("baron/pain", 3)
 		TNT1 A 0 A_Playsound("CLAP",2)
-		AFF3 GHI 2
+		AFF3 GHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		AFF3 J 4 A_Playsound("SwingWave2",1)
-		AFF3 KLM 2
+		AFF3 KLM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -1982,7 +1982,7 @@ FatalityAfrit3:
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		AFF3 N 5 A_PlaySound("baron/pain", 1)
 		TNT1 A 0 A_Playsound("CLAP",1)
-		AFF3 BCDE 2
+		AFF3 BCDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -1991,11 +1991,11 @@ FatalityAfrit3:
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		AFF3 F 5 A_PlaySound("DSDMPAIN", 3)
 		TNT1 A 0 A_Playsound("CLAP",2)
-		AFF3 GHI 2
+		AFF3 GHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		AFF3 J 4 A_Playsound("SwingWave2",1)
-		AFF3 KLM 2
+		AFF3 KLM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		//FASTER NOW!!!
-		AFF3 BCDE 1
+		AFF3 BCDE 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -2004,9 +2004,9 @@ FatalityAfrit3:
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		AFF3 F 5 A_PlaySound("baron/pain", 3)
 		TNT1 A 0 A_Playsound("CLAP",2)
-		AFF3 GHI 1
+		AFF3 GHI 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		AFF3 J 4 A_Playsound("SwingWave2",1)
-		AFF3 KLM 1
+		AFF3 KLM 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -2015,7 +2015,7 @@ FatalityAfrit3:
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		AFF3 N 5 A_PlaySound("DSKNTDTH", 3)
 		TNT1 A 0 A_Playsound("CLAP",2)
-		AFF3 BCDE 1
+		AFF3 BCDE 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -2024,9 +2024,9 @@ FatalityAfrit3:
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		AFF3 F 5 A_PlaySound("DSDMPAIN", 3)
 		TNT1 A 0 A_Playsound("CLAP",2)
-		AFF3 GHI 1
+		AFF3 GHI 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		AFF3 J 4 A_Playsound("SwingWave2",1)
-		AFF3 KLM 1
+		AFF3 KLM 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -2036,7 +2036,7 @@ FatalityAfrit3:
 		AFF3 N 5 A_PlaySound("DSKNTSIT", 3)
 		TNT1 A 0 A_Playsound("CLAP",2)
 		AFF3 P 7 A_Playsound("BURNUP",1)
-		AFF3 QRSTU 7
+		AFF3 QRSTU 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		
 		//////////////////////////////////////////////////////
         TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -2056,12 +2056,12 @@ FatalityAfrit3:
 
 		TNT1 A 0 A_Playsound("Daedabus/pain",1)
 		TNT1 A 0 A_Playsound("humans/step",1)
-		FDAE A 6
+		FDAE A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("humans/step",1)
 		FDAE BC 6 A_Playsound("humans/step",1)
 		FDAE DE 6 A_Playsound("humans/step",1)
 		FDAE F 5 A_Playsound("Daedabus/pain",1)
-		FDAE GHI 6
+		FDAE GHI 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		XXXX AAAA 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("FUCK5", 3)
 		FDAE K 10 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2131,7 +2131,7 @@ FatalityAfrit3:
 		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
 		TNT1 AAAAAA 0 A_CustomMissile ("Instestin", 32, 0, random (0, 360), 2, random (0, 160))
 		XXXX AAAA 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		FDA1 F 11
+		FDA1 F 11 A_SetTics(11 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("FLMDRAW",8)
 		TNT1 A 0 A_Playsound("misc/gibbed",9)
 		TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)		
@@ -2140,7 +2140,7 @@ FatalityAfrit3:
 		TNT1 AA 0 A_CustomMissile ("xdeath2", 15, 3, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("xdeath3", 15, 3, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("XDeath2", 15, 3, random (0, 360), 2, random (0, 160))
-		FDA1 G 11
+		FDA1 G 11 A_SetTics(11 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("HRSteam",1)//FLMDRAW
 		//////////////////////////////////////////////////////
 		TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -2159,16 +2159,16 @@ FatalityAfrit3:
 		TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		
 		ARF7 A 5 A_PlaySound("marine/superfist1")
-		ARF7 BC 5
+		ARF7 BC 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("arachnophyte/pain")
-		ARF7 D 10
-		ARF7 E 7 
+		ARF7 D 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
+		ARF7 E 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		ARF7 F 7 A_PlaySound("OHSNAP6")
-		ARF7 G 7 
+		ARF7 G 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("EYEPULL1")
 		NULL AAAA 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
-		ARF7 I 6
+		ARF7 I 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("misc/gibbed")
         NULL AAA 0 A_CustomMissile ("CeilBloodLauncher", 30, 0, random (0, 360), 2, random (50, 130))
         NULL AAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 32, 0, random (0, 360), 2, random (0, 160))
@@ -2176,7 +2176,7 @@ FatalityAfrit3:
 		TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 22, 0, random (170, 190), 2, random (0, 40))
 		TNT1 AAAAaA 0 A_CustomMissile ("BloodMistBig", 25, 0, random (0, 360), 2, random (-5, 5))
         XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		ARF7 IJK 6
+		ARF7 IJK 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_CustomMissile ("XDeathArachnotronHead3", 50, 0, random (0, 360), 2, random (40, 130))
         TNT1 A 0 A_SpawnItemEx("ArachnophyteFrame", 0, 1, 1, 1, 1)
 		//////////////////////////////////////////////////////
@@ -2193,25 +2193,25 @@ FatalityAfrit3:
 			TNT1 A 0 ACS_Execute(acsFatality, 0)
 			//////////////////////////////////////////////////////
 			
-			FCY1 A 1
+			FCY1 A 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_Playsound("monster/bruSit", 2)
-			FCY1 ABC 4
+			FCY1 ABC 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_Playsound("weapons/gswing", 3)
-			FCY1 DE 4
-			FCY1 FG 6
+			FCY1 DE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+			FCY1 FG 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 4)
-			FCY1 H 6
+			FCY1 H 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("monster/brudth", 5)
-			FCY1 IJI 4
+			FCY1 IJI 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("NECK_BRK", 1)
 			TNT1 A 0 A_PlaySound("HKPAIN", 6)
-			FCY1 JIJ 4
+			FCY1 JIJ 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("NECK_BRK", 2)
-			FCY1 IJI 4
+			FCY1 IJI 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			FCY1 JIJ 4
+			FCY1 JIJ 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("NECK_BRK", 2)
-			FCY1 IJI 4
+			FCY1 IJI 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
 			TNT1 A 0 A_PlaySound("misc/gibbed", 3)
 			TNT1 AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
@@ -2221,7 +2221,7 @@ FatalityAfrit3:
 			TNT1 AAA 0 A_CustomMissile ("SuperWallRedBlood", 50, 0, random (0, 360), 2, random (-5, 5))
 			TNT1 A 0 A_CustomMissile ("XDeath1", 52, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_CustomMissile ("XDeath2", 52, 0, random (0, 360), 2, random (0, 160))
-			FCY1 KL 6 
+			FCY1 KL 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 			FCY1 MMMMLLLLMMMMLLLLMMMLLLMMLLML 1 A_CustomMissile ("Brutal_LiquidBlood2", 60, 10, random (0, 360), 2, random (60, 120))
 			TNT1 A 0 A_SpawnItemEx("DyingCyberKnight3", 0, 1, 1, 1, 1)
 			TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -2237,25 +2237,25 @@ FatalityAfrit3:
 			//////////////////////////////////////////////////////
 			
 			TNT1 A 0 A_PlaySound("monster/brudth", 4)
-			FCY1 N 6 
+			FCY1 N 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 			TNT1 A 0 A_PlaySound("NECK_BRK", 3)
 			TNT1 A 0 A_SpawnItemEx("ShoqueAzul", 1, 1, 38)
-			FCY1 O 6 
+			FCY1 O 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 			TNT1 A 0 A_PlaySound("NECK_BRK", 4)
-			FCY1 N 6 
+			FCY1 N 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 			TNT1 A 0 A_PlaySound("NECK_BRK", 3)
 			TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 35, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_SpawnItemEx("ShoqueAzul", 1, 1, 38)
-			FCY1 O 6
+			FCY1 O 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 35, 0, random (0, 360), 2, random (0, 160))
-			FCY1 N 6 
+			FCY1 N 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 			TNT1 A 0 A_PlaySound("NECK_BRK", 3)
 			TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 35, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_SpawnItemEx("ShoqueAzul", 1, 1, 38)
-			FCY1 O 6
+			FCY1 O 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 35, 0, random (0, 360), 2, random (0, 160))
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-			FCY1 P 15
+			FCY1 P 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound("misc/gibbed", 3)
 			TNT1 AAA 0 A_SpawnItem("Spark_UpOnce",0,65)
@@ -2265,7 +2265,7 @@ FatalityAfrit3:
 			TNT1 AA 0 A_CustomMissile ("BloodMistExtraBig", 50, 0, random (0, 360), 2, random (20, 90))
 			TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_LiquidBlood2", 52, 0, random (0, 360), 2, random (20, 90))
 			TNT1 AA 0 A_CustomMissile ("SuperWallRedBlood", 50, 0, random (0, 360), 2, random (-5, 5))
-			FCY1 Q 6
+			FCY1 Q 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 53, 5, random (0, 360), 2, random (0, 160))
 			FCY1 R 1 A_CustomMissile ("Brutal_LiquidBlood2", 48, 0, random (0, 360), 2, random (20, 90))
 			TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 53, 5, random (0, 360), 2, random (0, 160))
@@ -2304,7 +2304,7 @@ FatalityAfrit3:
 			TNT1 AA 0 A_CustomMissile("OrangeLensFlareAlt", 34, -10, 0, 0)
 			TNT1 A 0 A_CustomMissile("SmokeSpawner", 34, -10, 15, 0)
 			TNT1 A 0 A_CustomMissile("RedFlareSpawn", 34, -10, 15, 0)
-			FCY1 ST 3
+			FCY1 ST 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			 TNT1 AA 0 A_CustomMissile ("ExplosionSpawner", 30, 4, random (0, 360), 2, random (0, 180))
 			TNT1 AAAA 0 A_CustomMissile ("ExplosionSpawner", 40, 4, random (0, 360), 2, random (0, 180))
 			TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 35, 0, random (0, 360), 2, random (0, 160))
@@ -2318,7 +2318,7 @@ FatalityAfrit3:
 			 TNT1 A 0 A_CustomMissile ("XDeath4", 32, 0, random (0, 360), 2, random (0, 160))
 			 TNT1 A 0 A_CustomMissile ("XDeathGuts", 32, 0, random (0, 360), 2, random (0, 160))
 			 TNT1 AAAAAAA 0 A_CustomMissile ("Instestin", 24, 0, random (0, 360), 2, random (0, 160))
-			FCY1 U 13 
+			FCY1 U 13 A_SetTics(13 / GetCVar("cl_fatalityspeed")) 
 			
 			FCY1 VVVVVVVVVVVVVVVVVVVVVVVVVVV 1 A_CustomMissile ("Brutal_FlyingBlood", 28, 8, random (0, 360), 2, random (0, 160))
 			
@@ -2337,53 +2337,53 @@ FatalityAfrit3:
 			//////////////////////////////////////////////////////
 			TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 1)
-			FCY2 AB 4
+			FCY2 AB 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("HKPAIN", 2)
-			FCY2 C 8
+			FCY2 C 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
-			FCY2 DEF 4
+			FCY2 DEF 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("misc/gibbed", 4)
 			TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AA 0 A_CustomMissile ("MuchBlood", 49, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 42, 0, random (0, 360), 2, random (0, 160))
-			FCY2 G 7
+			FCY2 G 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 			TNT1 AAA 0 A_SpawnItemEx("Spark_UpOnce", 0, 15, 15, 65, 1, 1, 1, SXF_NOCHECKPOSITION)
 			TNT1 A 0 A_SpawnItemEx("ShoqueAzul", 1, 1, 38)
 			TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 42, 0, random (0, 360), 2, random (0, 160))
-			FCY2 H 4
+			FCY2 H 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 AAA 0 A_SpawnItemEx("Spark_UpOnce", 0, 15, 15, 65, 1, 1, 1, SXF_NOCHECKPOSITION)
 			TNT1 A 0 A_SpawnItemEx("ShoqueAzul", 1, 1, 38)
 			TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 42, 0, random (0, 360), 2, random (0, 160))
-			FCY2 I 4
+			FCY2 I 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("HKPAIN", 3)
 			TNT1 AAA 0 A_SpawnItemEx("Spark_UpOnce", 0, 15, 15, 55, 1, 1, 1, SXF_NOCHECKPOSITION)
 			TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 42, 0, random (0, 360), 2, random (0, 160))
-			FCY2 J 4
+			FCY2 J 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 AAA 0 A_SpawnItemEx("Spark_UpOnce", 0, 15, 15, 55, 1, 1, 1, SXF_NOCHECKPOSITION)
 			TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 42, 0, random (0, 360), 2, random (0, 160))
-			FCY2 I 4
+			FCY2 I 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 AAA 0 A_SpawnItemEx("Spark_UpOnce", 0, 15, 15, 55, 1, 1, 1, SXF_NOCHECKPOSITION)
 			TNT1 A 0 A_SpawnItemEx("ShoqueAzul", 1, 1, 38)
 			TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 42, 0, random (0, 360), 2, random (0, 160))
-			FCY2 H 4
+			FCY2 H 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			FCY2 I 3
+			FCY2 I 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("HKPAIN", 5)
 			TNT1 AAA 0 A_SpawnItemEx("Spark_UpOnce", 0, 15, 15, 55, 1, 1, 1, SXF_NOCHECKPOSITION)
 			TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 42, 0, random (0, 360), 2, random (0, 160))
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-			FCY2 J 3
+			FCY2 J 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("EYEPULL", 4)
 			TNT1 A 0 A_SpawnItemEx("ShoqueAzul", 1, 1, 38)
 			TNT1 AAAAAA 0 A_SpawnItemEx("Spark_UpOnce", 0, 15, 15, 55, 1, 1, 1, SXF_NOCHECKPOSITION)
 			TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 42, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AA 0 A_CustomMissile ("XDeath1", 42, 0, random (0, 360), 2, random (0, 160))
-			FCY2 KLM 6
+			FCY2 KLM 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			
 			FCY2 MMMMMMMMMMMMMMMMM 1 A_CustomMissile ("Brutal_FlyingBlood", 52, -5, random (0, 360), 2, random (0, 160))
 		
@@ -2404,66 +2404,66 @@ FatalityAfrit3:
 			TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 			
 			TNT1 A 0 A_Playsound("SMASH1",6)
-			ICFT ABC 3
+			ICFT ABC 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
-			ICFT D 3
+			ICFT D 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 3)
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound ("DSBOTTLE")
 			TNT1 AAA 0 A_CustomMissile ("XIceChunk1", 48, 0, random (0, 360), 2, random (0, 160))
 			
-			ICFT EF 3
+			ICFT EF 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			
-			ICFT GG 5
+			ICFT GG 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			
 			
-			ICFT HI 3
+			ICFT HI 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
-			ICFT J 5
+			ICFT J 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 3)
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound ("DSBOTTLE")
 			TNT1 AAAA 0 A_CustomMissile ("XIceChunk2", 48, 0, random (0, 360), 2, random (0, 160))
 			
-			ICFT KL 3
+			ICFT KL 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
-			ICFT M 4
+			ICFT M 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
 			
-			ICFT N 4
+			ICFT N 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
-			ICFT O 4
+			ICFT O 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			ICFT P 4
+			ICFT P 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 3)
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound ("DSBOTTLE")
 			TNT1 AAAA 0 A_CustomMissile ("XIceChunk1", 48, 0, random (0, 360), 2, random (0, 160))
 			
-			ICFT QR 4
+			ICFT QR 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 3)
-			ICFT S 5
+			ICFT S 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			
-			ICFT TU 3
+			ICFT TU 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			
-			ICFT VW 3
+			ICFT VW 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
 			
-			ICFT X 6
+			ICFT X 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 3)
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound ("DSBOTTLE")
 			TNT1 AAAA 0 A_CustomMissile ("XIceChunk1", 48, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 //A_StopSound("SMASH1")
 			TNT1 A 0 A_PlaySound("DSSALUTE", 6)
-			ICFT YYYY 5
+			ICFT YYYY 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			
-			ICFT Z 3
+			ICFT Z 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 3)
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound ("DSBOTTLE")
 			TNT1 AAAA 0 A_CustomMissile ("XIceChunk1", 48, 0, random (0, 360), 2, random (0, 160))
-			FTIC A 3
+			FTIC A 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound ("DSBOTTLE")
 			TNT1 AAAAAAAAAAAAAAAAA 0 A_CustomMissile ("XIceChunk1", 48, 0, random (0, 360), 2, random (0, 160))
@@ -2473,9 +2473,9 @@ FatalityAfrit3:
 			TNT1 AAAAAAA 0 A_CustomMissile ("XDeath2", 15, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAA 0 A_CustomMissile ("Instestin", 32, 0, random (0, 360), 2, random (0, 160))
 			
-			FTIC B 4
+			FTIC B 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			FTIC CD 3
+			FTIC CD 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			
 			TNT1 A 0 A_SpawnItemEx("FatalizedIceVile", 0, 1, 1, 1, 1)
 			TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -2492,9 +2492,9 @@ FatalityAfrit3:
 			TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 			TNT1 A 0 A_PlaySound("DSSALUTE",7)
 			TNT1 A 0 A_PlaySound("grunt/pain")
-			C8MF A 4
+			C8MF A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("grunt/pain")
-			C8MF AAA 2
+			C8MF AAA 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_CustomMissile ("Blood", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist")
 			TNT1 A 0 A_PlaySound("misc/xdeath4")
@@ -2530,14 +2530,14 @@ FatalityAfrit3:
 			TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
 			TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (170, 190), 2, random (0, 40))
 			
-			C8MF G 4
+			C8MF G 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
 			TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
 			TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
 			TNT1 A 0 A_CustomMissile ("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
 			TNT1 A 0 A_CustomMissile ("Instestin", 32, 0, random (150, 210), 2, random (0, 40))
 			
-			C8MF HHHHHHH 3
+			C8MF HHHHHHH 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_SpawnItem ("BrutalizedChaingunMajor22")
 			TNT1 A 0 A_TakeInventory("GoFatality", 1)
 			TNT1 A 0 A_TakeInventory("ChaingunMajorFatality",1)
@@ -2617,26 +2617,26 @@ FatalityHFQSZ:
         
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        QZY1 A 6
+        QZY1 A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
 		QZY1 B 3 A_PlaySound("grunt/pain")
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-		QZY1 CDE 3
-		QZY1 E 5
+		QZY1 CDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		QZY1 E 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
 		//
 		
-		QZY1 F 5
+		QZY1 F 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-		QZY1 G 5
+		QZY1 G 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
-		QZY1 HIJKL 3
+		QZY1 HIJKL 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
         TNT1 A 0 A_PlaySound("grunt/pain", 1)
 		TNT1 A 0 A_PlaySound("CLAP")
-		QZY1 LMMMM 3
+		QZY1 LMMMM 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         
-		QZY1 NN 3
+		QZY1 NN 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		//BULLETSTORM 1
 		
@@ -2684,9 +2684,9 @@ FatalityHFQSZ:
 		//BULLETS
 		
 		QZY1 O 2 BRIGHT
-		QZY1 PPP 2
+		QZY1 PPP 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("grunt/pain", 1)
-		QZY1 QQQQ 2
+		QZY1 QQQQ 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		//BULLETSTORM 2
 		
@@ -2728,11 +2728,11 @@ FatalityHFQSZ:
 		TNT1 A 0 A_CustomMissile("MonsterTracer", 30, -1, 81, CMF_AIMDIRECTION, -41)
 		
 		QZY1 R 2 BRIGHT
-		QZY1 S 1
+		QZY1 S 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_CustomMissile ("XDeathHFQSZLeg1", 30, -60, random (0, 360), 2, random (45, 135))
 		TNT1 A 0 A_CustomMissile ("RipHFQSZ", 5, -30, random (0, 360), 2, random (180, 360))
-		QZY1 T 3
-		QZY1 TTTUUUUVVVVWWWWWWWWWWWW 2
+		QZY1 T 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		QZY1 TTTUUUUVVVVWWWWWWWWWWWW 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		//EXECUTION
 		
@@ -2752,11 +2752,11 @@ FatalityHFQSZ2:
         
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        QZY2 A 5
+        QZY2 A 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
         QZY2 A 1 A_PlaySound("BURNZOM")
-		QZY2 AAAA 4
+		QZY2 AAAA 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		QZY2 A 1 A_PlaySound("grunt/death")
-		QZY2 B 6
+		QZY2 B 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2767,8 +2767,8 @@ FatalityHFQSZ2:
 		TNT1 AA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("RipHFQSZ", 0, 0, random (0, 360), 2, random (0, 160))
-        QZY2 CDEF 5
-        QZY2 F 10
+        QZY2 CDEF 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
+        QZY2 F 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
         ///////////////////////////////////////////////////////
         TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("HFQSZFatality2",1)
@@ -2784,30 +2784,30 @@ FatalityHFQSZ3:
 		
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        QZY3 AB 5
+        QZY3 AB 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
         TNT1 A 0  A_PlaySound("grunt/pain")
-        QZY3 BCBCBCBC 4
+        QZY3 BCBCBCBC 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
           TNT1 A 0 A_PlaySound("grunt/pain")
-        QZY3 DEF 4
+        QZY3 DEF 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
 		
         TNT1 A 0 A_PlaySound("BURNZOM", 3)
 		
 		//The actor ShakeShakeShake makes the screen shake near the player, improving the overal felling of the fatalities
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		QZY3 FG 3
+		QZY3 FG 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound ("misc/xdeath", 1)
-		QZY3 FG 3
+		QZY3 FG 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound ("misc/xdeath", 1)
-		QZY3 F 3
+		QZY3 F 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-        QZY3 H 5
+        QZY3 H 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
         TNT1 AA 0 A_CustomMissile ("FatalityBlood", 50, 0, random (0, 360), 2, random (0, 160))
         TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-        QZY3 I 5
+        QZY3 I 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
         TNT1 AAAA 0 A_CustomMissile ("FatalityBlood", 50, 0, random (0, 360), 2, random (0, 160))
         TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 		 
@@ -2826,9 +2826,9 @@ FatalityHFQSZ3:
          TNT1 AAAA 0 A_CustomMissile ("XDeath3", 60, 0, random (0, 360), 2, random (0, 160))
          TNT1 AAAAAAA 0 A_CustomMissile ("Instestin", 50, 0, random (0, 360), 2, random (0, 160))
 		 TNT1 AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-		 QZY3 K 2
-         QZY3 L 2
-         QZY3 L 10
+		 QZY3 K 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+         QZY3 L 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+         QZY3 L 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         //TNT1 A 0 A_TakeInventory("ZombieManFatality",1)
 		 TNT1 A 0 A_TakeInventory("HFQSZFatality3",1)
@@ -2845,26 +2845,26 @@ FatalityHFQSZ3:
 			//////////////////////////////////////////////////////
 			TNT1 A 0  A_PlaySound("grunt/pain")
 			TNT1 A 0 A_PlaySound("player/cyborg/fist")
-			U1MF AAAA 3
+			U1MF AAAA 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 			
-			U1MF BB 3
+			U1MF BB 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist")
 			TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 			
-			U1MF CC 3
+			U1MF CC 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 AAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound("BURNZOM", 3)
 			
-			U1MF DD 3
+			U1MF DD 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound ("misc/xdeath", 3)
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAAA 0 A_CustomMissile ("Instestin", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-			U1MF EEE 4
+			U1MF EEE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			U1MF FFFFF 6
+			U1MF FFFFF 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			
 			TNT1 A 0 A_TakeInventory("UndeadMarineFatality1",1)
 			TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -2879,10 +2879,10 @@ FatalityHFQSZ3:
 			TNT1 A 0 ACS_Execute(acsFatality, 0)
 			//////////////////////////////////////////////////////
 			TNT1 A 0 A_Playsound("wizard/pain",2)
-			FW1Z AAAA 5
+			FW1Z AAAA 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/comehere", 1)
 			
-			FW1Z BB 5
+			FW1Z BB 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound ("misc/xdeath", 3)
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
@@ -2890,52 +2890,52 @@ FatalityHFQSZ3:
 			TNT1 AA 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AA 0 A_CustomMissile ("Instestin", 50, 0, random (0, 360), 2, random (0, 160))
 			
-			FW1Z CC 5
+			FW1Z CC 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 AA 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAA 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAA 0 A_CustomMissile ("Instestin", 50, 0, random (0, 360), 2, random (0, 160))
 			
-			FW1Z DEFG 5
+			FW1Z DEFG 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_Playsound("wizard/death")
 			TNT1 AAAAA 0 A_SpawnItemEx("Brutal_Blood", 0, 25, 10, 0, 0)
 			
-			FW1Z HHH 4
+			FW1Z HHH 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			FW1Z I 4
+			FW1Z I 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
 			TNT1 A 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAA 0 A_SpawnItemEx("Brutal_Blood", 0, 25, 10, 0, 0)
 			TNT1 AA 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-			FW1Z HH 5
+			FW1Z HH 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			
-			FW1Z I 4
+			FW1Z I 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
 			TNT1 A 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAA 0 A_SpawnItemEx("Brutal_Blood", 0, 25, 10, 0, 0)
 			TNT1 AAA 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-			FW1Z HH 6
+			FW1Z HH 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			
-			FW1Z I 4
+			FW1Z I 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
 			TNT1 AA 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAA 0 A_SpawnItemEx("Brutal_Blood", 0, 25, 10, 0, 0)
 			TNT1 AAA 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-			FW1Z HH 5
+			FW1Z HH 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			
-			FW1Z I 3
+			FW1Z I 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
 			TNT1 AA 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAA 0 A_SpawnItemEx("Brutal_Blood", 0, 25, 10, 0, 0)
 			TNT1 AAA 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 			
-			FW1Z HH 4
+			FW1Z HH 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			FW1Z I 3
+			FW1Z I 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
 			TNT1 AAAA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAA 0 A_SpawnItemEx("Brutal_Blood", 0, 25, 10, 0, 0)
@@ -2943,9 +2943,9 @@ FatalityHFQSZ3:
 			TNT1 AAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
 			
-			FW1Z HH 4
+			FW1Z HH 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			FW1Z I 3
+			FW1Z I 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
 			TNT1 AAAA 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAAA 0 A_SpawnItemEx("Brutal_Blood", 0, 25, 10, 0, 0)
@@ -2953,9 +2953,9 @@ FatalityHFQSZ3:
 			TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
 			
-			FW1Z HHH 7
+			FW1Z HHH 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 			
-			FW1Z J 3 
+			FW1Z J 3 A_SetTics(3 / GetCVar("cl_fatalityspeed")) 
 			TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
 			TNT1 AAAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
 			TNT1 AAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
@@ -2966,7 +2966,7 @@ FatalityHFQSZ3:
 			TNT1 AAAAAA 0 A_SpawnItemEx("Brutal_Blood", 0, 25, 10, 0, 0)
 			TNT1 AAAAAA 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
-			FW1Z JJJJ 7
+			FW1Z JJJJ 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 			TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
 			
 			TNT1 A 0 A_TakeInventory("FleshWizardFatality",1)
@@ -2982,203 +2982,203 @@ FatalityHFQSZ3:
 				TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 				TNT1 A 0 ACS_Execute(acsFatality, 0)
 				//////////////////////////////////////////////////////
-				O78F A 6
+				O78F A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				
-				O78F B 5
+				O78F B 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("player/cyborg/fist",2)
 				
-				O78F C 6
+				O78F C 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				
-				O78F D 5
+				O78F D 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
 				
-				O78F E 6
+				O78F E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)//special
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
-				O78F F 6
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F G 6
+				O78F G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F F 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F E 6
+				O78F E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F F 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F G 6
+				O78F G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F F 6
-				
-				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
-				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
-				
-				O78F E 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F F 6
+				O78F E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+				
+				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
+				TNT1 A 0 A_Explode(400,55,0)
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
+				
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F G 6
-				
-				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
-				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
-				
-				O78F F 6
+				O78F G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F E 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+				
+				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
+				TNT1 A 0 A_Explode(400,55,0)
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
+				
+				O78F E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F F 6
-				
-				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
-				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
-				
-				O78F G 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F F 6
+				O78F G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+				
+				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
+				TNT1 A 0 A_Explode(400,55,0)
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
+				
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F E 6
-				
-				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
-				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
-				
-				O78F F 6
+				O78F E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F G 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+				
+				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
+				TNT1 A 0 A_Explode(400,55,0)
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
+				
+				O78F G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F F 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F E 6
-				
-				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
-				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
-				
-				O78F F 6
+				O78F E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F G 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+				
+				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
+				TNT1 A 0 A_Explode(400,55,0)
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
+				
+				O78F G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F F 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F E 6
-				
-				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
-				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
-				
-				O78F F 6
+				O78F E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F G 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+				
+				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
+				TNT1 A 0 A_Explode(400,55,0)
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
+				
+				O78F G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F F 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F E 6
-				
-				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
-				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
-				
-				O78F F 6
+				O78F E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F G 6
+				O78F F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+				
+				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
+				TNT1 A 0 A_Explode(400,55,0)
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
+				
+				O78F G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				TNT1 A 0 ACS_Execute(32754, 0, 0, 0, 0)
 				TNT1 A 0 A_Explode(400,55,0)
-				TNT1 A 0 
+				TNT1 A 0 A_SetTics(0 / GetCVar("cl_fatalityspeed")) 
 				
-				O78F HI 6
+				O78F HI 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 				TNT1 A 0 A_PlaySound("monster/ovlpai",6)
 				
-				O78F J 6 
+				O78F J 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 				TNT1 A 0 A_PlaySound("player/cyborg/KICK")
 				TNT1 A 0 A_TakeInventory("OverlordFatality",1)
 				TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -3195,7 +3195,7 @@ FatalityHFQSZ3:
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
 		TNT1 A 0 A_PlaySound("player/cyborg/KICK")
-        FPZ5 ABCD 4
+        FPZ5 ABCD 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 	    EXPL A 0 Radius_Quake (2, 24, 0, 15, 0)
         TNT1 AAA 0 A_CustomMissile ("Brains1", 11, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("Brains2", 11, 0, random (0, 360), 2, random (0, 160))
@@ -3204,7 +3204,7 @@ FatalityHFQSZ3:
 		 TNT1 AA 0 A_CustomMissile ("XDeath2", 1, 0, random (0, 360), 2, random (0, 160))
 		 TNT1 AA 0 A_CustomMissile ("XDeath3", 1, 0, random (0, 360), 2, random (0, 160))
 		 TNT1 AA 0 A_CustomMissile ("XDeath4", 1, 0, random (0, 360), 2, random (0, 160))
-        FPZ5 EFGHIJJJ 4
+        FPZ5 EFGHIJJJ 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("ZombieManFatality5",1)
@@ -3219,18 +3219,18 @@ FatalityHFQSZ3:
         
 			TNT1 A 0 ACS_Execute(acsFatality, 0)
 			//////////////////////////////////////////////////////
-			FPMA A 4
+			FPMA A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
 			FPMA B 3 A_PlaySound("grunt/pain")
 			XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-			FPMA CDE 3
+			FPMA CDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			
-			FPMA F 3
+			FPMA F 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-			FPMA G 3
+			FPMA G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 			TNT1 A 0 A_PlaySound("CLAP",4)
-			FPMA H 3
+			FPMA H 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("grunt/pain", 1)
 			
 			FPMA IJ 2 Bright
@@ -3288,7 +3288,7 @@ FatalityHFQSZ3:
 			
 			
 			TNT1 A 0 A_StopSound(8)
-			FPMA OOO 4 
+			FPMA OOO 4 A_SetTics(4 / GetCVar("cl_fatalityspeed")) 
 			TNT1 A 0 A_TakeInventory("PlasmaZombieFatality",1)
 			TNT1 A 0 A_TakeInventory("GoFatality", 1)
 			TNT1 AAAAA 0 A_GiveInventory("HealthBonus",1)
@@ -3303,18 +3303,18 @@ FatalityHFQSZ3:
         
 			TNT1 A 0 ACS_Execute(acsFatality, 0)
 			//////////////////////////////////////////////////////
-			FPMA A 4
+			FPMA A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
 			FPMA B 3 A_PlaySound("grunt/pain")
 			XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-			FPMA CDE 3
+			FPMA CDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			
-			FPMA F 3
+			FPMA F 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-			FPMA G 3
+			FPMA G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 			TNT1 A 0 A_PlaySound("CLAP",4)
-			FPMA H 3
+			FPMA H 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("grunt/pain", 1)
 			
 			FPMA IJ 2 Bright
@@ -3371,7 +3371,7 @@ FatalityHFQSZ3:
 			TNT1 A 0 A_CustomMissile("ZombiePlasma", 30, -1, 103, CMF_AIMDIRECTION, -20)
 			
 			TNT1 A 0 A_StopSound(8)
-			FPMA OO 3 
+			FPMA OO 3 A_SetTics(3 / GetCVar("cl_fatalityspeed")) 
 			XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound("PLSM8", 4)
 			TNT1 AAA 0 A_CustomMissile ("XDeath1", 5, -40, random (0, 360), 2, random (0, 160))
@@ -3388,7 +3388,7 @@ FatalityHFQSZ3:
 			TNT1 A 0 A_StopSound(8)
 			FPMA QR 2 Bright
 			
-			FPMA RRR 4
+			FPMA RRR 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
 			TNT1 A 0 A_TakeInventory("PlasmaZombieFatality2",1)
 			TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -3403,27 +3403,27 @@ FatalityHFQSZ3:
         
 			TNT1 A 0 ACS_Execute(acsFatality, 0)
 			 //////////////////////////////////////////////////////
-			SGF8 A 5
+			SGF8 A 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			
-			SGF8 B 5
+			SGF8 B 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0  A_PlaySound("grunt/pain")
 			XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 			//SCREAMS!
-			SGF8 A 4
+			SGF8 A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			SGF8 B 4
+			SGF8 B 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0  A_PlaySound("grunt/pain")
 			XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 			//SCREAMS!
-			SGF8 A 4
+			SGF8 A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			SGF8 B 4
+			SGF8 B 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0  A_PlaySound("grunt/pain")
 			TNT1 A 0 A_PlaySound("misc/xdeath4a", 4)
 			XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 			//SPLATTERS!
 			
-			SGF8 CD 4
+			SGF8 CD 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("BURNZOM", 3)
 			TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 29, -5, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAA 0 A_CustomMissile ("Blood", 29, -5, random (0, 360), 2, random (0, 160))
@@ -3432,17 +3432,17 @@ FatalityHFQSZ3:
 			
 			SGF8 EF 4 A_CustomMissile ("Blood", 24, -11, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound("misc/xdeath2c", 5)
-			SGF8 G 5
+			SGF8 G 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("misc/xdeath2c", 5)
 			TNT1 AA 0 A_CustomMissile ("Blood", 29, -5, random (0, 360), 2, random (0, 160))
-			SGF8 H 10
+			SGF8 H 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-			SGF8 H 8
+			SGF8 H 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("misc/xdeath4a", 6)
 			XXXX AAAAA 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-			SGF8 H 6
+			SGF8 H 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-			SGF8 I 4
+			SGF8 I 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 AA 0 A_CustomMissile ("XDeath1", 7, -33, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_CustomMissile ("XDeath4", 8, -30, random (0, 360), 2, random (0, 160))
 			SGF8 JJ 4 A_CustomMissile ("Blood", 29, -27, random (0, 360), 2, random (0, 160))
@@ -3451,14 +3451,14 @@ FatalityHFQSZ3:
 			TNT1 A 0 A_Stopsound(3)
 			
 			XXXX AAA 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-			SGF8 LL 6
+			SGF8 LL 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 			TNT1 AAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 50, 0, random (0, 360), 2, random (50, 130))
 			TNT1 AA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAA 0 A_CustomMissile ("XDeath2", 60, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AA 0 A_CustomMissile ("XDeath3", 60, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAA 0 A_CustomMissile ("Instestin", 50, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-			SGF8 MMM 4
+			SGF8 MMM 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
 			TNT1 A 0 A_TakeInventory("SergeantFatality4",1)
 			TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -3474,46 +3474,46 @@ FatalityHFQSZ3:
 			TNT1 A 0 ACS_Execute(acsFatality, 0)
 			////////////////////////////////////////////////
 			
-			BHF2 A 5
+			BHF2 A 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh",1)
-			BHF2 B 4
+			BHF2 B 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			BHF2 C 4
+			BHF2 C 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/KICK",2)
 			TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-			BHF2 D 4
+			BHF2 D 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("HKPAIN", 3)
-			BHF2 E 4
+			BHF2 E 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			BHF2 FG 4
+			BHF2 FG 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			
-			BHF2 HH 4
+			BHF2 HH 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("CLAP",5)
 			XXXX AAAAA 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-			BHF2 IJ 5
+			BHF2 IJ 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("weapons/fistwhoosh",1)
-			BHF2 KL 4
+			BHF2 KL 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("CLAP",5)
-			BHF2 MN 5
+			BHF2 MN 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 20, 35, random (0, 360), 2, random (0, 160))
 			TNT1 A 0 A_PlaySound("HKPAIN", 3)
-			BHF2 OOO 5
+			BHF2 OOO 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("FUCK", 7)
-			BHF2 PP 5
+			BHF2 PP 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			
-			BHF2 Q 4
+			BHF2 Q 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 2)
 			TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 10, 84, random (0, 360), 2, random (0, 160))
 			TNT1 AA 0 A_CustomMissile ("Blood", 10, 84, random (0, 360), 2, random (0, 160))
-			BHF2 P 5
+			BHF2 P 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("HKPAIN", 4)
-			BHF2 Q 4
+			BHF2 Q 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 2)
 			TNT1 AAAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 10, 84, random (0, 360), 2, random (0, 160))
 			TNT1 AAAA 0 A_CustomMissile ("Blood", 10, 84, random (0, 360), 2, random (0, 160))
-			BHF2 R 5
+			BHF2 R 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("HKPAIN", 4)
-			BHF2 S 4
+			BHF2 S 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 2)
 			TNT1 A 0 A_PlaySound("misc/xdeath4a", 8, 3)
 			XXXX AA 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -3521,27 +3521,27 @@ FatalityHFQSZ3:
 			TNT1 AAAAA 0 A_CustomMissile ("Blood", 10, 84, random (0, 360), 2, random (0, 160))
 			TNT1 AA 0 A_CustomMissile ("SmallBrainPieceFast", 10, 44, random (170, 190), 2, random (-10, 10))
 			TNT1 A 0 A_CustomMissile ("SmallBrainPiece", 12, 84, random (0, 360), 2, random (0, 160))
-			BHF2 R 4
+			BHF2 R 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("HKPAIN", 4)
-			BHF2 S 4
+			BHF2 S 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
 			XXXX AA 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 10, 84, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAA 0 A_CustomMissile ("Blood", 10, 84, random (0, 360), 2, random (0, 160))
 			TNT1 AAA 0 A_CustomMissile ("SmallBrainPieceFast", 10, 44, random (170, 190), 2, random (-10, 10))
 			TNT1 AAA 0 A_CustomMissile ("SmallBrainPiece", 12, 84, random (0, 360), 2, random (0, 160))
-			BHF2 R 4
+			BHF2 R 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("HKPAIN", 4)
-			BHF2 S 4
+			BHF2 S 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
 			XXXX AA 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 10, 84, random (0, 360), 2, random (0, 160))
 			TNT1 AAAAA 0 A_CustomMissile ("Blood", 10, 84, random (0, 360), 2, random (0, 160))
 			TNT1 AAA 0 A_CustomMissile ("SmallBrainPieceFast", 10, 44, random (170, 190), 2, random (-10, 10))
 			TNT1 AAA 0 A_CustomMissile ("SmallBrainPiece", 12, 84, random (0, 360), 2, random (0, 160))
-			BHF2 T 5
+			BHF2 T 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("xdeath2c", 4)
-			BHF2 U 4
+			BHF2 U 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 			TNT1 A 0 A_PlaySound("player/cyborg/fist", 2)
 			TNT1 A 0 A_PlaySound("xdeath", 9, 4)
 			TNT1 AAAAA 0 A_CustomMissile ("Blood", 12, 45, random (0, 360), 2, random (0, 160))
@@ -3567,15 +3567,15 @@ FatalityHFQSZ3:
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
         FTYS A 5 A_PlaySound("grunt/pain")
-        FTYS BC 5
+        FTYS BC 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("BURNZOM", 3)
 
         TNT1 A 0 A_PlaySound("misc/xdeath")
-        FTYS DE 4
+        FTYS DE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath")
-		FTYS DE 4
+		FTYS DE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath")
-		FTYS DE 4
+		FTYS DE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -3589,9 +3589,9 @@ FatalityHFQSZ3:
         FSP4 J 4 A_PlaySound("misc/xdeath4c", 5)
 		FPS4 KLMNN 4 A_CustomMissile ("Blood", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("Blood", 1, 0, random (0, 360), 2, random (0, 160))
-        FPS4 OP 6 
+        FPS4 OP 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
         TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
-        FPS4 P 14
+        FPS4 P 14 A_SetTics(14 / GetCVar("cl_fatalityspeed"))
         ///////////////////////////////////////////////////////
         TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("SergeantFatality5",1)
@@ -3612,7 +3612,7 @@ FatalityHFQSZ3:
 		MDFT CC 3 A_PlaySound("NECK_BRK", 5)
 		TNT1 A 0 A_CustomMissile ("Blood", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("misc/xdeath", 3)
-		MDFT DEF 4
+		MDFT DEF 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4c", 3)
 		TNT1 A 0 A_CustomMissile ("Blood", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
@@ -3634,7 +3634,7 @@ FatalityHFQSZ3:
 	   TNT1 A 0 ACS_Execute(acsFatality, 0)
 	   //////////////////////////////////////////////////////
 	   TNT1 A 0 A_PlaySound("weapons/fistwhoosh",7)
-	   BS4F ABC 4
+	   BS4F ABC 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("gore/headshot", 2)
 	   TNT1 AAA 0 A_CustomMissile ("Green_Blood", 71, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath1Green", 73, 0, random (170, 190), 2, random (0, 40))
@@ -3643,14 +3643,14 @@ FatalityHFQSZ3:
 		TNT1 AAAAAAAAAAAAA 0 A_CustomMissile ("SmallBrainPieceFast", 71, 0, random (170, 190), 2, random (-10, 10))
 		TNT1 AAAAAAAAAA 0 A_CustomMissile ("SmallBrainPiece", 72, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAA 0 A_CustomMissile ("Teeth", 68, -7, random (0, 360), 2, random (0, 160))
-	   BS4F DDE 4
+	   BS4F DDE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 	   
 	   
-	   BS4F F 5
+	   BS4F F 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 	   //blood splashing
 	   TNT1 A 0 A_PlaySound("misc/xdeath2c",8)
 	   TNT1 AAAAAAAA 0 A_SpawnItem ("Green_Blood", 0, 69)
-	   BS4F F 5
+	   BS4F F 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 	   //blood splashing
 	   TNT1 A 0 A_PlaySound("misc/xdeath2c", 9)
 	   TNT1 AAAAAAAA 0 A_SpawnItem ("Green_Blood", 0, 69)
@@ -3661,11 +3661,11 @@ FatalityHFQSZ3:
 		TNT1 AAAA 0 A_CustomMissile ("Green_Instestin", 50, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath2Green", 55, 0, random (170, 190), 2, random (0, 40))
 		TNT1 A 0 A_CustomMissile ("XDeath3Green", 51, 0, random (170, 190), 2, random (0, 40))
-	   BS4F HI 6 
+	   BS4F HI 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 	   TNT1 AAAAAAAA 0 A_CustomMissile ("Green_Blood", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath1Green", 53, 0, random (170, 190), 2, random (0, 40))
 		TNT1 A 0 A_CustomMissile ("XDeath2Green", 55, 0, random (170, 190), 2, random (0, 40))
-	   BS4F II 3
+	   BS4F II 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 	   
 	   TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("BelphegorFatality",1)
@@ -3681,7 +3681,7 @@ FatalityHFQSZ3:
 
 	   TNT1 A 0 ACS_Execute(acsFatality, 0)
 	   //////////////////////////////////////////////////////
-	   FTDI AA 5
+	   FTDI AA 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 	   TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -3690,9 +3690,9 @@ FatalityHFQSZ3:
 		TNT1 A 0 A_CustomMissile ("Blood", 34, -7, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 34, -6, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("Teeth", 34, -7, random (0, 360), 2, random (0, 160))
-	   FTDI B 5
+	   FTDI B 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 	   
-	   FTDI C 8
+	   FTDI C 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 	   
 	   TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -3702,9 +3702,9 @@ FatalityHFQSZ3:
 		TNT1 A 0 A_CustomMissile ("Blood", 34, -7, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 34, -4, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("Teeth", 32, -6, random (0, 360), 2, random (0, 160))
-	   FTDI B 5
+	   FTDI B 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 	   
-	   FTDI C 7
+	   FTDI C 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 	   
 	   TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -3715,9 +3715,9 @@ FatalityHFQSZ3:
 		TNT1 AA 0 A_CustomMissile ("Blood", 34, -7, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 32, -5, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("Teeth", 33, -6, random (0, 360), 2, random (0, 160))
-	   FTDI D 5
+	   FTDI D 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 	   
-	   FTDI E 7
+	   FTDI E 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 	   TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -3730,11 +3730,11 @@ FatalityHFQSZ3:
 		TNT1 AAA 0 A_CustomMissile ("SmallBrainPieceFast", 35, -7, random (170, 190), 2, random (-10, 10))
 		TNT1 AAA 0 A_CustomMissile ("SmallBrainPiece", 33, -7, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAA 0 A_CustomMissile ("Teeth", 31, -7, random (0, 360), 2, random (0, 160))
-	   FTDI F 5
+	   FTDI F 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 	   
 	   FTDI GH 4 A_CustomMissile ("PlayerFlyingBlood", 33, -6, random (0, 360), 2, random (0, 160))
 	   TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
-	   FTDI IJKLM 6
+	   FTDI IJKLM 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 	   
 	   
 	   TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -3750,7 +3750,7 @@ FatalityHFQSZ3:
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
         TNT1 A 0 A_SetInvulnerable
         //////////////////////////////////////////////////////
-        FAFT ABC 5
+        FAFT ABC 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
         TNT1 AAAAAAAAAAAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 45, 0, random (0, 180), 2, random (0, 180))
         FAFT D 5 A_PlaySound("misc/xdeath4")
@@ -3775,33 +3775,33 @@ TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         FAFT LMNOP 5 A_CustomMissile ("Brutal_FlyingBloodTrail", 35, 0, random (0, 180), 2, random (0, 180))
 
 TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
-        FAFT O 9
+        FAFT O 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
         TNT1 A 0 A_PlaySound("fatso/pain")
         TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 55, 0, random (0, 180), 2, random (0, 180))
-        FAFT P 9
+        FAFT P 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
         TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 55, 0, random (0, 180), 2, random (0, 180))
 
-        FAFT O 9
+        FAFT O 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
         TNT1 A 0 A_PlaySound("fatso/pain")
         TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 55, 0, random (0, 180), 2, random (0, 180))
-        FAFT P 9
+        FAFT P 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
         TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 55, 0, random (0, 180), 2, random (0, 180))
 
-        FAFT O 9
+        FAFT O 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 TNT1 A 0 ACS_Execute(582, 0, 0, 0, 0)
         TNT1 A 0 A_PlaySound("fatso/pain")
         TNT1 AAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 55, 0, random (0, 180), 2, random (0, 180))
-        FAFT P 9
+        FAFT P 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 AAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 55, 0, random (0, 180), 2, random (0, 180))
 
-        FAFT O 9
+        FAFT O 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
         TNT1 A 0 A_PlaySound("fatso/pain")
 TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
         TNT1 AAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 55, 0, random (0, 180), 2, random (0, 180))
-        FAFT P 9
+        FAFT P 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
         TNT1 AAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 55, 0, random (0, 180), 2, random (0, 180))
 
@@ -3820,7 +3820,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
        TNT1 A 0 ACS_Execute(acsFatality, 0)
 	   //////////////////////////////////////////////////////
 	   TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
-	   FRAA AAB 3 
+	   FRAA AAB 3 A_SetTics(3 / GetCVar("cl_fatalityspeed")) 
 	   TNT1 A 0 A_PlaySound("misc/xdeath4c", 3)
 	   TNT1 A 0 A_PlaySound("BURNZOM", 2)
 	   FRAA BB 5 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -3845,9 +3845,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 	   //////////////////////////////////////////////////////
 	   TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
 	   XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-	   FRSA AAB 6 
+	   FRSA AAB 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 	   TNT1 A 0 A_PlaySound("grunt/pain", 1)
-	   FRSA BBB 5
+	   FRSA BBB 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 	   TNT1 A 0 A_PlaySound("misc/xdeath4c", 3)
 	   FRSA CC 8 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 	   XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -3883,9 +3883,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		C8FT A 6
+		C8FT A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("HKPAIN", 3)
-		C8FT B 6
+		C8FT B 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("misc/gibbed", 7)
 		TNT1 AAA 0 A_CustomMissile ("SuperWallRedBlood", 2, 0, random (170, 190), 2, random (0, 0))
@@ -3913,14 +3913,14 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 	   TNT1 AAA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 56, 0, random (0, 360), 2, random (0, 360))
 
-		C8FT C 6
+		C8FT C 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/gibbed", 8)
 		TNT1 A 0 A_PlaySound("HKPAIN", 2)
 		TNT1 AAA 0 A_CustomMissile ("XDeath2", 50, 0, random (0, 360), 2, random (0, 160))
 		 TNT1 AAA 0 A_CustomMissile ("XDeath3", 50, 0, random (0, 360), 2, random (0, 160))
 		 TNT1 AAA 0 A_CustomMissile ("SuperWallRedBlood", 2, 0, random (170, 190), 2, random (0, 0))
 	   TNT1 AAAAAAAA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
-		C8FT D 12
+		C8FT D 12 A_SetTics(12 / GetCVar("cl_fatalityspeed"))
 		
 		TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("CyberBaronFatality1",1)
@@ -3936,24 +3936,24 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
 		TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
-		C8FT E 5
+		C8FT E 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAAA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
-		C8FT FF 6 
+		C8FT FF 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 8)
 		TNT1 AA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 56, 0, random (0, 360), 2, random (0, 360))
-		C8FT F 6 
+		C8FT F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 7)
 		TNT1 AA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 56, 0, random (0, 360), 2, random (0, 360))
-		C8FT F 6 
+		C8FT F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 6)
 		TNT1 AA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 56, 0, random (0, 360), 2, random (0, 360))
-		C8FT F 6 
+		C8FT F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 6)
 		TNT1 A 0 A_PlaySound("HEADRIP", 4)
@@ -3962,7 +3962,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 	   TNT1 AAA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
 	    TNT1 AAAAA 0 A_CustomMissile ("MuchBlood", 27, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AA 0 A_CustomMissile ("XDeath3", 50, 0, random (0, 360), 2, random (0, 160))
-		C8FT GH 6
+		C8FT GH 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 0))
 		C8FT HHHHHH 2 A_CustomMissile ("MuchBlood", 31, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -3977,14 +3977,14 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		F4SG A 6
+		F4SG A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 
 		F4SG B 3 A_PlaySound("grunt/pain")
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-		F4SG CDE 3
-		F4SG E 5
+		F4SG CDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		F4SG E 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 
-		F4SG FG 4
+		F4SG FG 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("grunt/death")		
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -3994,7 +3994,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAAA 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
 
 		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-        F4SG HHHH 5
+        F4SG HHHH 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 
 	    TNT1 A 0 A_PlaySound("Weapons/AutoShotgun")	
 	    XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -4008,7 +4008,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 38, -25, random (0, 360), 2, random (0, 160))
 		
 		F4SG I 6 Bright
-		F4SG J 6 
+		F4SG J 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		
 		TNT1 A 0 A_PlaySound("Weapons/AutoShotgun")	
 	    XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -4022,7 +4022,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 38, -25, random (0, 360), 2, random (0, 160))
 		
 		F4SG K 6 Bright
-		F4SG L 6 
+		F4SG L 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		
 		TNT1 A 0 A_PlaySound("Weapons/AutoShotgun")	
 	    XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -4036,7 +4036,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 38, -25, random (0, 360), 2, random (0, 160))
 		
 		F4SG M 6 Bright
-		F4SG N 6 
+		F4SG N 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		
 		TNT1 A 0 A_PlaySound("Weapons/AutoShotgun")	
 	    XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -4049,7 +4049,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAAA 0 A_CustomMissile ("XDeath3", 38, -25, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 38, -25, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("FlyingImpaledASGGuy", 38, -27, random (30, 120), 2, random (70, 110))
-		F4SG OOOO 6 
+		F4SG OOOO 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 
 		///////////////////////////////////////////////////////
         TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -4065,29 +4065,29 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
 		
-		ZPFT ABC 5 
-		ZPFT C 2 
+		ZPFT ABC 5 A_SetTics(5 / GetCVar("cl_fatalityspeed")) 
+		ZPFT C 2 A_SetTics(2 / GetCVar("cl_fatalityspeed")) 
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("grunt/pain")
-		ZPFT DEE 3 
+		ZPFT DEE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed")) 
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh",7)
-		ZPFT F 3 
+		ZPFT F 3 A_SetTics(3 / GetCVar("cl_fatalityspeed")) 
 		TNT1 A 0 A_PlaySound("grunt/pain",4)
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_Playsound("misc/xdeath4b",1)
 		TNT1 AA 0 A_CustomMissile ("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
 		TNT1 A 0 A_CustomMissile ("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		ZPFT FGKH 5 
+		ZPFT FGKH 5 A_SetTics(5 / GetCVar("cl_fatalityspeed")) 
 		ZPFT IJKLMM 3 A_CustomMissile("PlayerFlyingBlood", 12, 15, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh",7)
-		ZPFT NOO 3 
+		ZPFT NOO 3 A_SetTics(3 / GetCVar("cl_fatalityspeed")) 
 		TNT1 A 0 A_Playsound("misc/xdeath4c",1)
 		XXXX A 0 A_CustomMissile ("shakeshakeshake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
 		TNT1 AAAA 0 A_CustomMissile ("SmallBrainPiece", 30, 10, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 10, random (0, 360), 2, random (0, 160)) 
-		ZPFT PP 4
+		ZPFT PP 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
 		TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("ZSpecFatality",1)
@@ -4103,7 +4103,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		 TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
 		FTL1 A 6 A_PlaySound("imp/pain", 3)
-		FTL1 BCDE 2
+		FTL1 BCDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -4111,45 +4111,45 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		FTL1 F 5 A_PlaySound("imp/pain", 3)
 		FTL1 A 0 A_Playsound("CLAP",2)
-		FTL1 GHI 2
+		FTL1 GHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		FTL1 J 4 A_Playsound("SwingWave2",1)
-		FTL1 KKLL 1
+		FTL1 KKLL 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		FTL1 A 1 A_PlaySound("imp/death", 1)
 		TNT1 A 0 A_Playsound("CLAP",1)
-		FTL1 BCDE 2
+		FTL1 BCDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		FTL1 F 4 
+		FTL1 F 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("CLAP",2)
-		FTL1 GHI 2
+		FTL1 GHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		FTL1 J 4 A_Playsound("SwingWave2",1)
-		FTL1 KKLL 1
+		FTL1 KKLL 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		FTL1 A 4 
+		FTL1 A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("CLAP",2)
 		FTL1 B 2 A_Playsound("SwingWave1",1)
-		FTL1 CDE 2
+		FTL1 CDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(584, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		//XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		FTL1 F 4 
+		FTL1 F 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("CLAP",2)
-		FTL1 GHI 2
+		FTL1 GHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		FTL1 J 4 A_Playsound("SwingWave2",1)
-		FTL1 KLL 1
+		FTL1 KLL 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
@@ -4158,9 +4158,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAAAAA 0 A_CustomMissile ("xdeath2", 2, -12, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		FTL1 M 5 
+		FTL1 M 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("CLAP",2)
-		FTL1 M 25 
+		FTL1 M 25 A_SetTics(25 / GetCVar("cl_fatalityspeed"))
 		//////////////////////////////////////////////////////
         TNT1 A 0 A_TakeInventory("GoFatality", 1)
 		TNT1 A 0 A_TakeInventory("ImpFatality5",1)
@@ -4175,19 +4175,19 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FRFZ A 4
+        FRFZ A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
-		FRFZ ABCDE 3
+		FRFZ ABCDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("CLAP",2)
        // XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
         TNT1 A 0 A_PlaySound("grunt/pain", 1)
-		FRFZ FGGGG 3
+		FRFZ FGGGG 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
-		FRFZ HI 3
+		FRFZ HI 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 5, 30, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("misc/gibbed", 5)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		FRFZ JJ 6
+		FRFZ JJ 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("Weapons/Rifle/SFire", 4)
 		TNT1 A 0 A_PlaySound("fleshimpact", 2)
 		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 5, -40, random (0, 360), 2, random (0, 160))
@@ -4195,7 +4195,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("xdeath3", 2, 25, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile("YellowFlareSpawn",12,5,0,0)
 		TNT1 A 0 A_CustomMissile("MonsterTracer", 10, 5, 258, CMF_AIMDIRECTION, -19)
-		FRFZ K 3
+		FRFZ K 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("Weapons/Rifle/SFire", 4)
 		TNT1 A 0 A_PlaySound("fleshimpact", 2)
 		TNT1 AAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 5, -40, random (0, 360), 2, random (0, 160))
@@ -4203,7 +4203,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("xdeath2", 2, 25, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile("YellowFlareSpawn",12,5,0,0)
 		TNT1 A 0 A_CustomMissile("MonsterTracer", 10, 5, 258, CMF_AIMDIRECTION, -19)
-		FRFZ L 3
+		FRFZ L 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("Weapons/Rifle/SFire", 4)
 		TNT1 A 0 A_PlaySound("fleshimpact", 2)
 		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 5, -40, random (0, 360), 2, random (0, 160))
@@ -4211,7 +4211,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("xdeath2", 2, 25, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile("YellowFlareSpawn",12,5,0,0)
 		TNT1 A 0 A_CustomMissile("MonsterTracer", 10, 5, 258, CMF_AIMDIRECTION, -19)
-		FRFZ K 3
+		FRFZ K 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("Weapons/Rifle/SFire", 4)
 		TNT1 A 0 A_PlaySound("fleshimpact", 2)
 		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 5, -40, random (0, 360), 2, random (0, 160))
@@ -4219,7 +4219,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("xdeath2", 2, 25, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile("YellowFlareSpawn",12,5,0,0)
 		TNT1 A 0 A_CustomMissile("MonsterTracer", 10, 5, 258, CMF_AIMDIRECTION, -19)
-		FRFZ L 3
+		FRFZ L 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("Weapons/Rifle/SFire", 4)
 		TNT1 A 0 A_PlaySound("fleshimpact", 2)
 		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 5, -40, random (0, 360), 2, random (0, 160))
@@ -4227,7 +4227,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAAA 0 A_CustomMissile ("xdeath2", 2, 25, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile("YellowFlareSpawn",12,5,0,0)
 		TNT1 A 0 A_CustomMissile("MonsterTracer", 10, 5, 258, CMF_AIMDIRECTION, -19)
-		FRFZ M 3
+		FRFZ M 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("Weapons/Rifle/SFire", 6)
 		TNT1 A 0 A_PlaySound("misc/gibbed", 5)
 		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 5, -40, random (0, 360), 2, random (0, 160))
@@ -4235,7 +4235,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AA 0 A_CustomMissile ("xdeath2", 2, 25, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile("YellowFlareSpawn",12,5,0,0)
 		TNT1 A 0 A_CustomMissile("MonsterTracer", 10, 5, 258, CMF_AIMDIRECTION, -19)
-		FRFZ N 3
+		FRFZ N 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		FRFZ OOOOO 3 A_CustomMissile ("PlayerFlyingBlood", 5, -40, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_TakeInventory("RapidFireTrooperFatality",1)
@@ -4251,31 +4251,31 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
-		AVF2 A 5
+		AVF2 A 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 55, 10, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
-		AVF2 B 4
+		AVF2 B 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
-		AVF2 C 6
+		AVF2 C 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
 		
-		AVF2 D 5
+		AVF2 D 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 5)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 55, 3, random (0, 360), 2, random (0, 160))
-		AVF2 E 5
+		AVF2 E 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
-		AVF2 D 7
+		AVF2 D 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 5)
 	//	XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 55, 5, random (0, 360), 2, random (0, 160))
-		AVF2 E 5
+		AVF2 E 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
-		AVF2 D 8
+		AVF2 D 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 5)
 	//	XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 55, 12, random (0, 360), 2, random (0, 160))
-		AVF2 E 5
+		AVF2 E 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 6)
 		TNT1 A 0 A_PlaySound("misc/gibbed", 7)
@@ -4283,89 +4283,89 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("xdeath2", 54, 12, random (0, 360), 2, random (0, 160))
 		AVF2 F 5 A_PlaySound("vile/pain",8)
 		
-		AVF2 G 9
+		AVF2 G 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 55,12, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath2", 55, 5, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 55, 13, random (0, 360), 2, random (0, 160))
-		AVF2 HG 5
+		AVF2 HG 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 55, 12, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath2", 15, 13, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 11, random (0, 360), 2, random (0, 160))
-		AVF2 HG 5
+		AVF2 HG 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("vile/pain",8)
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 14, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("xdeath2", 15, 12, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 11, random (0, 360), 2, random (0, 160))
-		AVF2 HI 5
+		AVF2 HI 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 11, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("xdeath2", 35, 12, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 13, random (0, 360), 2, random (0, 160))
-		AVF2 JI 5
+		AVF2 JI 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 55, 14, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("xdeath2", 15, 11, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 12, random (0, 360), 2, random (0, 160))
-		AVF2 JI 5
+		AVF2 JI 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("vile/pain",8)
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 13, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("xdeath3", 45, 14, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 46, 15, random (0, 360), 2, random (0, 160))
-		AVF2 JK 5
+		AVF2 JK 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 13, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 11, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 55, 8, random (0, 360), 2, random (0, 160))
-		AVF2 JK 5
+		AVF2 JK 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 9, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 11, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 55, 8, random (0, 360), 2, random (0, 160))
-		AVF2 LK 5
+		AVF2 LK 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 8, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("xdeath3", 45, 14, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 55, 10, random (0, 360), 2, random (0, 160))
-		AVF2 LK 5
+		AVF2 LK 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("vile/pain",8)
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 45, 13, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath2", 25, 11, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 55, 14, random (0, 360), 2, random (0, 160))
-		AVF2 L 5 
+		AVF2 L 5 A_SetTics(5 / GetCVar("cl_fatalityspeed")) 
 		TNT1 A 0 A_PlaySound("vile/death",9)
-		AVF2 M 5 
+		AVF2 M 5 A_SetTics(5 / GetCVar("cl_fatalityspeed")) 
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_Playsound("CLAP",2)
-		AVF2 N 10
+		AVF2 N 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("xdeath3", 15, 4, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		AVF2 O 5
+		AVF2 O 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c")
 		TNT1 AA 0 A_CustomMissile ("PlayerFlyingBlood", 17, 3, random (0, 360), 2, random (0, 160)) 
-		AVF2 PN 4
+		AVF2 PN 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("xdeath2", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		AVF2 O 6
+		AVF2 O 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c")
 		TNT1 AA 0 A_CustomMissile ("PlayerFlyingBlood", 17, 3, random (0, 360), 2, random (0, 160)) 
-		AVF2 PN 5
+		AVF2 PN 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
 		TNT1 AAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160)) 
 		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		AVF2 O 7
+		AVF2 O 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c")
 		TNT1 AA 0 A_CustomMissile ("PlayerFlyingBlood", 17, 3, random (0, 360), 2, random (0, 160)) 
-		AVF2 PNNN 6
+		AVF2 PNNN 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
 		TNT1 A 0 A_TakeInventory("ArchVileFatality2",1)
 		TNT1 A 0 A_TakeInventory("GoFatality", 1)
@@ -4380,9 +4380,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
 		
-		D1F1 A 6
+		D1F1 A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
-		D1F1 BC 2
+		D1F1 BC 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("dimp/pain", 1)
 		TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
@@ -4399,9 +4399,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 47, 0, random (0, 360), 2, random (0, 160))
 		D1F1 E 3 A_CustomMissile ("Brutal_FlyingBlood", 46, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 47, 0, random (0, 360), 2, random (0, 160))
-		D1F1 F 6
+		D1F1 F 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
-		D1F1 E 2
+		D1F1 E 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("dimp/pain", 1)
 		TNT1 A 0 A_PlaySound("misc/gibbed", 4)
@@ -4414,36 +4414,36 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AA 0 A_CustomMissile ("SmallBrainPieceFast", 50, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 47, 3, random (0, 360), 2, random (0, 160)) 
-		D1F1 D 5
+		D1F1 D 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
-		D1F1 E 3
+		D1F1 E 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 47, 0, random (0, 360), 2, random (0, 160))
-		D1F1 F 8
+		D1F1 F 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 54, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("dimp/pain", 1)
-		D1F1 GH 5
+		D1F1 GH 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh",1)
-		D1F1 IJKLM 2
+		D1F1 IJKLM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
         NULL A 0 A_PlaySound("CLAP")
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 14, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 17, 3, random (0, 360), 2, random (0, 160))
-		D1F1 N 3
+		D1F1 N 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
-		D1F1 OPQR 3
+		D1F1 OPQR 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
-		D1F1 S 4
+		D1F1 S 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("dimp/pain", 1)
 		TNT1 A 0 A_PlaySound("NECK_BRK", 4)
-		D1F1 T 4
+		D1F1 T 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
-		D1F1 S 4
+		D1F1 S 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("dimp/pain", 2)
 		TNT1 A 0 A_PlaySound("NECK_BRK", 4)
-		D1F1 T 4
+		D1F1 T 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("dimp/death", 3)
-		D1F1 ST 2
+		D1F1 ST 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/gibbed", 4)
 		TNT1 A 0 A_PlaySound("NECK_BRK", 5)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -4452,7 +4452,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 37, 3, random (0, 360), 2, random (0, 160)) 
 		D1F1 UVWWX 4 A_CustomMissile ("Brutal_FlyingBlood", 14, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
-		D1F1 Y 3
+		D1F1 Y 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 6)
 		TNT1 A 0 A_CustomMissile ("Teeth", 10, -6, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 14, -8, random (0, 360), 2, random (0, 160))
@@ -4461,13 +4461,13 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("xdeath2", 10, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("SmallBrainPiece", 28, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("xdeath2", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
-		D1F1 Z 8
+		D1F1 Z 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c", 7)
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 22, -3, random (0, 360), 2, random (0, 160)) 
 		TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 22, -3, random (0, 360), 2, random (0, 160)) 
-		D1F1 YX 3
+		D1F1 YX 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh",1)
-		D1F1 Y 3
+		D1F1 Y 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c", 2)
 		TNT1 A 0 A_CustomMissile ("Teeth", 10, -6, random (0, 360), 2, random (0, 160))
@@ -4479,13 +4479,13 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("SmallBrainPiece", 10, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("SmallBrainPiece", 18, 0, random (0, 360), 2, random (0, 160))
 		//TNT1 A 0 A_CustomMissile ("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
-		D1F1 Z 6
+		D1F1 Z 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c", 3)
 		TNT1 A 0 A_CustomMissile ("PlayerFlyingBlood", 12, -3, random (0, 360), 2, random (0, 160)) 
 		TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 22, -3, random (0, 360), 2, random (0, 160))
-		D1F2 AB 3
+		D1F2 AB 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
-		D1F2 A 3
+		D1F2 A 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c", 4)
 		TNT1 AAA 0 A_CustomMissile ("MuchBlood", 8, -15, random (0, 360), 2, random (0, 160))
@@ -4495,11 +4495,11 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("SmallBrainPiece", 8, 0, random (0, 360), 2, random (0, 160))
 		//TNT1 A 0 A_CustomMissile ("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
-		D1F2 C 6
+		D1F2 C 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
-		D1F2 AB 3
+		D1F2 AB 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
-		D1F2 A 3
+		D1F2 A 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c", 4)
 		TNT1 AAA 0 A_CustomMissile ("MuchBlood", 8, -15, random (0, 360), 2, random (0, 160))
@@ -4508,7 +4508,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AA 0 A_CustomMissile ("xdeath2", 16, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("SmallBrainPiece", 8, 0, random (0, 360), 2, random (0, 160))
-		D1F2 C 4
+		D1F2 C 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
 		D1F2 DDDD 3 A_CustomMissile ("Brutal_FlyingBlood", 14, -8, random (0, 360), 2, random (0, 160))
 		//TNT1 AAAAAAAAA 0
@@ -4528,46 +4528,46 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
 		
-		D2F1 A 8
+		D2F1 A 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
-		D2F1 A 2
+		D2F1 A 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("EYEPULL", 4)
 		TNT1 AA 0 A_CustomMissile ("MuchBlood", 42, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_LiquidBlood2", 46, 0, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_CustomMissile ("xdeath2", 16, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
-		D2F1 B 8
+		D2F1 B 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 52, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("marine/superfist1", 5)
 		TNT1 A 0 A_PlaySound("dimp/pain", 2)
-		D2F1 CDE 4
+		D2F1 CDE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c", 3)
 		D2F1 FFFFFFFF 1 A_CustomMissile ("Brutal_LiquidBlood2", 58, -4, random (0, 360), 2, random (60, 120))
 		
-		D2F1 E 6
+		D2F1 E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("dimp/pain", 2)
-		D2F1 F 5
+		D2F1 F 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
-		D2F1 GH 3
+		D2F1 GH 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 5)
 		TNT1 A 0 A_CustomMissile ("XDeath1", 40, -3, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("Brutal_LiquidBlood2", 46, 0, random (0, 360), 2, random (60, 120))
-		D2F1 I 7
+		D2F1 I 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		
-		D2F1 J 7
+		D2F1 J 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 4)
 		TNT1 A 0 A_CustomMissile ("XDeath1", 40, -3, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("Brutal_LiquidBlood2", 46, 0, random (0, 360), 2, random (60, 120))
-		D2F1 I 5
+		D2F1 I 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
-		D2F1 J 5
+		D2F1 J 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("NECK_BRK", 6)
 		TNT1 A 0 A_CustomMissile ("XDeath2", 42, -3, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("Brutal_LiquidBlood2", 46, 0, random (0, 360), 2, random (60, 120))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		D2F1 IJIJIJIJ 2
+		D2F1 IJIJIJIJ 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("dimp/death", 3)
-		D2F1 IJIJIJ 1
+		D2F1 IJIJIJ 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("MuchBlood", 46, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_LiquidBlood2", 50, -2, random (0, 360), 2, random (60, 120))
@@ -4598,19 +4598,19 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
-		HKF4 ABC 4
+		HKF4 ABC 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("player/cyborg/fist", 3)
-		HKF4 C 6
+		HKF4 C 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
-		HKF4 DE 6 
+		HKF4 DE 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		TNT1 A 0 A_PlaySound("NECK_BRK")
 		HKF4 DE 5 A_CustomMissile ("Green_Blood", 60, 8, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("NECK_BRK")
 		TNT1 AAA 0 A_CustomMissile ("Green_Blood", 60, 8, random (0, 360), 2, random (0, 160))
-		HKF4 DE 4
+		HKF4 DE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("baron/pain",4)
 		TNT1 AA 0 A_CustomMissile ("Green_Blood", 54, 8, random (0, 360), 2, random (0, 160))
-		HKF4 FGFG 5
+		HKF4 FGFG 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("EYEPULL", 5)
 		TNT1 AAA 0 A_CustomMissile ("GreenBloodMist", 65, 14, random (0, 360), 2, random (0, 160)) 
 		TNT1 AAA 0 A_CustomMissile ("xdeath1Green", 62, 12, random (0, 360), 2, random (0, 160))
@@ -4618,9 +4618,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAAA 0 A_CustomMissile ("Green_Blood", 54, 8, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("SuperWallGreenBlood", 52, 0, random (170, 190), 2, random (0, 40))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		HKF4 H 14
+		HKF4 H 14 A_SetTics(14 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 2)
-		HKF4 IJ 4
+		HKF4 IJ 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("baron/pain", 6)
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 3)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -4655,9 +4655,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		IN1F ABC 6
+		IN1F ABC 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 6)
-		IN1F D 6
+		IN1F D 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("monster/infpai", 2)
 		TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 40, 8, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
@@ -4680,7 +4680,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("MuchBlood", 40, 8, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAA 0 A_CustomMissile ("Brutal_LiquidBlood2", 55, 2, random (0, 360), 2, random (0, 160))
-		IN1F GH 6
+		IN1F GH 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/xdeath2c")
 		IN1F IIIIIIIIIIIIIIIIII 1 A_CustomMissile ("Brutal_LiquidBlood2", 61, -19, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_TakeInventory("MagCacoFatality", 1)
@@ -4696,11 +4696,11 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		TA1F A 3
+		TA1F A 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		FATF E 0 A_PlaySound("demon/pain",1)
 		TNT1 A 0 A_PlaySound("NECK_BRK",2)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		TA1F A 9
+		TA1F A 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("EYEPULL", 3)
 		NULL A 0 ACS_Execute(585, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -4710,8 +4710,8 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 40, 8, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("MuchBlood", 40, -3, random (0, 360), 2, random (0, 160))
-		TA1F BCDDDDDD 3
-		TA1F E 5
+		TA1F BCDDDDDD 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		TA1F E 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		FATF E 0 A_PlaySound("misc/gibbed",4)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("xdeath2", 16, 0, random (0, 360), 2, random (0, 160))
@@ -4735,28 +4735,28 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
         TNT1 A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
 		
-		FD3M A 6 
+		FD3M A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 0)
-		FD3M B 4
+		FD3M B 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		FD3M C 4 A_Playsound("CLAP",1)
 		FD3M C 1 A_Playsound("demon/pain", 2)
 		TNT1 AA 0 A_CustomMissile ("Brutal_FlyingBlood", 10, 4, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		FD3M D 20 
-		FD3M EF 6
+		FD3M D 20 A_SetTics(20 / GetCVar("cl_fatalityspeed")) 
+		FD3M EF 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_Playsound("demon/pain", 3)
-		FD3M GF 4
+		FD3M GF 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("NECK_BRK",0)
-		FD3M GFG 4
+		FD3M GFG 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("NECK_BRK",4)
 		FD3M FG 3 A_CustomMissile ("Brutal_FlyingBlood", 10, -5, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("NECK_BRK",5)
 		FD3M FG 3 A_CustomMissile ("Brutal_LiquidBlood2", 8, -4, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_PlaySound("NECK_BRK",6)
-		FD3M FG 3
+		FD3M FG 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		TNT1 AAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 8, 8, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAAA 0 A_CustomMissile ("Brutal_LiquidBlood2", 12, 10, random (0, 360), 2, random (60, 120))
 		TNT1 AAA 0 A_CustomMissile ("MuchBlood", 13, 6, random (0, 360), 2, random (0, 160))
@@ -4781,14 +4781,14 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		
 		
 		TNT1 A 0 A_PlaySound("Paladin/Pain",1)
-		CP1F AB 6
+		CP1F AB 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("Paladin/Pain",2)
-		CP1F AB 6
+		CP1F AB 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 3)
-		CP1F CDD 6
-		CP1F EFGH 4
+		CP1F CDD 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		CP1F EFGH 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("barrel/pain", 4)
-		CP1F H 1
+		CP1F H 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("Paladin/Sight", 5)
 		TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 48, 9, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("Brutal_LiquidBlood2", 45, 11, random (0, 360), 2, random (60, 120))
@@ -4796,16 +4796,16 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AA 0 A_CustomMissile ("xdeath1", 52, 11, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("Teeth", 59, 12, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("XDeath3b", 59, 12, random (0, 360), 2, random (0, 160))
-		CP1F I 11
+		CP1F I 11 A_SetTics(11 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 6)
-		CP1F JK 5
+		CP1F JK 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("barrel/pain", 1)
 		TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 8, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAA 0 A_CustomMissile ("Brutal_LiquidBlood2", 50, 11, random (0, 360), 2, random (60, 120))
 		TNT1 AA 0 A_CustomMissile ("MuchBlood", 47, 13, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Teeth", 59, 12, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("XDeath3b", 49, 8, random (0, 360), 2, random (0, 160))
-		CP1F LMN 4
+		CP1F LMN 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("knight/step",2)
 		CP1F OOOOO 2 A_CustomMissile ("Brutal_LiquidBlood2", 18, 43, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_PlaySound("Paladin/Pain",3)
@@ -4814,7 +4814,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		CP1F PPPPP 2 A_CustomMissile ("Brutal_LiquidBlood2", 13, 41, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 5)
 		
-		CP1F QR 5
+		CP1F QR 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("misc/gibbed",5)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Xdeath1", 21, 13, random (0, 360), 2, random (0, 160))
@@ -4831,7 +4831,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 	    TNT1 AAAAA 0 A_CustomMissile ("BloodMistBig", 21, 12, random (0, 360), 2, random (30, 90))
 		TNT1 AAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 21, 11, random (0, 360), 2, random (30, 90))
 		TNT1 AA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
-		CP1F S 4
+		CP1F S 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		CP1F TTTTTTTTTTTTTTTTTTT 1 A_CustomMissile ("Brutal_LiquidBlood2", 8, 50, random (0, 360), 2, random (60, 120))
 		
 		TNT1 A 0 A_TakeInventory("CyberPaladinFatality1", 1)
@@ -4848,12 +4848,12 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		ARF3 ABABABABABABAB 2
+		ARF3 ABABABABABABAB 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_SpawnItem("Spark_UpOnce",0,60)
-		ARF3 CD 3
+		ARF3 CD 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("baby/death")
-		ARF3 EFFFF 3
-		ARF3 GGHHI 3
+		ARF3 EFFFF 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		ARF3 GGHHI 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -4866,7 +4866,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		NULL AAAAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
 		NULL AAAAA 0 A_CustomMissile ("XDeath3", 10, 0, random (0, 360), 2, random (0, 160))
 		NULL AAAAAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-		ARF3 JKLMNNNNNNNNNNNNNNNN 3
+		ARF3 JKLMNNNNNNNNNNNNNNNN 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		//////////////////////////////////////////////////////
 		NULL A 0 A_TakeInventory("ArachnotronXFatality",1)
@@ -4885,11 +4885,11 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
-		ARF4 A 6
+		ARF4 A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("grunt/pain")
-		ARF4 B 3
+		ARF4 B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		ARF4 BIBIBI 2
+		ARF4 BIBIBI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("baby/death")
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -4902,7 +4902,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		NULL AAAAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
 		NULL AAAAAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 		
-		ARF4 CDE 3
+		ARF4 CDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_CustomMissile ("XDeathArachnotronHead2", 50, 0, random (0, 360), 2, random (40, 130))
 		//////////////////////////////////////////////////////
 		NULL A 0 A_TakeInventory("ArachnotronXFatality2",1)
@@ -4920,7 +4920,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		
 		TNT1 A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
-		FA2F AA 6
+		FA2F AA 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -4930,9 +4930,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 34, -6, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath1", 48, -7, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath2", 48, -7, random (0, 360), 2, random (0, 160))
-		FA2F B 5
+		FA2F B 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
-		FA2F C 10
+		FA2F C 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -4943,9 +4943,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 34, -4, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath3", 48, -7, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath2", 48, -7, random (0, 360), 2, random (0, 160))
-		FA2F B 5
+		FA2F B 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
-		FA2F C 8
+		FA2F C 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
 		 TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -4957,9 +4957,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 32, -5, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath1", 48, -7, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath3", 48, -7, random (0, 360), 2, random (0, 160))
-		FA2F D 5
+		FA2F D 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		
-		FA2F C 8
+		FA2F C 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
 		 TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -4973,7 +4973,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AA 0 A_CustomMissile ("XDeath2", 48, -7, random (0, 360), 2, random (0, 160))
 		FA2F FFF 2 A_CustomMissile ("PlayerFlyingBlood", 33, -6, random (0, 360), 2, random (0, 160))	
 		
-		FA2F E 8
+		FA2F E 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -4989,7 +4989,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AA 0 A_CustomMissile ("XDeath2", 48, -7, random (0, 360), 2, random (0, 160))
 		FA2F FFF 2 A_CustomMissile ("PlayerFlyingBlood", 48, -6, random (0, 360), 2, random (0, 160))	
 		
-		FA2F E 8
+		FA2F E 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -5018,11 +5018,11 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 ACS_Execute(477, 0, 0, 0, 0)
 		TNT1 A 0 A_SetInvulnerable
 		//////////////////////////////////////////////////////
-		FA3F A 8
+		FA3F A 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
 		TNT1 A 0 A_Playsound("misc/gibbed",3)
 		TNT1 AAAAAAA 0 A_CustomMissile ("Blood", 45, 0, random (0, 360), 2, random (0, 160))						
-		FA3F B 8
+		FA3F B 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAAAAAAAAAAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 45, 0, random (0, 180), 2, random (0, 180))
 		FA3F C 5 A_PlaySound("Volcabus/pain", 1)
@@ -5054,7 +5054,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AA 0 A_CustomMissile ("Instestin", 48, -6, random (0, 360), 2, random (0, 160))
 
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))		
-		FA3F K 10
+		FA3F K 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 				
 		//////////////////////////////////////////////////////
 		TNT1 A 0 A_TakeInventory("VolcabusFatality2",1)
@@ -5072,11 +5072,11 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
-		ARF6 A 6
+		ARF6 A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("baby/pain")
-		ARF6 B 3
+		ARF6 B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		ARF6 BIBIBI 2
+		ARF6 BIBIBI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("baby/death")
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -5088,9 +5088,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		 NULL AAAAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAAAAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 		
-		ARF6 CD 7
+		ARF6 CD 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))		
-		ARF6 EF 7
+		ARF6 EF 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_CustomMissile ("XDeathArachnotronHead2", 50, 0, random (0, 360), 2, random (40, 130))
 		//////////////////////////////////////////////////////
 		NULL A 0 A_TakeInventory("Arachnotron2FatalityB",1)
@@ -5109,14 +5109,14 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		ARF5 ABABABABABABAB 2
+		ARF5 ABABABABABABAB 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("BONEBRK3", 3)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 A_SpawnItem("Spark_UpOnce",0,60)
-		ARF5 CD 3
+		ARF5 CD 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("baby/death")
-		ARF5 EFFFF 3
-		ARF5 GGHHI 3
+		ARF5 EFFFF 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		ARF5 GGHHI 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		TNT1 A 0 A_PlaySound("misc/gibbed", 3)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -5149,14 +5149,14 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
-		FTAC ABB 4
-		FTAC CDEFG 2
+		FTAC ABB 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FTAC CDEFG 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0  A_PlaySound("baby/pain")
 		NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
 		NULL A 0 A_PlaySound("CLAP")
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		FTAC GGGGHHHHHHHHIIJJJJJJJJJJJ 1
-		FTAC K 3
+		FTAC GGGGHHHHHHHHIIJJJJJJJJJJJ 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FTAC K 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -5165,9 +5165,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		NULL A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
     TNT1 AAA 0 A_CustomMissile ("Aracnorb_Brain", 0, 10, random (0, 360), 2, random (0, 160))	  
 		TNT1 A 0 A_SpawnItemEx("SplatteredSmall", 0, 15)
-		FTAC LLLL 1
-		FTAC LMNNN 3
-		FTAC N 9
+		FTAC LLLL 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FTAC LMNNN 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FTAC N 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 		//////////////////////////////////////////////////////
 		NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("AracnorbFatality",1)
@@ -5185,7 +5185,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(acsFatality, 0)
 		//////////////////////////////////////////////////////
 		TNT1 A 0 A_PlaySound("misc/xdeath4b", 4)
-		S4VF A 6
+		S4VF A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))	
 		TNT1 AAAA 0 A_CustomMissile ("Blood", 25, 0, random (0, 360), 2, random (0, 160))
@@ -5193,9 +5193,9 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 A 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAA 0 A_CustomMissile ("Instestin", 48, -6, random (0, 360), 2, random (0, 160))		
-		S4VF BCC 5
+		S4VF BCC 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh", 4)
-		S4VF D 5
+		S4VF D 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("gore/headshot", 2)
 	    TNT1 AAAAA 0 A_CustomMissile ("BloodMistBig", 24, 0, random (0, 360), 2, random (30, 90))
 		TNT1 AAAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 25, 0, random (0, 360), 2, random (30, 90))
@@ -5209,7 +5209,7 @@ TNT1 A 0 ACS_Execute(585, 0, 0, 0, 0)
 		TNT1 AAA 0 A_CustomMissile ("Teeth", 23, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("XDeath1", 21, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("XDeath3b", 24, 0, random (0, 360), 2, random (50, 90))
-		S4VF E 6
+		S4VF E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))	
 		S4VF FFFFFF 2 A_CustomMissile ("Brutal_LiquidBlood2", 21, 0, random (0, 360), 2, random (60, 120))

--- a/actors/Player/PLAYER.dec
+++ b/actors/Player/PLAYER.dec
@@ -2150,29 +2150,29 @@ Death.Plasma: Death.Plasma2:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FTYZ AB 4
+        FTYZ AB 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
         NULL A 0  A_PlaySound("grunt/pain")
-        FTYZ BC 3
-        FTYZ DEF 3
+        FTYZ BC 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+        FTYZ DEF 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		
         NULL A 0 A_PlaySound("BURNZOM", 3)
 		
 		//The actor ShakeShakeShake makes the screen shake near the player, improving the overal felling of the fatalities
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		FTYZ FG 2
+		FTYZ FG 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound ("misc/xdeath", 1)
-		FTYZ FG 2
+		FTYZ FG 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound ("misc/xdeath", 1)
-		FTYZ F 2
+		FTYZ F 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-        FTYZ H 4
+        FTYZ H 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
         NULL AA 0 A_CustomMissile ("FatalityBlood", 50, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-        FTYZ I 4
+        FTYZ I 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
         NULL AAAA 0 A_CustomMissile ("FatalityBlood", 50, 0, random (0, 360), 2, random (0, 160))
         NULL AA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 		 
@@ -2191,8 +2191,8 @@ Death.Plasma: Death.Plasma2:
          NULL AAAA 0 A_CustomMissile ("XDeath3", 60, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAAAA 0 A_CustomMissile ("Instestin", 50, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-		 FTYZ K 2
-         FTYZ L 15
+		 FTYZ K 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+         FTYZ L 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         //NULL A 0 A_TakeInventory("ZombieManFatality",1)
 		 NULL A 0 A_TakeInventory("ZombieManFatality",1)
@@ -2209,7 +2209,7 @@ Death.Plasma: Death.Plasma2:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FPZ2 AB 4
+        FPZ2 AB 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2220,9 +2220,9 @@ Death.Plasma: Death.Plasma2:
         NULL AA 0 A_CustomMissile ("XDeath2", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AA 0 A_CustomMissile ("XDeath3", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-        FPZ2 C 10
+        FPZ2 C 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("imp/melee")
-        FPZ2 D 10
+        FPZ2 D 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		NULL AAAAA 0 A_CustomMissile ("Instestin2", 32, 0, random (0, 360), 2, random (0, 160))
 		NULL AAA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
 		NULL AAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
@@ -2230,9 +2230,9 @@ Death.Plasma: Death.Plasma2:
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(582, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
-		FPZ2 EF 3
+		FPZ2 EF 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("grunt/death")
-		FPZ2 G 6
+		FPZ2 G 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("ZombieManFatality2",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -2251,14 +2251,14 @@ Death.Plasma: Death.Plasma2:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FPZ3 A 6
+        FPZ3 A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 ACS_ExecuteAlways(477, 0, 0, 0, 0)//Start Camera
-		FPZ3 BCDE 3
+		FPZ3 BCDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_PlaySound("grunt/pain", 1)
-		FPZ3 FGGGG 2
+		FPZ3 FGGGG 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         
-		FPZ3 HHHIIIIIIIIHJJJ 1
+		FPZ3 HHHIIIIIIIIHJJJ 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2268,7 +2268,7 @@ Death.Plasma: Death.Plasma2:
         NULL AA 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
 		TNT1 A 0 A_SpawnItemEx("SplatteredSmall")
 		
-		FPZ3 KKKLLLLLLKJJJ 1
+		FPZ3 KKKLLLLLLKJJJ 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2278,7 +2278,7 @@ Death.Plasma: Death.Plasma2:
         NULL AA 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
 		
         
-		FPZ3 MMMNNNNNNNMOOO 1
+		FPZ3 MMMNNNNNNNMOOO 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2286,7 +2286,7 @@ Death.Plasma: Death.Plasma2:
 		NULL A 0 A_PlaySound("player/cyborg/fist", 4)
 		NULL AA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AA 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
-		FPZ3 MMMNNNNNNNMOOO 1
+		FPZ3 MMMNNNNNNNMOOO 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2302,7 +2302,7 @@ Death.Plasma: Death.Plasma2:
 		NULL AAAAAAAA 0 A_CustomMissile ("SmallBrainPiece", 5, 0, random (0, 360), 2, random (0, 160))
 		
 		
-        FPZ3 PPPQQQQQQQPRRR 1
+        FPZ3 PPPQQQQQQQPRRR 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2310,14 +2310,14 @@ Death.Plasma: Death.Plasma2:
 		NULL A 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
 		
-		FPZ3 PPPQQQQQQPRRR 1
+		FPZ3 PPPQQQQQQPRRR 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 A_PlaySound("player/cyborg/fist", 4)
 		NULL A 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_CustomMissile ("BloodMistSmall", 5, 0, random (0, 360), 2, random (40, 90))
-		FPZ3 RP 3
+		FPZ3 RP 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -2336,14 +2336,14 @@ FatalityZMan4:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FPZ4 AB 2
+        FPZ4 AB 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_PlaySound("grunt/pain", 1)
 		NULL A 0 A_PlaySound("player/cyborg/fist", 4)
-		FPZ4 CDEEE 3
-		FPZ4 FGH 2
+		FPZ4 CDEEE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FPZ4 FGH 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         
-		FPZ4 HHI 2
+		FPZ4 HHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2353,9 +2353,9 @@ FatalityZMan4:
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_SpawnItemEx("SplatteredSmall", 0, 20)
-		FPZ4 JJJIH 2
+		FPZ4 JJJIH 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
-		FPZ4 HHI 2
+		FPZ4 HHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2364,9 +2364,9 @@ FatalityZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		FPZ4 JJJIH 2
+		FPZ4 JJJIH 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
-		FPZ4 HHI 2
+		FPZ4 HHI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2375,10 +2375,10 @@ FatalityZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		FPZ4 OOOMN 2
+		FPZ4 OOOMN 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		
-		FPZ4 NNM 2
+		FPZ4 NNM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2387,9 +2387,9 @@ FatalityZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		FPZ4 OOOMN 2
+		FPZ4 OOOMN 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
-		FPZ4 NNM 2
+		FPZ4 NNM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2398,11 +2398,11 @@ FatalityZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("BloodmistSmall", 5, 0, random (0, 360), 2, random (0, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		FPZ4 OOOMN 2
+		FPZ4 OOOMN 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		
 		
-		FPZ4 NNM 2
+		FPZ4 NNM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2428,8 +2428,8 @@ FatalityZMan4:
 		NULL A 0 A_CustomMissile ("Brains5", 5, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_SpawnItem("SplatteredLarge")
 		NULL AAAAAAAA 0 A_CustomMissile ("SmallBrainPiece", 5, 0, random (0, 360), 2, random (0, 160))
-		FPZ4 P 7
-		FPZ4 L 6
+		FPZ4 P 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
+		FPZ4 L 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("ZombieManFatality4",1)
@@ -2446,14 +2446,14 @@ FatalityZMan4:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FTYI ABB 4
-        FTYI CDEFG 2
+		FTYI ABB 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FTYI CDEFG 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0  A_PlaySound("imp/pain")
         NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
         NULL A 0 A_PlaySound("CLAP")
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-        FTYI GGGGHHHHHHHHIIJJJJJJJJJJJ 1
-        FTYI K 3
+		FTYI GGGGHHHHHHHHIIJJJJJJJJJJJ 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FTYI K 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2462,9 +2462,9 @@ FatalityZMan4:
         NULL A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
 		TNT1 A 0 A_SpawnItem("ImpHeadExplode", 0, 10)
 		TNT1 A 0 A_SpawnItemEx("SplatteredSmall", 0, 15)
-		FTYI LLLL 1
-        FTYI LMNNN 3
-		FTYI N 9
+		FTYI LLLL 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FTYI LMNNN 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FTYI N 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("ImpFatality",1)
@@ -2492,9 +2492,10 @@ FatalityZMan4:
         NULL AAA 0 A_CustomMissile ("XDeath2", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("XDeath3", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-		FTBI BC 2
+		FTBI BC 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0  A_PlaySound("imp/die")
-		FTBI D 25
+		FTBI D 25 A_SetTics(25 / GetCVar("cl_fatalityspeed"))
+
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2505,8 +2506,9 @@ FatalityZMan4:
         NULL AAA 0 A_CustomMissile ("XDeath2", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("XDeath3", 60, 0, random (0, 360), 2, random (0, 160))
         NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-        FTBI EF 3
-		FTBI G 25
+		FTBI EF 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FTBI G 25 A_SetTics(25 / GetCVar("cl_fatalityspeed"))
+
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("ImpFatality2",1)
@@ -2523,15 +2525,15 @@ FatalityZMan4:
 		
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FTCI AB 2
+        FTCI AB 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_PlaySound("imp/pain", 1)
 		NULL A 0 A_PlaySound("player/cyborg/fist", 4)
-		FTCI CDE 2
-		FTCI E 6
+		FTCI CDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		FTCI E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
         
-		FTCI FGG 4
-		FTCI H 2
+		FTCI FGG 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		FTCI H 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2540,11 +2542,11 @@ FatalityZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         TNT1 AA 0 A_CustomMissile ("BloodMistSmall", 2, 0, random (0, 360), 2, random (20, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		FTCI I 5
-		FTCI H 2
-		FTCI G 3
+		FTCI I 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
+		FTCI H 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		FTCI G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
-		FTCI H 2
+		FTCI H 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2553,11 +2555,11 @@ FatalityZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         TNT1 AA 0 A_CustomMissile ("BloodMistSmall", 2, 0, random (0, 360), 2, random (20, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		FTCI I 5
-		FTCI H 2
-		FTCI G 3
+		FTCI I 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
+		FTCI H 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		FTCI G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
-		FTCI H 2
+		FTCI H 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2567,11 +2569,11 @@ FatalityZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         TNT1 AA 0 A_CustomMissile ("BloodMistSmall", 2, 0, random (0, 360), 2, random (20, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		FTCI I 5
-		FTCI H 2
-		FTCI G 3
+		FTCI I 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
+		FTCI H 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		FTCI G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
-		FTCI H 2
+		FTCI H 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2580,11 +2582,11 @@ FatalityZMan4:
 		NULL A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
         TNT1 AA 0 A_CustomMissile ("BloodMistSmall", 2, 0, random (0, 360), 2, random (20, 90))
 		NULL A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
-		FTCI I 5
-		FTCI H 2
-		FTCI G 3
+		FTCI I 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
+		FTCI H 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		FTCI G 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
-		FTCI H 2
+		FTCI H 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
         NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2592,8 +2594,8 @@ FatalityZMan4:
 		NULL A 0 A_PlaySound("imp/pain", 1)
 		NULL A 0 A_PlaySound("player/cyborg/fist", 4)
 		TNT1 A 0 A_SpawnItem("ImpHeadExplode", 0, 10)
-		FTCI L 10
-		FTCI J 10
+		FTCI L 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
+		FTCI J 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("ImpFatality3",1)
@@ -2612,15 +2614,15 @@ FatalityZMan4:
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
         FTYS A 6 A_PlaySound("grunt/pain")
-        FTYS BC 6
+        FTYS BC 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("BURNZOM", 3)
 
         NULL A 0 A_PlaySound("misc/xdeath")
-        FTYS DE 4
+        FTYS DE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("misc/xdeath")
-		FTYS DE 3
+		FTYS DE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("misc/xdeath")
-		FTYS DEE 2
+		FTYS DEE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2633,9 +2635,9 @@ FatalityZMan4:
 		TNT1 AAAAAA 0 A_CustomMissile ("BloodMist", 30, 0, random (0, 360), 2, random (20, 90))
         FTYS FGHIIPPP 2 A_CustomMissile ("Blood", 1, 0, random (0, 360), 2, random (0, 160))
 
-        FTYS QR 5 
+        FTYS QR 5 A_SetTics(5 / GetCVar("cl_fatalityspeed")) 
         NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
-        FTYS R 15
+        FTYS R 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_GiveInventory("ShotgunguyHead", 1)
         ///////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -2652,11 +2654,11 @@ FatalityZMan4:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FTYS J 3
+        FTYS J 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         FTYS J 1 A_PlaySound("BURNZOM")
-		FTYS JJJJ 3
+		FTYS JJJJ 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		FTYS J 1 A_PlaySound("grunt/death")
-		FTYS K 4
+		FTYS K 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2667,8 +2669,8 @@ FatalityZMan4:
 		NULL AA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAAAAAAA 0 A_CustomMissile ("BloodMist", 50, 0, random (0, 360), 2, random (20, 90))
 		NULL A 0 A_CustomMissile ("RipSergeant", 0, 0, random (0, 360), 2, random (0, 160))
-        FTYS LMNO 3
-        FTYS O 10
+        FTYS LMNO 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+        FTYS O 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
         ///////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("SergeantFatality2",1)
@@ -2686,14 +2688,14 @@ FatalityZMan4:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FSP3 A 4
+        FSP3 A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		
 		FSP3 B 4 A_PlaySound("grunt/pain")
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
-		FSP3 CDE 2
-		FSP3 E 6
+		FSP3 CDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+		FSP3 E 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
-		FSP3 FG 3
+		FSP3 FG 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("grunt/death")		
 		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -2705,7 +2707,7 @@ FatalityZMan4:
 		//NULL AA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
 		 TNT1 AAA 0 A_CustomMissile ("BloodMistSmall", 30, 0, random (0, 360), 2, random (20, 90))
 		
-        FSP3 HIIIIII 3
+        FSP3 HIIIIII 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 	   
 	   NULL A 0 A_PlaySound("weapons/sg")	
 	   XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
@@ -2722,8 +2724,8 @@ FatalityZMan4:
 		
 		
 		FSP3 L 3 BRIGHT
-		FSP3 K 3
-		FSP3 J 10
+		FSP3 K 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FSP3 J 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		///////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("SergeantFatality3",1)
@@ -2739,24 +2741,24 @@ FatalityZMan4:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        CFTA AAABCDE 2
+        CFTA AAABCDE 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
           NULL A 0 A_PlaySound("commando/pain")
 NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
           NULL A 0 A_PlaySound("CLAP")
-        CFTA EFF 6
-        CFTA GHIJK 2
+        CFTA EFF 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+        CFTA GHIJK 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
           NULL A 0 A_PlaySound("commando/pain")
 NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
 NULL A 0 A_CustomMissile ("ShakeShakeShake", 50, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 A_CustomMissile ("GoreSound", 22, 0, random (0, 360), 2, random (0, 160))
-         CFTA L 6
+         CFTA L 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 	    
-        CFTA M 12
-        CFTA OPQR 3
+        CFTA M 12 A_SetTics(12 / GetCVar("cl_fatalityspeed"))
+        CFTA OPQR 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
          NULL A 0 A_PlaySound("commando/pain")
           NULL A 0 A_PlaySound("commando/death")
-       CFTA R 12
+       CFTA R 12 A_SetTics(12 / GetCVar("cl_fatalityspeed"))
 NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(582, 0, 0, 0, 0)
@@ -2768,7 +2770,7 @@ NULL A 0 A_CustomMissile ("ShakeShakeShake", 50, 0, random (0, 360), 2, random (
          NULL AAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
          NULL AAA 0 A_CustomMissile ("XDeath3", 10, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-        CFTA S 20
+        CFTA S 20 A_SetTics(20 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("ComandoFatality",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -2786,11 +2788,11 @@ NULL A 0 A_CustomMissile ("ShakeShakeShake", 50, 0, random (0, 360), 2, random (
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        CFTC A 1
+        CFTC A 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
         CFTC A 1 A_PlaySound("BURNZOM")
-		CFTC AAAA 5
+		CFTC AAAA 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		CFTC B 1 A_PlaySound("commando/death")
-		CFTC B 6
+		CFTC B 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2804,8 +2806,8 @@ NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 
 		NULL A 0 A_CustomMissile ("XdeathChainArm", 42, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 A_CustomMissile ("XdeathChainLeg", 42, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 A_CustomMissile ("XdeathGuts", 42, 0, random (0, 360), 2, random (0, 160))
-        CFTC CDEF 4
-        CFTC F 15
+        CFTC CDEF 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+        CFTC F 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("ComandoFatality2",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -2821,12 +2823,12 @@ NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FDEM A 4
+        FDEM A 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 ACS_ExecuteAlways(477, 0, 0, 0, 0)//Start Camera
         FDEM B 4 A_PlaySound("demon/melee")
-        FDEM C 8
+        FDEM C 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
         FDEM C 1 A_PlaySound("demon/pain")
-        FDEM CDCDCD 3
+        FDEM CDCDCD 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2854,11 +2856,11 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		FDEM J 2
+		FDEM J 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 ACS_ExecuteAlways(477, 0, 0, 0, 0)//Start Camera
         FDEM J 5 A_PlaySound("demon/pain")
-        FDEM J 9
-        FDEM K 7
+        FDEM J 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
+        FDEM K 7 A_SetTics(7 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
@@ -2870,8 +2872,8 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
          NULL AAA 0 A_CustomMissile ("XDeath3", 10, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 		 NULL A 0 A_CustomMissile ("XDeathStomach", 32, 0, random (0, 360), 2, random (0, 160))
-        FDEM LMN 6
-		FDEM OO 3
+        FDEM LMN 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
+		FDEM OO 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("DemonFatality2",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -2887,69 +2889,69 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		FD2M A 2
+		FD2M A 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 ACS_ExecuteAlways(477, 0, 0, 0, 0)//Start Camera
         FDEM J 0 A_PlaySound("demon/pain")
-        FD2M A 10
+        FD2M A 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
 		
-        FD2M B 3
-		FD7M B 1
-		FD2M C 3
+        FD2M B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FD7M B 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FD2M C 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 A_PlaySound("demon/pain")
 NULL A 0 A_PlaySound("player/cyborg/fist", 1)
 NULL A 0 A_SpawnItem("Blood", 0, 20)
-		FD7M B 1
-		FD2M B 3
-		FD2M A 6
+		FD7M B 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FD2M B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FD2M A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		 
-		 FD2M B 3
-		FD7M B 1
-		FD2M C 3
+		 FD2M B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FD7M B 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FD2M C 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 A_PlaySound("demon/pain")
 NULL A 0 A_PlaySound("player/cyborg/fist", 1)
 NULL A 0 A_SpawnItem("Blood", 0, 20)
-		FD7M B 1
-		FD2M B 3
-		FD2M A 6
+		FD7M B 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FD2M B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FD2M A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
-		FD2M B 3
-		FD7M B 1
-		FD2M C 3
+		FD2M B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FD7M B 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FD2M C 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 A_PlaySound("demon/pain")
 NULL A 0 A_PlaySound("player/cyborg/fist", 1)
 NULL A 0 A_SpawnItem("Blood", 0, 20)
-		FD7M B 1
-		FD2M B 3
-		FD2M A 6
+		FD7M B 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FD2M B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FD2M A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		
-		FD2M B 3
-		FD7M B 1
-		FD2M C 3
+		FD2M B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FD7M B 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FD2M C 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 A_PlaySound("demon/pain")
 NULL A 0 A_PlaySound("player/cyborg/fist", 1)
 NULL A 0 A_SpawnItem("Blood", 0, 20)
-		FD7M B 1
-		FD2M B 3
-		FD2M A 6
+		FD7M B 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
+		FD2M B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		FD2M A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		 
-		 FD2M AD 3
+		 FD2M AD 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 A_PlaySound("demon/pain")
 NULL A 0 A_PlaySound("player/cyborg/fist", 1)
 NULL A 0 A_SpawnItem("Blood", 0, 5)
 		 
-		 FD2M E 4
-		 FD2M F 15
-		 FD2M GHHH 4
+		 FD2M E 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+		 FD2M F 15 A_SetTics(15 / GetCVar("cl_fatalityspeed"))
+		 FD2M GHHH 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 
 NULL AAA 0 A_SpawnItem("Blood", 0, 5)
 NULL A 0 A_SpawnItem("MeatDeath", 0, 1)
-		 FD2M IJJJJ 5
+		 FD2M IJJJJ 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		 
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("DemonFatality3",1)
@@ -2966,7 +2968,7 @@ NULL A 0 A_SpawnItem("MeatDeath", 0, 1)
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        CACF ABC 4
+        CACF ABC 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
         CACF D 4 A_PlaySound("misc/xdeath4")
         CACF E 4 A_PlaySound("demon/pain")
 		TNT1 A 0 A_Playsound("EYEPULL", 2)
@@ -2993,19 +2995,19 @@ XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        CA2F AB 4
+        CA2F AB 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("demon/pain")
-        CA2F BCDEE 4
-        CA2F F 2
+        CA2F BCDEE 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+        CA2F F 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("demon/pain")
         XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		CA2F F 4
+		CA2F F 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("misc/xdeath2")
 		CA2F FFFF 2 A_CustomMissile ("Blue_Blood", 25, 0, random (0, 180), 2, random (0, 180))
 		NULL AAAAA 0 A_CustomMissile ("CacoXDeath7", 25, 0, random (0, 360), 2, random (0, 160))
-        CA2F GH 4
+        CA2F GH 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_CustomMissile ("RipCaco", 35, 0, random (0, 360), 2, random (0, 160))
-		CA2F I 20
+		CA2F I 20 A_SetTics(20 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("CacoDemonFatality2",1)
@@ -3022,7 +3024,7 @@ XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FREV ABABAB 3
+        FREV ABABAB 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAAAAA 0 A_CustomMissile ("CeilBloodLauncher", 40, 0, random (0, 360), 2, random (50, 130))
          NULL AAAA 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
@@ -3031,12 +3033,12 @@ XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0
 NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(582, 0, 0, 0, 0)
         FREV C 4 A_PlaySound("skeleton/pain")
-        FREV D 4
-        FREV EFGHIJJJKL 4
+        FREV D 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
+        FREV EFGHIJJJKL 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
         FREV M 5 A_PlaySound("skeleton/sight")
-        FREV M 10
-        FREV N 2
-        FREV O 2
+        FREV M 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
+        FREV N 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
+        FREV O 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		 NULL AA 0 A_CustomMissile ("XDeath1", 50, 0, random (0, 360), 2, random (0, 160))
@@ -3048,7 +3050,7 @@ NULL A 0 ACS_Execute(581, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(582, 0, 0, 0, 0)
 NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
 
-        FREV PQR 2
+        FREV PQR 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
 		NULL A 0 A_TakeInventory("RevenantFatality",1)
@@ -3065,16 +3067,16 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FRE2 A 5
+        FRE2 A 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		FRE2 A 5 A_PlaySound("skeleton/pain")
-		FRE2 A 5
+		FRE2 A 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAAAAA 0 A_CustomMissile ("CeilBloodLauncher", 40, 0, random (0, 360), 2, random (50, 130))
          NULL AAAA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
 		 NULL AA 0 A_CustomMissile ("XDeath2", 40, 0, random (0, 360), 2, random (0, 160))
 		 NULL AA 0 A_CustomMissile ("XDeath3", 40, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-        FRE2 BCDEFGGGGG 6 
+        FRE2 BCDEFGGGGG 6 A_SetTics(6 / GetCVar("cl_fatalityspeed")) 
 		
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -3097,7 +3099,7 @@ XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        FATF A 6
+        FATF A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 NULL A 0 ACS_Execute(585, 0, 0, 0, 0)
         NULL A 0 A_CustomMissile ("Blood", 45, 0, random (0, 360), 2, random (0, 160))
         NULL AAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail", 45, 0, random (0, 180), 2, random (0, 180))
@@ -3121,9 +3123,9 @@ NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 		 NULL A 0 A_CustomMissile ("XDeath1", 50, 0, random (0, 360), 2, random (0, 160))
 		 NULL A 0 A_CustomMissile ("XDeath2", 50, 0, random (0, 360), 2, random (0, 160))
 		 NULL A 0 A_CustomMissile ("XDeath3", 50, 0, random (0, 360), 2, random (0, 160))
-        FATF BCD 8
+        FATF BCD 8 A_SetTics(8 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("fatso/pain")
-		FATF D 50
+		FATF D 50 A_SetTics(50 / GetCVar("cl_fatalityspeed"))
 
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -3141,9 +3143,9 @@ NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        BHF1 AAABCDEF 2
+        BHF1 AAABCDEF 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         BHF1 G 3 A_PlaySound("weapons/gswing")
-        BHF1 HIJKLLLMN 2
+        BHF1 HIJKLLLMN 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
         BHF1 O 3 A_PlaySound("baron/pain")
         NULL AAAAAAA 0 A_CustomMissile ("Green_Blood", 35, 0, random (0, 180), 2, random (0, 180))
         NULL A 0 A_PlaySound("misc/xdeath4")
@@ -3170,7 +3172,7 @@ NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
          NULL AAA 0 A_CustomMissile ("MuchBlood3Green", 50, 0, random (0, 360), 2, random (0, 160))
 
 
-        BHF1 WXYZZZZZZZZZZZZZZ 3
+        BHF1 WXYZZZZZZZZZZZZZZ 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -3192,14 +3194,14 @@ NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		HKF1 AB 5
+		HKF1 AB 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_CustomMissile ("GoreSound", 22, 0, random (0, 360), 2, random (0, 160))
         HKF1 C 6 A_PlaySound("PSXDPN")
 		NULL AAA 0 A_CustomMissile ("Green_Blood", 45, 0, random (0, 360), 2, random (0, 160))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		HKF1 C 5
+		HKF1 C 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("imp/melee")
-		HKF1 C 5
+		HKF1 C 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
         
 		 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 
@@ -3210,7 +3212,7 @@ NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
 
         HKF1 CDE 6 A_SpawnItem ("Green_Blood", 30)
 		HKF1 FG 6 A_SpawnItem ("Green_Blood", 15)
-		HKF1 HHH 5
+		HKF1 HHH 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -3231,11 +3233,11 @@ NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         //////////////////////////////////////////////////////
         NULL A 0 A_PlaySound("weapons/gswing", 1)
 		NULL A 0 A_PlaySound("PSXDPN")
-		HKF3 ABC 5
+		HKF3 ABC 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 SetPlayerProperty(0,1,0)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 A_PlaySound("PSXDPN", 2)
-		HKF3 D 10
+		HKF3 D 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
          NULL A 0 A_PlaySound("knight/death")
 
 		 NULL AAAAAAA 0 A_CustomMissile ("XDeath1Green", 50, 0, random (0, 360), 2, random (0, 160))
@@ -3245,13 +3247,13 @@ NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
         HKF3 EFGG 6 A_CustomMissile ("Green_Blood", 40, 0, random (0, 360), 2, random (0, 160))
 		
 		TNT1 A 0 A_PlaySound("NECK_BRK")
-		HKF3 H 11
+		HKF3 H 11 A_SetTics(11 / GetCVar("cl_fatalityspeed"))
         TNT1 A 0 A_PlaySound("gore/headshot")
 		 NULL AAAAAAA 0 A_CustomMissile ("XDeath1Green", 50, 0, random (0, 360), 2, random (0, 160))
          NULL AA 0 A_CustomMissile ("Green_Blood", 50, 0, random (0, 360), 2, random (0, 160))
          NULL AA 0 A_CustomMissile ("Muchblood2Green", 50, 0, random (0, 360), 2, random (0, 160))
 		 NULL A 0 A_CustomMissile ("XDeathHellKnightHead", 40, 0, 270, 2, random (0, 20))
-		 HKF3 I 12
+		 HKF3 I 12 A_SetTics(12 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("HKFatality3",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -3268,20 +3270,20 @@ FatalityHK2:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		HKF2 A 5 
+		HKF2 A 5 A_SetTics(5 / GetCVar("cl_fatalityspeed")) 
 		HKF2 A 0 A_PlaySound("player/cyborg/fist",8)
-		HKF2 B 5
+		HKF2 B 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 SetPlayerProperty(0,1,0)
 		NULL A 0 A_PlaySound("PSXDPN")
 		
-		HKF2 DEF 4
+		HKF2 DEF 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("NECK_BRK")
 		 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		HKF2 GH 5
+		HKF2 GH 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
          NULL A 0 A_PlaySound("PSXDPN")
-		 HKF2 IJI 4
+		 HKF2 IJI 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		TNT1 A 0 A_PlaySound("NECK_BRK")
-		 HKF2 JIJIJ 3
+		 HKF2 JIJIJ 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         TNT1 A 0 A_PlaySound("gore/headshot")
 
 		 NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -3294,9 +3296,9 @@ FatalityHK2:
          NULL AA 0 A_CustomMissile ("Muchblood2Green", 50, 0, random (0, 360), 2, random (0, 160))
          
 
-        HKF2 KL 5
+        HKF2 KL 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_CustomMissile ("XDeathHellKnightHead", 64, 0, random (0, 360), 2, random (60, 120))
-		HKF2 MNNNNN 5
+		HKF2 MNNNNN 5 A_SetTics(5 / GetCVar("cl_fatalityspeed"))
 
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("HKFatality2",1)
@@ -3316,12 +3318,12 @@ FatalityHK2:
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-        ARF1 ABABABABABABAB 2
+        ARF1 ABABABABABABAB 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_SpawnItem("Spark_UpOnce",0,60)
-		ARF1 CD 3
+		ARF1 CD 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("baby/death")
-		ARF1 EFFFF 3
-		ARF1 GGHHI 3
+		ARF1 EFFFF 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
+		ARF1 GGHHI 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -3334,7 +3336,7 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
          NULL AAAAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAA 0 A_CustomMissile ("XDeath3", 10, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-		ARF1 JKLMNNNNNNNNNNNNNNNN 3
+		ARF1 JKLMNNNNNNNNNNNNNNNN 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("ArachnotronFatality",1)
@@ -3353,11 +3355,11 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-		ARF2 A 6
+		ARF2 A 6 A_SetTics(6 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("grunt/pain")
-		ARF2 B 3
+		ARF2 B 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-        ARF2 BIBIBI 2
+        ARF2 BIBIBI 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("baby/death")
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -3370,7 +3372,7 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
          NULL AAAAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
          NULL AAAAAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 		
-		ARF2 CDE 3
+		ARF2 CDE 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
         NULL A 0 A_CustomMissile ("XDeathArachnotronHead", 50, 0, random (0, 360), 2, random (40, 130))
 		//////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("ArachnotronFatality2",1)
@@ -3390,10 +3392,10 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        AVF1 A 1
+        AVF1 A 1 A_SetTics(1 / GetCVar("cl_fatalityspeed"))
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
         AVF1 A 1 A_PlaySound("vile/pain")
-        AVF1 A 20
+        AVF1 A 20 A_SetTics(20 / GetCVar("cl_fatalityspeed"))
 
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		 NULL AA 0 A_CustomMissile ("XDeath1", 50, 0, random (0, 360), 2, random (0, 160))
@@ -3407,7 +3409,7 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
 
         AVF1 A 1 A_PlaySound("vile/Death")
         AVF1 BCDEEEFGHHH 5 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
-		AVF1 IJKLM 2
+		AVF1 IJKLM 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL AAAA 0 A_CustomMissile ("XDeath1", 5, 0, random (0, 360), 2, random (0, 160))
 		NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 20, 0, random (0, 360), 2, random (0, 160))
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -3417,19 +3419,19 @@ NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
 NULL A 0 A_PlaySound("CLAP")
 NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
 XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		AVF1 N 30
-		AVF1 OPQQR 3
+		AVF1 N 30 A_SetTics(30 / GetCVar("cl_fatalityspeed"))
+		AVF1 OPQQR 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		 NULL AA 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAA 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
 		 NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
 		 NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
-		AVF1 STUUUUVVVV 2
+		AVF1 STUUUUVVVV 2 A_SetTics(2 / GetCVar("cl_fatalityspeed"))
 		NULL A 0 A_PlaySound("TAUNT")
-		AVF1 V 10
-		AVF1 WXWX 10
-		AVF1 V 10
+		AVF1 V 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
+		AVF1 WXWX 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
+		AVF1 V 10 A_SetTics(10 / GetCVar("cl_fatalityspeed"))
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("ArchVileFatality",1)
 		NULL A 0 A_TakeInventory("GoFatality", 1)
@@ -3446,10 +3448,10 @@ FatalityPE:
         
 		NULL A 0 ACS_Execute(acsFatality, 0)
         //////////////////////////////////////////////////////
-        PA1F A 3
+        PA1F A 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		FATF E 0 A_PlaySound("demon/pain")
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
-		PA1F A 9
+		PA1F A 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 		
         NULL A 0 ACS_Execute(585, 0, 0, 0, 0)
 		NULL A 0 ACS_Execute(580, 0, 0, 0, 0)
@@ -3461,13 +3463,13 @@ FatalityPE:
         NULL AA 0 A_CustomMissile ("XDeath1", 55, 0, random (0, 360), 2, random (0, 160))
         NULL A 0 A_PlaySound("demon/pain")
 		
-		PA1F BCDEEEEEFGHI 3
+		PA1F BCDEEEEEFGHI 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
 		NULL A 0 A_PlaySound("demon/pain")
         
-		PA1F JKKKK 3
+		PA1F JKKKK 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		
-		PA1F L 4
+		PA1F L 4 A_SetTics(4 / GetCVar("cl_fatalityspeed"))
 		NULL AAAA 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
 		NULL AAA 0 A_CustomMissile ("MuchBlood", 90, 0, random (0, 360), 2, random (0, 160))
@@ -3478,10 +3480,10 @@ FatalityPE:
         NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		
-		  PA1F MNNNNNNN 3
+		  PA1F MNNNNNNN 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		  
 		  
-		  PA1F OPQR 3
+		  PA1F OPQR 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		  
 		NULL AAAA 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
         NULL AAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
@@ -3493,7 +3495,7 @@ FatalityPE:
         NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		  
-		  PA1F RQPQR 3
+		  PA1F RQPQR 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		  
 		  
 		  NULL AAAA 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
@@ -3506,7 +3508,7 @@ FatalityPE:
         NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		
-		PA1F RQPQR 3
+		PA1F RQPQR 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		  
 		  
 		  NULL AAAA 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
@@ -3519,7 +3521,7 @@ FatalityPE:
         NULL A 0 ACS_Execute(583, 0, 0, 0, 0)
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		
-		PA1F RQPQR 3
+		PA1F RQPQR 3 A_SetTics(3 / GetCVar("cl_fatalityspeed"))
 		  
 		  
 		  NULL AAAA 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
@@ -3533,9 +3535,9 @@ FatalityPE:
 		XXXX A 0 A_CustomMissile ("ShakeShakeShake", 1, 0, random (0, 360), 2, random (0, 160))
 		
 		
-		PA1F S 30
+		PA1F S 30 A_SetTics(30 / GetCVar("cl_fatalityspeed"))
 		PA1F STSTST 6 A_CustomMissile ("MuchBlood", 30, 0, random (0, 360), 2, random (0, 160))
-		PA1F S 9
+		PA1F S 9 A_SetTics(9 / GetCVar("cl_fatalityspeed"))
 		
         //////////////////////////////////////////////////////
         NULL A 0 A_TakeInventory("PEFatality",1)


### PR DESCRIPTION
Hello, Mr. pa1nki113r:

First, thanks for making such an amazing mod.  I come back to playing classic Doom often and almost exclusively with Project Brutality (PB).

After playing some PB recently and the new Doom Eternal, I thought it would be cool to have the option to speed up the fatalities in PB.  There were times when I was running with berserk in a room full of demons and, while I enjoy the fatalities, wanted to speed up the animations to keep the game moving.

MENUDEF and CVARINFO have been updated to include a new FLOAT fatality speed setting: "cl_fatalityspeed".  The setting is located under Gameplay Settings.  The min value is 1.0 (original speed) and the max is 3.0.   Feel free to tweak the max.  Anything over 2.0 doesn't seem to change the speed much.  The increment is set to 0.05.  I'm really enjoying 1.60 speed!

Remaining changes are all in NEWPLAYE.dec and PLAYER.dec .  The changes are all the same and simple.  If a Doomguy fatality actor state has a valid sprite name with a non-zero tic duration (and no action function),  I add an action function call that resembles:

> A_SetTics(_TICS_ / GetCVar("cl_fatalityspeed"))

The changes should be easy enough to spot and understand.  If you have any questions, let me know.  Obviously, feel free to change any of the code as needed.  This was my first time doing any modding with PB or ZDoom.

Thanks!

PS: Attached is a screenshot of the new option in Gameplay Settings. Below is a list of fatalities that I updated (I think I got them all):
AfritFatality1
AfritFatality2
AfritFatality3
ArachnophyteFatality
ArachnotronFatality
ArachnotronFatality2
ArachnotronFatality2A
ArachnotronFatality2B
ArachnotronXFatality
ArachnotronXFatality2
AracnorbFatality
ArchVileFatality
ArchVileFatality2
AutoshotgunGuyFatality
BaronFatality
BaronFatality2
BeamRevenantFatality1
BelphegorFatality
BruiserFatality
CacoDemonFatality
CacoDemonFatality2
ChaingunMajorFatality
ChainsawZombieFatality
ComandoFatality
ComandoFatality2
CyberBaronFatality1
CyberBaronFatality2
CyberKnightFatality1
CyberKnightFatality1Part2
CyberKnightFatality2
CyberPaladinFatality1
DarkImpFatality1
DarkImpFatality2
DemonFatality
DemonFatality2
DemonFatality3
DraugrFatality
FatsoFatality
FatsoFatality2
FleshWizardFatality
HellionFatality
HellTrooperFatality1
HellTrooperFatality2
HellTrooperFatality3
HelmetComandoFatality1
HelmetComandoFatality2
HelmetSergeantFatality1
HelmetSergeantFatality2
HelmetSergeantFatality3
HelmetZombieManFatality
HelmetZombieManFatality2
HelmetZombieManFatality3
HelmetZombieManFatality4
HFQSZFatality
HFQSZFatality2
HFQSZFatality3
HKFatality
HKFatality2
HKFatality3
HKFatality4
IceVileFatality
ImpFatality
ImpFatality2
ImpFatality3
ImpFatality4
ImpFatality5
LabGuyToken1
LabGuyToken2
LabGuyToken3
MagCacoFatality
MeanDemonFatality1
MechDemonFatality
OtherFatsoFatality
OtherFatsoFatality2
OverlordFatality
PEFatality
PistolZombiemanFatality1
PlasmaZombieFatality
PlasmaZombieFatality2
RapidFireTrooperFatality
RevenantFatality
RevenantFatality2
RiotSergeantFatality
SavageImpFatality1
SergeantFatality
SergeantFatality2
SergeantFatality3
SergeantFatality4
SergeantFatality5
SergeantFatality6
SpiderMastermindFatality
TriteElementalFatality
UndeadMarineFatality1
VoidSpectreFatality
VolcabusFatality
VolcabusFatality2
ZombieManFatality
ZombieManFatality2
ZombieManFatality3
ZombieManFatality4
ZombieManFatality5
ZombieManFatality6
ZSpecFatality

![Untitled](https://user-images.githubusercontent.com/3980470/79033606-6b53bd80-7b7d-11ea-9f49-add22cc0e70c.jpg)
