### PR TITLE
Altermate tracer for minigun

### DIFF
--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -403,7 +403,7 @@ OptionMenu "RenderingSettings"
 	StaticText "Enables GL light emitted from tracers"
 	StaticText " "
 	Option "Alternate Tracers","PB_alttracer", "OnOff"
-	StaticText "Enables longer/more realistic tracer (Rifle only currently)"
+	StaticText "Enables longer/more realistic tracer (Rifle/Minigun only currently)"
 	StaticText " "
 	
 	

--- a/actors/Weapons/Slot4/MINIGUN.dec
+++ b/actors/Weapons/Slot4/MINIGUN.dec
@@ -622,7 +622,13 @@ States
 			A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
+			
 			A_Giveinventory("OverHeating",1);
 			A_GunFlash;
 		}
@@ -645,7 +651,12 @@ States
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("MiniBeltPieceSpawn",0,0,-12,-18);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
 			A_Giveinventory("OverHeating",1);
 			A_GunFlash;
 		}
@@ -667,7 +678,12 @@ States
 			A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
 			A_Giveinventory("OverHeating",1);
 			A_GunFlash;
 		}
@@ -690,7 +706,12 @@ States
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("MiniBeltPieceSpawn",0,0,-12,-18);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
 			A_Giveinventory("OverHeating",1);
 			A_GunFlash;
 			A_ReFire("Holding1");
@@ -812,7 +833,12 @@ States
 			A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
 			A_Giveinventory("OverHeating",1);
 			A_StartSound("weapons/minigun/chaingunmode/fire");
 			A_GunFlash;
@@ -833,7 +859,12 @@ States
 			A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
 			A_Giveinventory("OverHeating",1);
 			A_StartSound("weapons/minigun/chaingunmode/fire");
 			A_GunFlash;
@@ -850,7 +881,12 @@ States
 			A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
 			A_Giveinventory("OverHeating",1);
 			A_StartSound("weapons/minigun/chaingunmode/fire");
 			A_GunFlash;
@@ -877,7 +913,12 @@ States
 			A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
 			A_Giveinventory("OverHeating",1);
 			A_StartSound("weapons/minigun/chaingunmode/fire");
 			A_GunFlash;
@@ -907,7 +948,12 @@ States
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("MiniBeltPieceSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
 			A_Giveinventory("OverHeating",1);
 			A_StartSound("weapons/minigun/chaingunmode/fire");
 			A_GunFlash;
@@ -937,7 +983,12 @@ States
 			A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
-			A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-3,3), 0, -1, random(-3,3));}
 			A_Giveinventory("OverHeating",1);
 			A_StartSound("weapons/minigun/chaingunmode/fire");
 			A_GunFlash;
@@ -1054,7 +1105,12 @@ States
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			A_FireBullets(4, 3, -1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));}
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Giveinventory("OverHeating",1);
 			A_GunFlash;
@@ -1072,7 +1128,12 @@ States
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			A_FireBullets(4, 3, -1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));}
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("MiniBeltPieceSpawn",0,0,-12,-18);
 			A_Giveinventory("OverHeating",1);
@@ -1083,7 +1144,12 @@ States
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			A_FireBullets(4, 3, -1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));}
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Giveinventory("OverHeating",1);
 			A_GunFlash;
@@ -1101,7 +1167,12 @@ States
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			A_FireBullets(4, 3, -1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));}
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("MiniBeltPieceSpawn",0,0,-12,-18);
 			A_Giveinventory("OverHeating",1);
@@ -1112,7 +1183,12 @@ States
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			A_FireBullets(4, 3, -1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));}
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Giveinventory("OverHeating",1);
 			A_GunFlash;
@@ -1130,7 +1206,12 @@ States
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			A_FireBullets(4, 3, -1, 10, "MachineGunBulletPuff", 1);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));}
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("MiniBeltPieceSpawn",0,0,-12,-18);
 			A_Giveinventory("OverHeating",1);
@@ -1195,7 +1276,14 @@ States
 		//TNT1 A 0 A_JumpIf(CountInv("NewClip") < 1, "HoldingDeathDealer_Stop")
         8HBF A 1 BRIGHT {
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-4,4));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, -4, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);//Left
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);//Center
+				 A_RailAttack(0, 4, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);//Right
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));}
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
@@ -1217,7 +1305,14 @@ States
         8HBF BC 1 A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer")
         8HBF D 1 BRIGHT {
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-4,4));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, -4, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);//Left
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);//Center
+				 A_RailAttack(0, 4, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);//Right
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));}
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
@@ -1239,7 +1334,14 @@ States
         8HBF EF 1 A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer")
         8HBF G 1 BRIGHT {
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-4,4));
+			if(GetCvar("PB_alttracer") >=1)
+				{
+				 A_RailAttack(0, -4, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);//Left
+				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);//Center
+				 A_RailAttack(0, 4, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);//Right
+				// A_FireBullets (0.1, 0.1, -1, 22, "HitPuff", FBF_NORANDOM,8192,none, -2,0);
+				}
+			else {A_FireCustomMissile("MinigunTracer", random(-6,6), 0, -1, random(-6,6));}
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);
 			A_Firecustommissile("FiftyCaseSpawn",0,0,-12,-18);


### PR DESCRIPTION
Just like the tracer for the rifle previously written, except now it is for the minigun.  It is for all modes except for plain gatling mode.  The upgraded fire uses sprites that go well above the crosshair mark so even though I wrote the tracer for that it isn't actually visible (I would suggest having all tracers and projectiles hit point of impact about 12 degrees higher than point of aim center as I have written for myself personally in order to force the player to angle the weapon down (and give more space) 12 degrees to compensate, but that is a different PR for a different day.