### PR TITLE
Dragons Breath Piece changes

### DIFF
--- a/actors/Effects/FIRE.dec
+++ b/actors/Effects/FIRE.dec
@@ -1644,11 +1644,11 @@ ACTOR DragonsBreathPiece1: TinyBurningPiece2
 	Spawn:
 	
 	CFCF ABC 1 BRIGHT// A_SpawnItem("RedFlareSmall", 0, 5)
-	CFCF D 1 A_Explode(3, 28)
+	CFCF D 1 A_Explode(3, 28, 0, 0)
 	CFCF EFG 1 BRIGHT// A_SpawnItem("RedFlareSmall", 0, 5)
-	CFCF H 1 //A_Explode(4, 28)
+	CFCF H 1 //A_Explode(4, 28, 0, 0)
 	CFCF IJK 1 BRIGHT// A_SpawnItem("RedFlareSmall", 0, 5)
-	CFCF L 1 A_Explode(3, 28)
+	CFCF L 1 A_Explode(3, 28, 0, 0)
 	TNT1 A 0 A_Jump(24, "StopBurning")
 	Loop
 	
@@ -1674,11 +1674,11 @@ ACTOR DragonsBreathPiece2: TinyBurningPiece2
 	Spawn:
 	
 	CFCF ABC 1 BRIGHT// A_SpawnItem("RedFlareSmall", 0, 5)
-	CFCF D 1 A_Explode(3, 35)
+	CFCF D 1 A_Explode(3, 35, 0, 0)
 	CFCF EFG 1 BRIGHT// A_SpawnItem("RedFlareSmall", 0, 5)
-	CFCF H 1 //A_Explode(4, 35)
+	CFCF H 1 //A_Explode(4, 35, 0, 0)
 	CFCF IJK 1 BRIGHT// A_SpawnItem("RedFlareSmall", 0, 5)
-	CFCF L 1 A_Explode(3, 35)
+	CFCF L 1 A_Explode(3, 35, 0, 0)
 	TNT1 A 0 A_Jump(24, "StopBurning")
 	Loop
 	
@@ -1703,11 +1703,11 @@ ACTOR DragonsBreathPiece3: TinyBurningPiece2
 	Spawn:
 	
 	CFCF ABC 1 BRIGHT// A_SpawnItem("RedFlareSmall", 0, 5)
-	CFCF D 1 A_Explode(3, 40)
+	CFCF D 1 A_Explode(3, 40, 0, 0)
 	CFCF EFG 1 BRIGHT// A_SpawnItem("RedFlareSmall", 0, 5)
-	CFCF H 1 //A_Explode(4, 40)
+	CFCF H 1 //A_Explode(4, 40, 0, 0)
 	CFCF IJK 1 BRIGHT// A_SpawnItem("RedFlareSmall", 0, 5)
-	CFCF L 1 A_Explode(3, 40)
+	CFCF L 1 A_Explode(3, 40, 0, 0)
 	TNT1 A 0 A_Jump(24, "StopBurning")
 	Loop
 	


### PR DESCRIPTION
Prevent Dragon Breath from dealing damage to player. 

At current state Dragon Breath flames deals a lot of damage when walked over. This makes DB gameplay slow, kinga unpredictable and generaly uncomfortable (a specially in close quarters). 

The "Species" thing doesn't work for some reasons, so implemented this fix.