### PR TITLE
You can pick a loudout of weapons at spawn

### DIFF
--- a/CVARINFO
+++ b/CVARINFO
@@ -213,6 +213,7 @@ user int bd_RestoreCarbines = 0;
 user int bd_ADSHoldDown = 0;
 user int bd_SGAltAmmoSwap = 0;
 user int bd_SGPumpFromHip = 0;
+user int pb_StartingWeapons = 0;
 server int bd_UnifiedExplosives = 0;
 
 

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -72,6 +72,22 @@ OptionValue "BrutalBlood"
 	666, "Overdrawn at Blood Bank"
 }
 
+OptionValue "StartingWeapons"
+{
+	0, "Infantry (Default)"
+	1, "Fire Support"
+	2, "Commando"
+	3, "Sniper"
+	4, "Grenadier"
+	5, "Anti-Vehicle"
+	6, "Close-Quarters"
+	7, "Psychopath"
+	8, "Splinter Cell"
+	9, "Deathwish"
+	10, "Helljumper"
+	11, "Biohazard Cleanup"
+}
+
 OptionValue "YesOrNo"
 {
 	0, "No"
@@ -257,7 +273,13 @@ OptionMenu "WeaponSpawns"
 OptionMenu "GameplaySettings"
 {
 	Title "---------Game Settings---------"
-	
+
+	StaticText " "
+	Option "Starting Weapons Loadout",	"pb_StartingWeapons", "StartingWeapons"
+	StaticText "Loadout when beginning a new game."
+	StaticText " "
+	StaticText " "
+
 	
 	StaticText " "
 	Option "Weapon Special Wheel Freezes Time",	"py_weaponwheel_freeze", "OnOff"
@@ -781,6 +803,7 @@ ListMenu "MainMenu"
 	}
 	IfGame(Doom, Strife, Chex)
 	{
+		//TextItem "NEW GAME", "n", "StartingWeapons"//Uncomment this line and comment the line below to have weapon select directly at new game
 		TextItem "New Game", "n", "PlayerclassMenu"
 		Selector "M_SKULL1", -30, -8
 		ifOption(SwapMenu)
@@ -813,6 +836,23 @@ ListMenu "MainMenu"
 		TextItem "$MNU_INFO", "i", "ReadThisMenu"
 		TextItem "$MNU_QUITGAME", "q", "QuitMenu"
 	}
+}
+
+OptionMenu "StartingWeapons"
+{
+	statictext ""
+	statictext ""
+	statictext ""
+	statictext ""
+	statictext ""
+	statictext ""
+	statictext ""
+	statictext ""
+	statictext ""
+	statictext ""
+	StaticText "-----------------Initial Loadout-----------------"
+	Option "Weapons to spawn with:","pb_StartingWeapons","StartingWeapons"
+	Submenu "Project Brutality - Class/Skill Menu", "PlayerclassMenu"
 }
 
 ListMenu "PlayerclassMenu"

--- a/actors/Player/PLAYER.dec
+++ b/actors/Player/PLAYER.dec
@@ -989,8 +989,9 @@ ACTOR Doomer : PlayerPawnBase Replaces DoomPlayer
 	Player.WeaponSlot 0, HitlersBuzzsaw, SecretWeapon_MP40, HellishMissileLauncher, FlameCannon, Hell_rifle
 	
 	Player.StartItem "PB_PDAWeaponContainer",1
-	Player.StartItem "Rifle"
-	Player.StartItem "BDPistol"
+	//Player.StartItem "Rifle"
+	//Player.StartItem "BDPistol"
+	Player.StartItem "StartingWeapons"
 	Player.StartItem "Melee_Attacks"
 	Player.StartItem "NewClip", 90
 	Player.StartItem "RifleAmmo", 31

--- a/actors/Weapons/BaseWeapon.dec
+++ b/actors/Weapons/BaseWeapon.dec
@@ -14,10 +14,105 @@ Actor WW_StunGrenadeSelected : Inventory {inventory.maxamount 1}
 Actor WW_LeechSelected : Inventory {inventory.maxamount 1}
 Actor WW_HealthBackPackSelected : Inventory {inventory.maxamount 1}
 
+//to trigger a resolve state to get that weapon in your hands
+Actor StartingWeaponSelect : Inventory {inventory.maxamount 1}
 
 //Actions observed by the AI!
 Actor PlayerIsThrowingAGrenade : Inventory {inventory.maxamount 1}
 Actor CantWeaponSpecial : Inventory {inventory.maxamount 1}
+
+Actor StartingWeapons : Custominventory
+{
+//$Category Ammunition
+	Game Doom
+	//SpawnID 9410
+	Height 24
+	Inventory.MaxAmount 1
+	+INVENTORY.ALWAYSPICKUP
+	+COUNTITEM
+	Inventory.Pickupsound "misc/rockboxa"
+	Inventory.PickupMessage "Starting Loadout Placeholder"
+	States
+	{
+	Spawn:
+		TNT1 A 35
+	Pickup:
+		TNT1 A 35
+		TNT1 A 0 {
+			if(GetCVar("pb_StartingWeapons") ==0)
+				{
+					A_Log("Starting Weapon Loadout: Infantry");
+					A_GiveInventory("BDPistol",1);
+					A_GiveInventory("Rifle",1);
+				}
+			if(GetCVar("pb_StartingWeapons") ==1)
+				{
+					A_Log("Starting Weapon Loadout: Fire Support");
+					A_GiveInventory("Deagle",1);
+					A_GiveInventory("Mini_Gun",1);
+				}
+			if(GetCVar("pb_StartingWeapons") ==2)
+				{
+					A_Log("Starting Weapon Loadout: Commando");
+					A_GiveInventory("BDPistol",1);
+					A_GiveInventory("Carbine",1);
+				}
+			if(GetCVar("pb_StartingWeapons") ==3)
+				{
+					A_Log("Starting Weapon Loadout: Sniper");
+					A_GiveInventory("Revolver",1);
+					A_GiveInventory("Rifle",1);
+				}
+			if(GetCVar("pb_StartingWeapons") ==4)
+				{
+					A_Log("Starting Weapon Loadout: Grenadier");
+					A_GiveInventory("CompactSMG",1);
+					A_GiveInventory("Super_Grenade_Launcher",1);
+				}
+			if(GetCVar("pb_StartingWeapons") ==5)
+				{
+					A_Log("Starting Weapon Loadout: Anti-Vehicle");
+					A_GiveInventory("CompactSMG",1);
+					A_GiveInventory("Rocket_Launcher",1);
+				}
+			if(GetCVar("pb_StartingWeapons") ==6)
+				{
+					A_Log("Starting Weapon Loadout: Close-Quarters");
+					A_GiveInventory("Revolver",1);
+					A_GiveInventory("Shot_Gun",1);
+				}
+			if(GetCVar("pb_StartingWeapons") ==7)
+				{
+					A_Log("Starting Weapon Loadout: Psychopath");
+					A_GiveInventory("BrutalAxe",1);
+					A_GiveInventory("Chain_Saw",1);
+				}
+			if(GetCVar("pb_StartingWeapons") ==7)
+				{
+					A_Log("Starting Weapon Loadout: Splinter Cell (Pistol Only)");
+					A_GiveInventory("BDPistol",1);
+				}
+			if(GetCVar("pb_StartingWeapons") ==8)
+				{
+					A_Log("Starting Weapon Loadout: Deathwish (Fists Only)");
+				}
+			if(GetCVar("pb_StartingWeapons") ==9)
+				{
+					A_Log("Starting Weapon Loadout: Helljumper");
+					A_GiveInventory("Plasma_Gun",1);
+					A_GiveInventory("StunGrenadeAmmo",5);
+				}
+			if(GetCVar("pb_StartingWeapons") ==9)
+				{
+					A_Log("Starting Weapon Loadout: Biohazard Cleanup");
+					A_GiveInventory("M2PlasmaRifle",1);
+					A_GiveInventory("FlameCannon",1);
+				}
+		}
+		TNT1 A 0 A_GiveInventory("StartingWeaponSelect",1)
+		Stop
+	}
+}
 
 Actor PB_Weapon : PB_WeaponBase
 {
@@ -713,6 +808,28 @@ States
 		TNT1 A 0
 		Goto GoingToReady
 		
+	StartingWeaponSelect:
+		TNT1 A 0 {
+			A_SetInventory("StartingWeaponSelect",0);
+			A_SetInventory("StartingWeapons",0);
+			}
+		TNT1 A 0 {
+			if(GetCVar("pb_StartingWeapons") ==0){A_SelectWeapon("Rifle"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==1){A_SelectWeapon("Mini_Gun"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==2){A_SelectWeapon("Carbine"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==3){A_SelectWeapon("Rifle"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==4){A_SelectWeapon("Super_Grenade_Launcher"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==5){A_SelectWeapon("Rocket_Launcher"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==6){A_SelectWeapon("Shot_Gun"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==7){A_SelectWeapon("Chain_Saw"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==7){A_SelectWeapon("BDPistol"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==8){Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==9){A_SelectWeapon("Plasma_Gun"); Return State("GoingToReady");}
+			if(GetCVar("pb_StartingWeapons") ==9){A_SelectWeapon("M2PlasmaRifle"); Return State("GoingToReady");}
+		Return State("");
+		}
+		goto GoingToReady
+	
 	////////////////////////////////////////////////KNIFE COMBO//////////////////////////////////////////////////////////////
 		
 	QuickPunchPurist:

--- a/actors/Weapons/Slot1/MELEE.dec
+++ b/actors/Weapons/Slot1/MELEE.dec
@@ -256,7 +256,8 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		Goto ReadyFists
 	
 	Ready:
-        ////////////////// Check if player is performing a fatality
+		TNT1 A 0 A_JumpIfInventory("StartingWeaponSelect",1,"StartingWeaponSelect") //selects initial loadout of weapons      
+	    ////////////////// Check if player is performing a fatality
 		TNT1 A 0 A_JumpIfInventory("ArachnoGun",1,"ReadyArachno")
         TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
  		TNT1 A 0 A_JumpIfInventory("ShotgunguyHead",1,"ReadyShotgunguyHead")


### PR DESCRIPTION
-The rifle and pistol have been removed from start items for the player.
-a new item starting weapons has been put into its place
-this item gets a cvar that is decided in menu and will directly give the appropriate inventory along with a token that melee attacks resolve a state from
-from that state it will select the appropriate weapon when beginning and clean out the tokens items initially involved.

-I sent another PR a couple days ago and it may conflict this one at the file baseweapon when merging.  They are both compatible just github will likely have a fit about it.

-the menu option for this is under Project Brutality  > Gameplay Options.  I also have placed in code to for it to take over a new game option (it would be selected between new game and player class/difficulty screen) but it is commented out.  Feel free to swap the two lines (I marked it) if you want it.