### PR TITLE
Chamber round with PumpSG with Box Mag

### DIFF
--- a/actors/Weapons/Slot3/SHOTGUN.dec
+++ b/actors/Weapons/Slot3/SHOTGUN.dec
@@ -1454,6 +1454,7 @@ ACTOR Shot_Gun : PB_Weapon Replaces Shotgun
 		SHTM H 1 A_PlaySoundEx("RIFCL_IN", "Auto")
 		SHTM I 1 A_PlaySoundEx("insertshell", "Auto")
         SHTM JKLMN 1 
+		TNT1 A 0 A_JumpIf(CountInv("ShotgunAmmo") == 0,"ShellCheckerMag2")
 	ShellCheckerMag:	
 		TNT1 A 0 A_JumpIf(CountInv("NewShell") == 0,"ReloadMagFinished")
 		TNT1 A 0 A_JumpIfInventory("ShotgunAmmo",11,"ReloadMagFinished")
@@ -1463,6 +1464,46 @@ ACTOR Shot_Gun : PB_Weapon Replaces Shotgun
 		 A_Takeinventory("NewShell",1);
 		}
 		Goto ShellCheckerMag
+	ShellCheckerMag2:	
+		TNT1 A 0 A_JumpIf(CountInv("NewShell") == 0,"LoadChamberMag")
+		TNT1 A 0 A_JumpIfInventory("ShotgunAmmo",10,"LoadChamberMag")
+		TNT1 A 0 
+		{
+		 A_Giveinventory("ShotgunAmmo",1);
+		 A_Takeinventory("NewShell",1);
+		}
+		Goto ShellCheckerMag2
+	LoadChamberMag:
+		SHMG J 1 A_SetRoll(roll-0.1,SPF_INTERPOLATE)
+	    SHMA K 0
+		SHMF K 0
+		SHMG N 1 
+		{
+		 A_SetRoll(roll-0.1,SPF_INTERPOLATE);
+		 A_PlaySoundEx("weapons/sgmvpump","Auto"); 
+		}
+		SHMG L 1
+		{
+		 A_SetRoll(roll-0.4,SPF_INTERPOLATE);
+		 A_SetPitch(pitch+0.1,SPF_INTERPOLATE);
+		}
+		SHTG M 2
+		SHMG L 1 
+		{
+		 A_SetRoll(roll+0.4,SPF_INTERPOLATE);
+		 A_SetPitch(pitch-0.1,SPF_INTERPOLATE);
+		}
+		SHMG K 1 
+		{
+		 If( CountInv("HasSlugs") >=1 )        
+		   {A_SetWeaponSprite("SHMA");} 
+		 If (CountInv("HasDragonBreath") >=1 )        
+		   {A_SetWeaponSprite("SHMF");}
+		 A_SetRoll(roll+0.1,SPF_INTERPOLATE);
+		 A_PlaySoundEx("weapons/sgpump", "Auto");
+		 return state("");
+		}	
+		SHMG J 1 A_SetRoll(roll+0.1,SPF_INTERPOLATE)
 	ReloadMagFinished:
 	    SHTM OPQR 1 A_SetRoll(roll+0.1,SPF_INTERPOLATE)
 		SHTG EDCB 1 A_SetRoll(roll+0.1,SPF_INTERPOLATE)


### PR DESCRIPTION
This was a feature that was included originally but subsiquently omitted when the Pump shotgun code additions were re-written.  As promised here is the addition of a pumping animation to chamber a round when you reload the Pump SG with box magazine and zero rounds originally in the SG at time of reload.

Only an A_JumpIf added and a couple of states created.  Uses all existing assets.