### PR TITLE
Redo: Rifle and Shotgun wheels fixed.

### DIFF
--- a/actors/Weapons/Slot4/PBRIFLE.dec
+++ b/actors/Weapons/Slot4/PBRIFLE.dec
@@ -462,7 +462,6 @@ ACTOR Rifle : PB_Weapon
 			A_ZoomFactor(1.0);
 			A_ClearOverlays(10,11);
 			}
-		TNT1 A 0 A_JumpIf(CountInv("DMRUpgraded") < 1, "HandleDualWield")
 		
 		TNT1 A 0 {
 			if ((CountInv("SelectSingleRifle") == 1) && A_GetCurrentRifleMode() == "NormalMode") {

--- a/zscript/PbWheel/ev_core_special.zsc
+++ b/zscript/PbWheel/ev_core_special.zsc
@@ -745,12 +745,16 @@ Class PB_SpecialWheelHandler : EventHandler
 				rifle_normal.specialAlias = "Single Rifle";
 				rifle_normal.specialPriority = 1;
 				rifle_normal.iconScale = iconScale;
+				wheelSpecials.Push(rifle_normal);
+			if(players[consoleplayer].mo.FindInventory("DMRUpgraded")){
 				PB_SpecialWheel_Mode rifle_grenade = new ("PB_SpecialWheel_Mode");
 				rifle_grenade.specialIcon = TexMan.CheckForTexture("graphics/pywheel/RWGLG0.png",TexMan.Type_Any);
 				rifle_grenade.specialName = "SelectRifleGrenade";
 				rifle_grenade.specialAlias = "Underbarrel Grenade Launcher";
 				rifle_grenade.specialPriority = 2;
 				rifle_grenade.iconScale = iconScale;
+				wheelSpecials.Push(rifle_grenade);
+			}
 				PB_SpecialWheel_Mode rifle_dual = new ("PB_SpecialWheel_Mode");
 				rifle_dual.specialIcon = TexMan.CheckForTexture("graphics/pywheel/RWGLH0.png",TexMan.Type_Any);
 				rifle_dual.specialName = "SelectDualWieldRifles";
@@ -758,8 +762,6 @@ Class PB_SpecialWheelHandler : EventHandler
 				rifle_dual.specialPriority = 3;
 				rifle_dual.iconScale = iconScale;
 				
-				wheelSpecials.Push(rifle_normal);
-				wheelSpecials.Push(rifle_grenade);
 				wheelSpecials.Push(rifle_dual);
 				
 				specialWheel_handleMouse();
@@ -1095,18 +1097,16 @@ if (players[consoleplayer].ReadyWeapon == NULL)
 					return;
 					
 				case 'Rifle':
-					if (players[consoleplayer].mo.FindInventory("DMRUpgraded")) {
-						return;
-					}
-					else
-						break;
-						
+					specialWheel_Rifle();
+					return;
+							
 				case 'BDPistol':
 					specialWheel_Pistol();
 					return;
 					
 				case 'Shot_Gun':
 					if (!players[consoleplayer].mo.FindInventory("Zoomed")) {
+					specialWheel_Shotgun();
 						return;
 					}
 					else


### PR DESCRIPTION
Fixed a major issue with the weapon special wheels not working with the Rifle and Shotgun.
Weapon Special wheel can now be used on the un-upgraded DMR but can only select dual wield and single rifle until the upgrade is picked up, acting more akin to the Minigun only selecting Chaingun and Gatling mode until the upgrade was picked up.
This is a much more cleaner and efficient method I did rather than I did in #469. Works pretty well to me. If this was already before this pull request was made, please let me know.