### PR TITLE
Cyberdemon laser pointer for railgun

### DIFF
--- a/actors/Weapons/Slot7/RAILGUN.dec
+++ b/actors/Weapons/Slot7/RAILGUN.dec
@@ -562,6 +562,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_1:
 			R036 BCDEF 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.1,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast");
@@ -575,6 +576,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R036 G 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.1,6);
 				if(JustReleased(BT_ATTACK) || !PressingFire()) {
 					return state("Laser_Blast");
@@ -588,6 +590,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_2:
 			R036 HIJKL 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.18,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast");
@@ -600,6 +603,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R036 M 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.18,6);
 				if(JustReleased(BT_ATTACK) || !PressingFire()) {
 					return state("Laser_Blast");
@@ -614,6 +618,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_3:
 			R036 NOPQR 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.26,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast");
@@ -626,6 +631,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R036 S 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.26,6);
 				if(JustReleased(BT_ATTACK) || !PressingFire()) {
 					return state("Laser_Blast");
@@ -639,6 +645,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_4:
 			R036 TUVWX 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.32,6);
 				if(CountInv("RailgunLaserCharge") == 60) {
 					A_StartSound("weapons/railgun/lasercharge4", CHAN_AUTO, CHANF_OVERLAP);
@@ -654,6 +661,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R036 Y 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.32,6);
 				if(CountInv("RailgunLaserCharge") == 60) {
 					A_StartSound("weapons/railgun/lasercharge4", CHAN_AUTO, CHANF_OVERLAP);
@@ -759,6 +767,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_1_Scope:
 			R039 BCDEF 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.1,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast");
@@ -772,6 +781,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R039 G 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.1,6);
 				if(JustReleased(BT_ATTACK) || !PressingFire()) {
 					return state("Laser_Blast_Scope");
@@ -785,6 +795,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_2_Scope:
 			R039 HIJKL 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.18,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast_Scope");
@@ -797,6 +808,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R039 M 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.18,6);
 				if(JustReleased(BT_ATTACK) || !PressingFire()) {
 					return state("Laser_Blast_Scope");
@@ -811,6 +823,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_3_Scope:
 			R039 NOPQR 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.26,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast_Scope");
@@ -823,6 +836,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R039 S 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.26,6);
 				if(JustReleased(BT_ATTACK) || !PressingFire()) {
 					return state("Laser_Blast_Scope");
@@ -836,6 +850,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 			}
 		Laser_Stage_4_Scope:
 			R039 TUVWX 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.32,6);
 				if(CountInv("RailgunAmmo") < 1) {
 					return state("Laser_Blast_Scope");
@@ -851,6 +866,7 @@ ACTOR Rail_Gun : PB_Weapon 13204
 				return state("");
 			}
 			R039 Y 1 BRIGHT {
+				A_RailAttack(0, 0, 0,"None", "Red", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 0, "NullPuff", 0, 0, 0, 0, 0.98, 1.0, "LaserCannonPointer", -7,0,0);
 				A_SetBlend("Red",0.32,6);
 				if(CountInv("RailgunLaserCharge") == 60) {
 					A_StartSound("weapons/railgun/lasercharge4", CHAN_AUTO, CHANF_OVERLAP);
@@ -1574,4 +1590,27 @@ ACTOR MicrowaveTrailSpark : RailGunTrailSpark
     YAE4 A 2 bright A_FadeOut(0.05)
     Loop
     }
+}
+
+ACTOR LaserCannonPointer
+{
+  RenderStyle Add
+  Scale 0.02
+  Alpha 0.8
+  Translation "0:255=%[0,0,0]:[1,0,0]"
+  +NOINTERACTION
+  +NOGRAVITY
+  States
+  {
+  Spawn:
+    TNT1 A 0
+    TNT1 A 0 A_SetScale(ScaleX+0.03, ScaleY -0.01)
+    YAE5 A 1 bright
+    YAE5 A 1 bright A_FadeOut(0.020)
+  Trolololo:
+    YAE5 A 0 //A_JumpIf(ScaleY <= 0, "NULL")
+    YAE5 A 0 A_SetScale(ScaleX -0.01, ScaleY -0.01)
+    YAE5 A 1 bright A_FadeOut(0.1)
+    Loop
+  }
 }


### PR DESCRIPTION
The cyberdemon laser pointer has been repurposed (it is its own actor within railgun.dec at the end of the file).

Does not add any damage or change the mechanics, just comes on while charging a laser shot.  Added as a single line (A_RailAttack) to each of the charging states for both fire modes of the laser.