### PR TITLE
Icons for pump shotgun and shells restored for fullscreen HUD

### DIFF
--- a/actors/Items/Ammo/ShellboxBig.dec
+++ b/actors/Items/Ammo/ShellboxBig.dec
@@ -97,7 +97,7 @@ ACTOR NewShell : Ammo Replaces Shell
 	+DONTGIB
 	Inventory.Amount 4
 	Inventory.MaxAmount 50
-	Inventory.Icon "SBOXA0"
+	Inventory.Icon "SHELA0"
 	Ammo.BackpackAmount 4
 	Ammo.BackpackMaxAmount 100
 	States

--- a/actors/Items/Ammo/ShellboxBig.dec
+++ b/actors/Items/Ammo/ShellboxBig.dec
@@ -97,6 +97,7 @@ ACTOR NewShell : Ammo Replaces Shell
 	+DONTGIB
 	Inventory.Amount 4
 	Inventory.MaxAmount 50
+	Inventory.Icon "SBOXA0"
 	Ammo.BackpackAmount 4
 	Ammo.BackpackMaxAmount 100
 	States

--- a/actors/Weapons/Slot3/SHOTGUN.dec
+++ b/actors/Weapons/Slot3/SHOTGUN.dec
@@ -1667,5 +1667,5 @@ ACTOR ShotgunAmmo : Ammo
    Inventory.MaxAmount 9
    Ammo.BackpackAmount 0
    Ammo.BackpackMaxAmount 9
-   Inventory.Icon "SHTCA1"
+   Inventory.Icon "SHTCA0"
 }


### PR DESCRIPTION
Issue: #449 

Restores entries in the fullscreen HUD  for pump shotgun and total inventory shell count. 

Edit: updated shell icon to be more similar to native ZDoom:
![shellfix_update](https://user-images.githubusercontent.com/31620802/92320599-e2a15680-f022-11ea-9712-b656b05be2d0.png)

