### PR TITLE
Undefined drop item class fixes

### DIFF
--- a/actors/Decorations/DEAD.dec
+++ b/actors/Decorations/DEAD.dec
@@ -458,7 +458,7 @@ ACTOR DeadDeadStick: DeadStick Replaces DeadStick
 	DropItem "ArmorShard" 55
 	DropItem "ArmorShard" 55
 	DropItem "Stimpack" 55
-	DropItem "NewClip" 55
+	DropItem "BulletCartridge" 55
 	DropItem "NewShell" 55
     bloodtype "DeadBlood"
     damagefactor "Blood", 0.0    damagefactor "GreenBlood", 0.0    damagefactor "BlueBlood", 0.0    damagefactor "Taunt", 0.0    damagefactor "KillMe", 0.0  damagefactor "Avoid", 0.0  damagefactor "Taunt", 0.0
@@ -523,7 +523,7 @@ ACTOR DeadLiveStick: LiveStick Replaces LiveStick
 	DropItem "ArmorShard" 55
 	DropItem "ArmorShard" 55
 	DropItem "Stimpack" 55
-	DropItem "NewClip" 55
+	DropItem "BulletCartridge" 55
 	DropItem "NewShell" 55
     damagefactor "Blood", 0.0    damagefactor "GreenBlood", 0.0    damagefactor "BlueBlood", 0.0    damagefactor "Taunt", 0.0    damagefactor "KillMe", 0.0  damagefactor "Avoid", 0.0  damagefactor "Taunt", 0.0
     bloodtype "DeadBlood"
@@ -910,7 +910,7 @@ ACTOR HangingBody: Meat2 Replaces Meat2
 	+SHOOTABLE
     GibHealth 10
 	damagefactor "Fire", 0.0
-	DropItem "NewClip" 128
+	DropItem "BulletCartridge" 128
 	DropItem "HealthPlus" 128
 	DropItem "HealthPlus" 128
 	DropItem "HealthPlus" 128

--- a/actors/Decorations/DEAD.dec
+++ b/actors/Decorations/DEAD.dec
@@ -458,8 +458,8 @@ ACTOR DeadDeadStick: DeadStick Replaces DeadStick
 	DropItem "ArmorShard" 55
 	DropItem "ArmorShard" 55
 	DropItem "Stimpack" 55
-	DropItem "Clips" 55
-	DropItem "Shells" 55
+	DropItem "NewClip" 55
+	DropItem "NewShell" 55
     bloodtype "DeadBlood"
     damagefactor "Blood", 0.0    damagefactor "GreenBlood", 0.0    damagefactor "BlueBlood", 0.0    damagefactor "Taunt", 0.0    damagefactor "KillMe", 0.0  damagefactor "Avoid", 0.0  damagefactor "Taunt", 0.0
     GibHealth 10
@@ -523,8 +523,8 @@ ACTOR DeadLiveStick: LiveStick Replaces LiveStick
 	DropItem "ArmorShard" 55
 	DropItem "ArmorShard" 55
 	DropItem "Stimpack" 55
-	DropItem "Clips" 55
-	DropItem "Shells" 55
+	DropItem "NewClip" 55
+	DropItem "NewShell" 55
     damagefactor "Blood", 0.0    damagefactor "GreenBlood", 0.0    damagefactor "BlueBlood", 0.0    damagefactor "Taunt", 0.0    damagefactor "KillMe", 0.0  damagefactor "Avoid", 0.0  damagefactor "Taunt", 0.0
     bloodtype "DeadBlood"
 	States
@@ -910,7 +910,7 @@ ACTOR HangingBody: Meat2 Replaces Meat2
 	+SHOOTABLE
     GibHealth 10
 	damagefactor "Fire", 0.0
-	DropItem "CLIP1Drop" 128
+	DropItem "NewClip" 128
 	DropItem "HealthPlus" 128
 	DropItem "HealthPlus" 128
 	DropItem "HealthPlus" 128

--- a/actors/Monsters/T1-Grunts/CarbineZombie.dec
+++ b/actors/Monsters/T1-Grunts/CarbineZombie.dec
@@ -804,7 +804,7 @@ States{Spawn:
 
 Actor Vanilla_ARZombieMan : ARZombieMan
 {
-	DropItem "DropedVanillaRifle" 256
+	DropItem "DropedRifle" 256
 	DropItem "DropedGrenade" 5
 	States
 	{

--- a/actors/Monsters/T1-Grunts/ClassicCommando.dec
+++ b/actors/Monsters/T1-Grunts/ClassicCommando.dec
@@ -38,7 +38,7 @@ ACTOR ChaingunGuy2: ChaingunGuy1 Replaces ChaingunGuy
     DamageFactor "Shrapnel", 0.4
 	DamageFactor "explosiveimpact", 2.0
 	DamageFactor "MinorHead", 1.2
-	DropItem "NewChain_Gun", 255
+	DropItem "Mini_Gun", 255
 	SeeSound "commando/sight"
 	PainSound "commando/pain"
 	DeathSound "commando/death"

--- a/actors/Monsters/T1-Grunts/RifleCommando.dec
+++ b/actors/Monsters/T1-Grunts/RifleCommando.dec
@@ -1455,7 +1455,7 @@ actor CommandoSpawnBeaconFriendly : CommandoSpawnBeacon
 
 Actor Vanilla_RifleCommando : RifleCommando
 {
-	DropItem "DropedVanillaRifle" 256
+	DropItem "DropedRifle" 256
 	DropItem "DropedGrenade" 15
 	States
 	{

--- a/actors/Monsters/T1-Grunts/ZSpecOps.dec
+++ b/actors/Monsters/T1-Grunts/ZSpecOps.dec
@@ -2169,7 +2169,7 @@ Actor Vanilla_ZSpec : ZSpecOpsMachinegun
 {
 	DropItem "NewClip" 256
 	DropItem "Shell" 256
-	DropItem "DropedVanillaSMG" 256
+	DropItem "DropedSMG" 256
 	DropItem "DropedGrenade" 5
 	States
 	{

--- a/actors/Monsters/T1-Imps/ImpVariant1.dec
+++ b/actors/Monsters/T1-Imps/ImpVariant1.dec
@@ -6,7 +6,7 @@ Actor DNImpVariant1 : Imp Replaces DoomImp
 	Speed 9
 	SpawnID 1430
 	Tag "Vicious Imp"
-	DropItem Imp2DropSpawner	
+	DropItem ImpSpawner	
 	States
 	{
 	////////////////////////////////////////////////////////////////////////////

--- a/actors/Monsters/T2-Pinkies/MeanDemon.dec
+++ b/actors/Monsters/T2-Pinkies/MeanDemon.dec
@@ -32,7 +32,6 @@ Actor DemonX : Demon Replaces Demon
 	DropItem "DemonStrengthRune" 4
 	DropItem "RageSphere" 3
 	DropItem "DoubleSphere" 2
-	DropItem "ShieldSphere" 1
 	BloodType "Brutal_Blood", "BloodSPlatterReplacer", "Brutal_Blood"
 	DamageFactor "CauseObjectsToSplash", 0.0
 	DropItem "Demonpickup" 150

--- a/actors/Monsters/T3-Arachnos/EliteArachnotron.dec
+++ b/actors/Monsters/T3-Arachnos/EliteArachnotron.dec
@@ -18,7 +18,6 @@ ACTOR Arachnotron2: Arachnotron replaces Arachnotron
 	DropItem "DemonMorphRune" 2
 	DropItem "RageSphere" 8
 	DropItem "DoubleSphere" 7
-	DropItem "ShieldSphere" 2
 	DropItem "TimeSphere" 3
 	DropItem "Demonpickup2" 255
 	DropItem "Demonpickup" 55

--- a/actors/Monsters/T3-Arachnos/InfernalArachnotron.dec
+++ b/actors/Monsters/T3-Arachnos/InfernalArachnotron.dec
@@ -17,7 +17,6 @@ ACTOR ArachnotronX: Arachnotron replaces Arachnotron
 	DropItem "DemonMorphRune" 1
 	DropItem "RageSphere" 8
 	DropItem "DoubleSphere" 7
-	DropItem "ShieldSphere" 2
 	DropItem "TimeSphere" 3
 	DropItem "Demonpickup2" 255
 	DropItem "Demonpickup" 55

--- a/actors/Monsters/T3-Fats/Daedabus.dec
+++ b/actors/Monsters/T3-Fats/Daedabus.dec
@@ -31,7 +31,6 @@ Actor Daedabus replaces Fatso
 	DropItem "DemonMorphRune" 3
 	DropItem "RageSphere" 4
 	DropItem "DoubleSphere" 4
-	DropItem "ShieldSphere" 3
 	Species "BigFatAss"
    +DONTHARMSPECIES
 	+DONTHARMCLASS

--- a/actors/Monsters/T3-Fats/Volcabus.dec
+++ b/actors/Monsters/T3-Fats/Volcabus.dec
@@ -32,7 +32,6 @@ Actor Volcabus : Fatso replaces Fatso
 	DropItem "DemonMorphRune" 5
 	DropItem "RageSphere" 4
 	DropItem "DoubleSphere" 4
-	DropItem "ShieldSphere" 3
 	Species "BigFatAss"
 	+DONTHARMSPECIES
     +DONTHARMCLASS

--- a/actors/Monsters/T3-Floaters/InfernalCaco.dec
+++ b/actors/Monsters/T3-Floaters/InfernalCaco.dec
@@ -36,7 +36,6 @@ ACTOR MagCaco : PainElemental replaces Cacodemon
 	DropItem "DemonStrengthRune" 3
 	DropItem "RageSphere" 4
 	DropItem "DoubleSphere" 2
-	DropItem "ShieldSphere" 2
 	DamageFactor "Blood", 0.0 DamageFactor "BlueBlood", 0.0 DamageFactor "GreenBlood", 0.0
 	damagefactor "killme", 0.0
 	

--- a/actors/Monsters/T3-Floaters/Overlord.dec
+++ b/actors/Monsters/T3-Floaters/Overlord.dec
@@ -24,7 +24,6 @@ DropItem "DemonStrengthRune" 25
 	DropItem "Demonpickup2" 76
 	DropItem "RageSphere" 22
 	DropItem "DoubleSphere" 15
-	DropItem "ShieldSphere" 13
 	DropItem "TimeSphere" 13
 Obituary "%o was smoked by the Overlord."
 HitObituary "The Overlord ate %o for lunch."

--- a/actors/Monsters/T3-Floaters/TriteElem.dec
+++ b/actors/Monsters/T3-Floaters/TriteElem.dec
@@ -28,7 +28,6 @@ ACTOR TriteElemental replaces PainElemental
 	DropItem "DemonStrengthRune" 7
 	DropItem "RageSphere" 6
 	DropItem "DoubleSphere" 5
-	DropItem "ShieldSphere" 4
     damagetype Flames
    Obituary "%o was nested by a Trite Elemental."
     BloodType "Green_Blood", "GreenSawBlood", "GreenSawBlood"

--- a/actors/Monsters/T4-Nobles/CyberBaron.dec
+++ b/actors/Monsters/T4-Nobles/CyberBaron.dec
@@ -29,7 +29,6 @@ ACTOR Cyberbaron replaces BaronofHell
 	DropItem "DemonStrengthRune" 9
 	DropItem "RageSphere" 8
 	DropItem "DoubleSphere" 7
-	DropItem "ShieldSphere" 5
 	DropItem "DemonMorphRune" 5
   PainChance "Kick", 200
   PainChance "ExtremePunches", 200

--- a/actors/Monsters/T4-Nobles/CyberKnight.dec
+++ b/actors/Monsters/T4-Nobles/CyberKnight.dec
@@ -45,7 +45,6 @@ Actor PhasicKnightX: Hellknight Replaces HellKnight
 	DropItem "DemonStrengthRune" 7
 	DropItem "RageSphere" 6
 	DropItem "DoubleSphere" 5
-	DropItem "ShieldSphere" 4
 	SeeSound "monster/bruSit" 
 	PainSound "baron/pain" 
 	DeathSound "monster/brudth"

--- a/actors/Monsters/T4-Nobles/CyberPaladin.dec
+++ b/actors/Monsters/T4-Nobles/CyberPaladin.dec
@@ -47,7 +47,6 @@ ACTOR CyberPaladin replaces Hellknight
 	DropItem "DemonStrengthRune" 7
 	DropItem "RageSphere" 6
 	DropItem "DoubleSphere" 5
-	DropItem "ShieldSphere" 4
 	DropItem "Demonpickup2" 90
     DropItem "Demonpickup" 196
 	States

--- a/actors/Monsters/T4-Viles/FleshWizard.dec
+++ b/actors/Monsters/T4-Viles/FleshWizard.dec
@@ -22,7 +22,6 @@ DropItem "DemonStrengthRune" 7
 DropItem "DemonMorphRune" 10
 	DropItem "RageSphere" 7
 	DropItem "DoubleSphere" 7
-	DropItem "ShieldSphere" 6
 	DropItem "TimeSphere" 20
 	DropItem "Demonpickup2" 255
  DropItem "Demonpickup2" 255

--- a/actors/Monsters/Tz-Bosses/ANNIHILATOR.dec
+++ b/actors/Monsters/Tz-Bosses/ANNIHILATOR.dec
@@ -45,7 +45,6 @@ ACTOR Annihilator: Cyberdemon Replaces Cyberdemon
 	DropItem "DemonMorphRune" 25
 	DropItem "RageSphere" 25
 	DropItem "DoubleSphere" 25
-	DropItem "ShieldSphere" 20
     BloodType "Brutal_Blood"
 DamageFactor "Blood", 0.0 DamageFactor "BlueBlood", 0.0 DamageFactor "GreenBlood", 0.0
 	

--- a/actors/Player/PLAYER.dec
+++ b/actors/Player/PLAYER.dec
@@ -1007,7 +1007,6 @@ ACTOR Doomer : PlayerPawnBase Replaces DoomPlayer
 	Player.StartItem "PlasmaAmmo", 50
 	Player.StartItem "RocketRounds", 6
 	Player.StartItem "RailgunAmmo", 50
-	Player.StartItem "DualSSGAmmo", 4
 	Player.StartItem "IsPlayer", 1
 	Player.StartItem "SMGAmmo", 50
 	Player.StartItem "XRifleAmmo", 40


### PR DESCRIPTION
This PR is meant to remove the following warnings found in various files
<details>
  <summary>Undefined drop item class </summary>

```text/plain
Undefined drop item class ShieldSphere referenced from actor PoorMeanDemonLostHisArm
Undefined drop item class ShieldSphere referenced from actor TriteElemental
Undefined drop item class ShieldSphere referenced from actor HellsFury
Undefined drop item class ShieldSphere referenced from actor Cybruiser
Undefined drop item class ShieldSphere referenced from actor Cyberbaron
Undefined drop item class ShieldSphere referenced from actor SuperOverlord
Undefined drop item class ShieldSphere referenced from actor OverLord
Undefined drop item class ShieldSphere referenced from actor Volcabus
Undefined drop item class ShieldSphere referenced from actor Daedabus
Undefined drop item class ShieldSphere referenced from actor Annihilator
Undefined drop item class ShieldSphere referenced from actor Vore
Undefined drop item class ShieldSphere referenced from actor Arachnotron2
Undefined drop item class ShieldSphere referenced from actor ArachnotronX
Undefined drop item class ShieldSphere referenced from actor FleshWizard
Undefined drop item class ShieldSphere referenced from actor HellWarrior
Undefined drop item class ShieldSphere referenced from actor CyberPaladin
Undefined drop item class ShieldSphere referenced from actor CyberKnight
Undefined drop item class ShieldSphere referenced from actor FriendlyCyberKnight
Undefined drop item class ShieldSphere referenced from actor PhasicKnightX
Undefined drop item class ShieldSphere referenced from actor BloodDemonClone
Undefined drop item class ShieldSphere referenced from actor Bloodfiend
Undefined drop item class ShieldSphere referenced from actor DemonX
Undefined drop item class ShieldSphere referenced from actor MagCaco
Undefined drop item class NewChain_Gun referenced from actor ChaingunGuy2
Undefined drop item class DropedVanillaRifle referenced from actor Vanilla_RifleCommando
Undefined drop item class Imp2DropSpawner referenced from actor DNImpVariant1
Undefined drop item class DropedVanillaSMG referenced from actor Vanilla_ZSpec
Undefined drop item class DropedVanillaRifle referenced from actor Vanilla_ARZombieMan
Undefined drop item class DualSSGAmmo referenced from actor BrutalDoomer
Undefined drop item class DualSSGAmmo referenced from actor Doomer
Undefined drop item class CLIP1Drop referenced from actor NSHangingBody
Undefined drop item class CLIP1Drop referenced from actor HangingBody
Undefined drop item class Shells referenced from actor ImpaledMarineAlive1d
Undefined drop item class Clips referenced from actor ImpaledMarineAlive1d
Undefined drop item class Shells referenced from actor ImpaledMarineAlive1c
Undefined drop item class Clips referenced from actor ImpaledMarineAlive1c
Undefined drop item class Shells referenced from actor ImpaledMarineAlive1b
Undefined drop item class Clips referenced from actor ImpaledMarineAlive1b
Undefined drop item class Shells referenced from actor ImpaledMarineAlive1a
Undefined drop item class Clips referenced from actor ImpaledMarineAlive1a
Undefined drop item class Shells referenced from actor ImpaledMarineAlive2d
Undefined drop item class Clips referenced from actor ImpaledMarineAlive2d
Undefined drop item class Shells referenced from actor ImpaledMarineAlive2c
Undefined drop item class Clips referenced from actor ImpaledMarineAlive2c
Undefined drop item class Shells referenced from actor ImpaledMarineAlive2b
Undefined drop item class Clips referenced from actor ImpaledMarineAlive2b
Undefined drop item class Shells referenced from actor ImpaledMarineAlive2a
Undefined drop item class Clips referenced from actor ImpaledMarineAlive2a
Undefined drop item class Shells referenced from actor ImpaledMarineAlive2
Undefined drop item class Clips referenced from actor ImpaledMarineAlive2
Undefined drop item class Shells referenced from actor ImpaledMarineAlive1
Undefined drop item class Clips referenced from actor ImpaledMarineAlive1
Undefined drop item class Shells referenced from actor DeadLiveStick
Undefined drop item class Clips referenced from actor DeadLiveStick
Undefined drop item class Shells referenced from actor DeadDeadStick
Undefined drop item class Clips referenced from actor DeadDeadStick
```
</details>

Some details I want to add:

`actors/Decorations/DEAD.dec`
~~I chose to replace "Clips" with the high caliber magazine "NewClip", it's possible the original intent was the low caliber clip used for slot 2 weapons, but who knows. When you kill a doom guy impaled on a stick, it will now possibly release shells or a HiCal magazine.~~ Replaced with `BulletCartridge`

`actors/Monsters/T1-Imps/ImpVariant1.dec`
When you kill this type of Imp, a new basic Imp will spawn, as I think the original intent was. It could be that the whole line should be deleted because the "Imp2DropSpawner" was deleted and someone forgot to delete the reference to it, but I like the idea of the Imp spawning.


