### PR TITLE
Deprecated fixes part 3 - CheckClass

### DIFF
--- a/zscript/Gore/NashGore/NashGoreStatics.zc
+++ b/zscript/Gore/NashGore/NashGoreStatics.zc
@@ -140,35 +140,34 @@ class NashGoreStatics play
 				if (mo = Actor(it.Next()))
 				{		
 					bool valid = (
-						mo.CheckClass("Actor", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("NashGoreGibs", AAPTR_DEFAULT) ||
-						mo.CheckClass("NashGoreBloodPlane", AAPTR_DEFAULT) ||
-						mo.CheckClass("NashGoreIceChunk", AAPTR_DEFAULT) ||
-						mo.CheckClass("NashGoreSquishyGibs", AAPTR_DEFAULT) ||
-						mo.CheckClass("NashGoreStickyGibsCeiling", AAPTR_DEFAULT) ||
-						mo.CheckClass("NashGoreStickyGibs", AAPTR_DEFAULT) ||
-						mo.CheckClass("NashGoreGibs", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("NashGoreBloodPlane", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("NashGoreIceChunk", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("NashGoreSquishyGibs", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_GibBase", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_LimbBase", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_XDeath1", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_XDeath2", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_XDeathOrgan1", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_XDeathBurnedMeat", AAPTR_DEFAULT) ||
-						mo.CheckClass("FlyingGibBase", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_XDeathArm1", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_SmallBrainPiece", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_Brains4", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_Brains6", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_Brains7", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_BrainsImpHeadPiece", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_XDeathZombieManHead", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_XDeathZombieManHead", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PB_Teeth", AAPTR_DEFAULT, TRUE)
-						
-						);
+						mo is "Actor" ||
+						mo.GetClassName() == "NashGoreGibs" ||
+						mo.GetClassName() == "NashGoreBloodPlane" ||
+						mo.GetClassName() == "NashGoreIceChunk" ||
+						mo.GetClassName() == "NashGoreSquishyGibs" ||
+						mo.GetClassName() == "NashGoreStickyGibsCeiling" ||
+						mo.GetClassName() == "NashGoreStickyGibs" ||
+						mo is "NashGoreGibs" ||
+						mo is "NashGoreBloodPlane" ||
+						mo is "NashGoreIceChunk" ||
+						mo is "NashGoreSquishyGibs" ||
+						mo is "PB_GibBase" ||
+						mo is "PB_LimbBase" ||
+						mo is "PB_XDeath1" ||
+						mo is "PB_XDeath2" ||
+						mo is "PB_XDeathOrgan1" ||
+						mo.GetClassName() == "PB_XDeathBurnedMeat" ||
+						mo is "FlyingGibBase" ||
+						mo is "PB_XDeathArm1" ||
+						mo is "PB_SmallBrainPiece" ||
+						mo is "PB_Brains4" ||
+						mo is "PB_Brains6" ||
+						mo is "PB_Brains7" ||
+						mo is "PB_BrainsImpHeadPiece" ||
+						mo is "PB_XDeathZombieManHead" ||
+						mo is "PB_XDeathZombieManHead" ||
+						mo is "PB_Teeth"
+					);
 
 					if (valid) {
 						mo.Destroy();
@@ -205,52 +204,51 @@ class NashGoreStatics play
 				if (mo = Actor(it.Next()))
 				{		
 					bool valid = (
-						mo.CheckClass("Actor", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("Mp40CaseSpawn", AAPTR_DEFAULT) ||
-						mo.CheckClass("Mp40CaseSpawnRight", AAPTR_DEFAULT) ||
-						mo.CheckClass("DeagleCasingRight", AAPTR_DEFAULT) ||
-						mo.CheckClass("DeagleCasingLeft", AAPTR_DEFAULT) ||
-						mo.CheckClass("MagnumCasing", AAPTR_DEFAULT) ||
-						mo.CheckClass("PistolCasingSpawner", AAPTR_DEFAULT) ||
-						mo.CheckClass("SMGCasingSpawner", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("RifleCaseSpawn", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("ShotCaseSpawn", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("ShotCaseSpawn2", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("ShotCaseSpawn3", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("SSGCaseSpawner", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("FiftyCaseSpawn", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("FiftyCaseSpawn2", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("GrenadeCaseSpawn", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("BigEmptyCaseSpawn", AAPTR_DEFAULT) ||
-						mo.CheckClass("MastermindCaseSpawn", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyBrass", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyBrassMinigun", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyGrenadeBrass", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("GiantEmptyBrass", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("BigEmptyBrass", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("underwaterEmptyBrass", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("ShotgunCasing", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("ShotgunCasingSSG", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("ShotgunCasing2", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("ShotgunCasing3", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyClipMP40", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyClip", AAPTR_DEFAULT) ||
-						mo.CheckClass("EmptyBrassMP40", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyBrassDeagle", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyBrassMagnum", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyBrassPistol", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyBrassSMG", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyRocketChamber", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyLMGMag", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyASGDrum", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyHMGDrum", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("EmptyCell", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("RocketCaseSpawn", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("PlasmaCaseSpawn", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("MinigunBeltPiece", AAPTR_DEFAULT, TRUE) ||
-						mo.CheckClass("MiniBeltPieceSpawn", AAPTR_DEFAULT) ||
-						mo.CheckClass("MiniBeltPieceSpawn2", AAPTR_DEFAULT, TRUE)
-						
+						mo is "Actor" ||
+						mo.GetClassName() == "Mp40CaseSpawn" ||
+						mo.GetClassName() == "Mp40CaseSpawnRight" ||
+						mo.GetClassName() == "DeagleCasingRight" ||
+						mo.GetClassName() == "DeagleCasingLeft" ||
+						mo.GetClassName() == "MagnumCasing" ||
+						mo.GetClassName() == "PistolCasingSpawner" ||
+						mo is "SMGCasingSpawner" ||
+						mo is "RifleCaseSpawn" ||
+						mo is "ShotCaseSpawn" ||
+						mo is "ShotCaseSpawn2" ||
+						mo is "ShotCaseSpawn3" ||
+						mo is "SSGCaseSpawner" ||
+						mo is "FiftyCaseSpawn" ||
+						mo is "FiftyCaseSpawn2" ||
+						mo is "GrenadeCaseSpawn" ||
+						mo.GetClassName() == "BigEmptyCaseSpawn" ||
+						mo is "MastermindCaseSpawn" ||
+						mo is "EmptyBrass" ||
+						mo is "EmptyBrassMinigun" ||
+						mo is "EmptyGrenadeBrass" ||
+						mo is "GiantEmptyBrass" ||
+						mo is "BigEmptyBrass" ||
+						mo is "underwaterEmptyBrass" ||
+						mo is "ShotgunCasing" ||
+						mo is "ShotgunCasingSSG" ||
+						mo is "ShotgunCasing2" ||
+						mo is "ShotgunCasing3" ||
+						mo is "EmptyClipMP40" ||
+						mo.GetClassName() == "EmptyClip" ||
+						mo is "EmptyBrassMP40" ||
+						mo is "EmptyBrassDeagle" ||
+						mo is "EmptyBrassMagnum" ||
+						mo is "EmptyBrassPistol" ||
+						mo is "EmptyBrassSMG" ||
+						mo is "EmptyRocketChamber" ||
+						mo is "EmptyLMGMag" ||
+						mo is "EmptyASGDrum" ||
+						mo is "EmptyHMGDrum" ||
+						mo is "EmptyCell" ||
+						mo is "RocketCaseSpawn" ||
+						mo is "PlasmaCaseSpawn" ||
+						mo is "MinigunBeltPiece" ||
+						mo.GetClassName() == "MiniBeltPieceSpawn" ||
+						mo is "MiniBeltPieceSpawn2"
 						);
 
 					if (valid) {

--- a/zscript/PlayerPawn.zc
+++ b/zscript/PlayerPawn.zc
@@ -3642,7 +3642,7 @@ class PlayerPawnBase : PlayerPawn
 	{
 		// Check the parent class the monster is derived from
 		//let target_ptr = AAPTR_PLAYER_GETTARGET;
-		if (CheckClass("PB_Monster", AAPTR_PLAYER_GETTARGET, TRUE)){
+		if (GetPointer(AAPTR_PLAYER_GETTARGET) is "PB_Monster"){
 			//A_Print("This is a PB Monster!!!"); // Debug code
 			A_GiveInventory("HeadshotToken", 1, AAPTR_PLAYER_GETTARGET);
 		}


### PR DESCRIPTION
`Accessing deprecated function CheckClass - deprecated since 3.7.0, Use GetClass(), type cast, or 'is' operator instead`

I have used the 'is' operator to check if class is of specified class or any of its descendants and CheckClassName for specific class name checks.

https://forum.zdoom.org/viewtopic.php?f=122&t=66017&p=1120668&hilit=getclass#p1120668