### PR TITLE
Deprecated fixes part 5 - CharAt / CharCodeAt

### DIFF
--- a/zscript/PbWheel/parse.zsc
+++ b/zscript/PbWheel/parse.zsc
@@ -68,7 +68,7 @@ Class PyWheel_Tokenizer
 	
 	static bool IsDigit(string c)
     {
-        int cc = c.CharCodeAt(0);
+        int cc = c.ByteAt(0);
         return cc <= 57 && cc >= 48;
     }
 
@@ -84,19 +84,19 @@ Class PyWheel_Tokenizer
 
     static bool IsLower(string c)
     {
-        int cc = c.CharCodeAt(0);
+        int cc = c.ByteAt(0);
         return cc <= 122 && cc >= 97;
     }
 
     static bool IsUpper(string c)
     {
-        int cc = c.CharCodeAt(0);
+        int cc = c.ByteAt(0);
         return cc <= 90 && cc >= 65;
     }
 	
 	virtual PyWheel_Token GoThru()
 	{
-		while(isWhitespace(lumpString.CharCodeAt(currentPos))&&currentPos<=lumpString.Length())
+		while(isWhitespace(lumpString.ByteAt(currentPos))&&currentPos<=lumpString.Length())
 		{
 			currentPos++;
 		}
@@ -109,8 +109,8 @@ Class PyWheel_Tokenizer
 			//Console.Printf("~ END OF FILE ~");
 			return tk;
 		}
-		//Console.Printf("\ctRead "..lumpString.CharCodeAt(currentPos));
-		switch(lumpString.CharCodeAt(currentPos))
+		//Console.Printf("\ctRead "..lumpString.ByteAt(currentPos));
+		switch(lumpString.ByteAt(currentPos))
 		{
 			case 123:
 				tk.type = PTK_BraceO;
@@ -134,9 +134,9 @@ Class PyWheel_Tokenizer
 				break;
 			case 47: // '/'
 				tk.type = PTK_Slash;
-				while(!isNewline(lumpString.CharCodeAt(currentPos))&&currentPos<=lumpString.Length())
+				while(!isNewline(lumpString.ByteAt(currentPos))&&currentPos<=lumpString.Length())
 				{
-					tk.value.AppendFormat("%s", lumpString.CharAt(currentPos));
+					tk.value.AppendFormat("%s", lumpString.Mid(currentPos,1));
 					currentPos++;
 				}
 				break;
@@ -152,29 +152,29 @@ Class PyWheel_Tokenizer
 			case 39: // '''
 				tk.type = PTK_String;
 				currentPos++;
-				while(/* !isWhitespace(lumpString.CharCodeAt(currentPos))&&*/lumpString.CharCodeAt(currentPos)!=34&&currentPos<=lumpString.Length())
+				while(/* !isWhitespace(lumpString.ByteAt(currentPos))&&*/lumpString.ByteAt(currentPos)!=34&&currentPos<=lumpString.Length())
 				{
-					tk.value.AppendFormat("%s", lumpString.CharAt(currentPos));
+					tk.value.AppendFormat("%s", lumpString.Mid(currentPos,1));
 					currentPos++;
 				}
 				break;
 			default:
-				if(IsLetter(lumpString.CharAt(currentPos)))
+				if(IsLetter(lumpString.Mid(currentPos,1)))
 				{
 					tk.type = PTK_Identifier;
-					while(!isWhitespace(lumpString.CharCodeAt(currentPos))&&lumpString.CharCodeAt(currentPos)!=44/*&&IsLetterOrDigit(lumpString.CharAt(currentPos))*/&&currentPos<=lumpString.Length())
+					while(!isWhitespace(lumpString.ByteAt(currentPos))&&lumpString.ByteAt(currentPos)!=44/*&&IsLetterOrDigit(lumpString.Mid(currentPos,1))*/&&currentPos<=lumpString.Length())
 					{
-						tk.value.AppendFormat("%s", lumpString.CharAt(currentPos));
+						tk.value.AppendFormat("%s", lumpString.Mid(currentPos,1));
 						currentPos++;
 					}
 					currentPos--;
 				}
-				else if(IsDigit(lumpString.CharAt(currentPos)))
+				else if(IsDigit(lumpString.Mid(currentPos,1)))
 				{
 					tk.type = PTK_Number;
-					while(!isWhitespace(lumpString.CharCodeAt(currentPos))&&lumpString.CharCodeAt(currentPos)!=59/*&&IsDigit(lumpString.CharAt(currentPos))*/&&currentPos<=lumpString.Length())
+					while(!isWhitespace(lumpString.ByteAt(currentPos))&&lumpString.ByteAt(currentPos)!=59/*&&IsDigit(lumpString.Mid(currentPos,1))*/&&currentPos<=lumpString.Length())
 					{
-						tk.value.AppendFormat("%s", lumpString.CharAt(currentPos));
+						tk.value.AppendFormat("%s", lumpString.Mid(currentPos,1));
 						currentPos++;
 					}
 					currentPos--;


### PR DESCRIPTION
This PR will take care of these warnings:
`Accessing deprecated function CharCodeAt - deprecated since 4.1.0, use ByteAt() instead`
`Accessing deprecated function CharAt - deprecated since 4.1.0, use Left() or Mid() instead`

These fixes are not utf-8 safe, but I believe the previous code was not either, so nothing new introduced.

Relevant links:
https://zdoom.org/wiki/String