### PR TITLE
Deprecated fixes part 4 - A_ChangeFlag

### DIFF
--- a/zscript/Decorations/PBDeadGeneric.zc
+++ b/zscript/Decorations/PBDeadGeneric.zc
@@ -233,9 +233,9 @@ class PB_CurbstompedMarine : Actor
 		Death.TeleportRemover:
 		Death.GibRemoving:
 			TNT1 A 0 A_NoBlocking();
-			TNT1 A 0 A_ChangeFlag("NOCLIP", 1);
-			TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0);
-			TNT1 A 0 A_ChangeFlag("NOBLOCKMAP", 1);
+			TNT1 A 0 {bNOCLIP = True;}
+			TNT1 A 0 {bSHOOTABLE = False;}
+			TNT1 A 0 A_ChangeLinkFlags(True);
 			Stop;
 		
 		Death.CrushedBodies:

--- a/zscript/Gore/PBGore.zc
+++ b/zscript/Gore/PBGore.zc
@@ -100,7 +100,7 @@ class PB_GibBase : Actor
 			TNT1 A 0 {
 				bNOCLIP = True;
 				bSHOOTABLE = False;
-				A_ChangeFlag("NOBLOCKMAP", true);
+				A_ChangeLinkFlags(True);
 				A_NoBlocking();
 			}
 			Stop;	 
@@ -882,7 +882,7 @@ class PB_GibArm: PB_LimbBase
 	
 		Death.ExplosiveImpact:
 			TNT1 A 0 {	
-				A_ChangeFlag("NOBLOCKMAP", 0);
+				A_ChangeLinkFlags(False);
 				ThrustThingZ(0,50,0,1);
 			}
 			XARM A 6;
@@ -994,7 +994,7 @@ class PB_GibZombieLeg1: PB_LimbBase
 			Goto Spawn;
 		
 		Death.ExplosiveImpact:
-			TNT1 A 0 {A_ChangeFlag("NOBLOCKMAP", 0);}
+			TNT1 A 0 {A_ChangeLinkFlags(False);}
 			TNT1 A 0 ThrustThingZ(0,50,0,1);
 			LEG1 A 5;
 			LEG1 ABCDEFGHABCDEFGHABCDEFGH 5 A_CheckFloor("Landz");
@@ -1198,6 +1198,7 @@ Class PB_SmearingBrain : PB_TinyGibBase
 		Speed 10;
 		Mass 1;
 		Scale 0.5;
+		Gravity 0.25;
 		+NOBLOCKMAP;
 		+NOTELEPORT;
 		+THRUGHOST;
@@ -1206,7 +1207,6 @@ Class PB_SmearingBrain : PB_TinyGibBase
 		+MOVEWITHSECTOR;
 		-DONTSPLASH;
 		+FORCEXYBILLBOARD;
-		+QUARTERGRAVITY;
 	}
     States
     {
@@ -1230,7 +1230,7 @@ Class PB_SmearingBrain : PB_TinyGibBase
 	
 	Death:
 	Rest:
-		TNT1 A 0 A_ChangeFlag("QUARTERGRAVITY", 0);
+		TNT1 A 0 { Gravity = 1.0; }
 		XDB5 A 2 ThrustThingZ(0,-2,0,1);
 		TNT1 A 0 A_CheckFloor("Sleep");
 		Loop;
@@ -1759,7 +1759,7 @@ class PB_ZombiemanHead: PB_LimbBase
 		
 		Death.ExplosiveImpact:
 			TNT1 A 0;
-			TNT1 A 0 {A_ChangeFlag("NOBLOCKMAP", 0);}
+			TNT1 A 0 {A_ChangeLinkFlags(False);}
 			TNT1 A 0 ThrustThingZ(0,50,0,1);
 			XHE2 ABCD 6;
 			XDT5 I 0 A_SpawnItem("PB_ZombiemanHead");
@@ -1893,7 +1893,7 @@ class PB_HelmetZombieHead: PB_ZombiemanHead
 		
 		Death.ExplosiveImpact:
 			TNT1 A 0;
-			TNT1 A 0 {A_ChangeFlag("NOBLOCKMAP", 0);}
+			TNT1 A 0 {A_ChangeLinkFlags(False);}
 			TNT1 A 0 ThrustThingZ(0,50,0,1);
 			XHEQ ABCD 6;
 			TNT1 A 0 A_SpawnItem("PB_HelmetZombieHead");
@@ -1988,7 +1988,7 @@ class PB_ARZombiemanHead: PB_LimbBase
 		
 		Death.ExplosiveImpact:
 			TNT1 A 0;
-			TNT1 A 0 {A_ChangeFlag("NOBLOCKMAP", 0);}
+			TNT1 A 0 {A_ChangeLinkFlags(False);}
 			TNT1 A 0 ThrustThingZ(0,50,0,1);
 			RHE2 ABCD 6;
 			XDT5 I 0 A_SpawnItem("PB_ARZombiemanHead");
@@ -2097,7 +2097,7 @@ class PB_ChainsawZombieHead: PB_LimbBase
 		
 		Death.ExplosiveImpact:
 			TNT1 A 0;
-			TNT1 A 0 {A_ChangeFlag("NOBLOCKMAP", 0);}
+			TNT1 A 0 {A_ChangeLinkFlags(False);}
 			TNT1 A 0 ThrustThingZ(0,50,0,1);
 			LCE0 AAAAAAAA 2 A_SetRoll(roll+45);
 			XDT5 I 0 A_SpawnItem("PB_ChainsawZombieHead");


### PR DESCRIPTION
`Accessing deprecated function A_ChangeFlag - deprecated since 2.3.0, Use 'b<FlagName> = [true/false]' instead`

QUARTERGRAVITY is deprecated: https://zdoom.org/wiki/Actor_flags
Use A_ChangeLinkFlags to modify NOBLOCKMAP: https://zdoom.org/wiki/A_ChangeLinkFlags