### PR TITLE
Deprecated fixes part 2 - level.frozen

### DIFF
--- a/zscript/PbWheel/ev_core_special.zsc
+++ b/zscript/PbWheel/ev_core_special.zsc
@@ -491,7 +491,7 @@ Class PB_SpecialWheelHandler : EventHandler
 		
 		if(CVar.GetCVar("py_weaponwheel_freeze", players[consoleplayer]).GetInt()==true)
 		{
-			level.frozen = wheelIsOpen;
+			Level.setFrozen(wheelIsOpen);
 		}
 		invertControls = CVar.GetCVar("py_weaponwheel_invert", players[consoleplayer]).GetInt();
 		if(musicFadeEnabled&&musicFade>0)
@@ -508,7 +508,7 @@ Class PB_SpecialWheelHandler : EventHandler
 			{
 				musicFade+=fadeSpeed;
 			}
-			if(level.frozen)
+			if(Level.isFrozen())
 			{
 				players[consoleplayer].viewz = players[consoleplayer].mo.pos.z+players[consoleplayer].viewheight;
 				players[consoleplayer].bob = 0;
@@ -579,7 +579,7 @@ Class PB_SpecialWheelHandler : EventHandler
 				players[consoleplayer].mo.A_SetAngle(players[consoleplayer].mo.angle + 1, SPF_INTERPOLATE);
 				players[consoleplayer].mo.A_SetPitch(players[consoleplayer].mo.pitch + 1, SPF_INTERPOLATE);
 				
-				if(level.frozen&&oldPTics.Size()==0)
+				if(Level.isFrozen()&&oldPTics.Size()==0)
 				{
 					let pspr = players[consoleplayer].psprites;
 					while (pspr)
@@ -590,7 +590,7 @@ Class PB_SpecialWheelHandler : EventHandler
 					}
 				}
 				
-				if(level.frozen)
+				if(Level.isFrozen())
 				{
 					if(oldPUTics.Size()==0)
 					{


### PR DESCRIPTION
`Accessing deprecated member variable frozen - deprecated since 3.8.0, Use Level.isFrozen() instead`