### PR TITLE
Imp Replacer in impspawner

### DIFF
--- a/CVARINFO.txt
+++ b/CVARINFO.txt
@@ -1,0 +1,522 @@
+user bool py_weaponwheel_freeze = false;
+user int py_weaponwheel_invert = 0;
+user bool py_weaponwheel_musicfade = false;
+user bool pb_toggle_aim_hold = false;
+
+user int bd_bloodamount	= 2;
+user int PB_tracerlight	= 0;
+user int PB_alttracer = 0;
+user int bd_lowgraphicsmode = 0;
+server int bd_classicmonsters = 0;
+server int bd_TraditionalMode = 0;
+server int zdoombrutalblood	= 2;
+server int zdoombrutaljanitor = 0; //For gibs
+server int zdoombrutaljanitorcasings = 0; //For casings & clips
+server int isrunningzandronum = 1;
+server int bd_nobulletpenetration = 1;// CVar Info
+server int pb_knuckleanimationinstart = 0;
+server bool pb_fadeonmapexit = false; //Fade Effect on exiting a map
+
+server int bd_disabledecorations = 1;
+
+server int bd_disablemapenhancements = 1;
+
+server int bd_disablenewguns = 0;
+
+server int bd_disablenewenemies = 0;
+
+// Mode (0 = Crop, 1 = Scale)
+server noarchive int widemode         = 1;
+
+// Title Page
+server noarchive string titlemusic    = "TM_MUS";
+server noarchive string titlepage     = "TM_BACK";
+server noarchive int titlepage_w      = 3840;
+server noarchive int titlepage_h      = 2160;
+server noarchive float titlepage_time = 11;
+
+// Number of credit pages
+server noarchive int creditpages = 0;
+
+// Credit page
+server noarchive string creditpage1     = "CREDIT";
+server noarchive int creditpage1_w      = 320;
+server noarchive int creditpage1_h      = 200;
+server noarchive float creditpage1_time = 5;
+
+//Smart Scavenger
+server int pb_SmartScavenger = 0;
+server int pb_SmartScavengerHealth = 0;
+server int pb_HealthPackColor = 0;
+server int pb_EnableCarryableHealth = 0;
+server int pb_SmartScavengerNoFade = 0;
+
+
+//Screen Tilting
+user int disable_screentilt = 0;
+user float qtilt_strength = 1.0;
+user bool cl_MoveTilt = true;
+
+//Weapon Sway
+user int disable_weaponsway = 0;
+
+// CVar Info
+server float fs_volume_mul = 1.0;
+server float fs_delay_mul = 1.0;
+
+//Lives Mode for Servers
+server int bd_cooplives = 0;
+server int bd_numcooplives = 8;
+
+
+//Fatalities
+server float cl_fatalityspeed = 1.0;
+
+//Footsteps
+user float cl_step_volmul = 7.0;
+user float cl_step_delaymul = 1.0;
+
+//Gameplay Option
+server int donotsidestep = 0;
+server int donotdoublejump = 0;
+server int donotclimb = 0;
+server int nodoomguytalk = 0;
+server int performancemode = 0;
+server int bd_replacemarines = 0;
+server bool pb_enemyexplosiondamage = false;
+
+server int bd_restrictedmode = 0; //Nothing
+
+//Rendering
+server int noscreensplash = 0;
+server int nopaineffect = 0;
+
+//Global Spawn balance. Do NOT touch.
+server int BrutalSpawnBalance=671;
+
+//Monster Ability Toggles
+server int bd_NoZmanGrenade = 0;
+server int bd_NoZmanAdvancedAttacks = 0;
+server int bd_GroundImps = 0;
+server int bd_HungryPinky = 0;
+server int bd_GroundRevenant = 0;
+server int bd_NoKnightCharge = 0;
+server int bd_NoBaronBarrel = 0;
+server int bd_NoArchvileHeal = 0;
+server int bd_NoArchvileSummon = 0;
+server int bd_NoMancubusFlamer = 0;
+
+////////////////////Monster Spawning Toggles//////////////////////////
+
+//Zombieman
+server int bd_NoPistolZman = 0;
+server int bd_NoHelmetZman = 0;
+server int bd_NoZombieScientist = 0;
+server int bd_NoCarbineZombie = 0;
+server int bd_NoMinigunZombieman = 0;
+server int bd_NoRifleCommando = 0;
+
+//Sergeant
+server int bd_NoHelmetSergeant = 0;
+server int bd_NoAutoshotgunSergeant = 0;
+server int bd_NoZSpecOps = 0;
+server int bd_NoQuadSergeant = 0;
+server int bd_NoRocketSergeant = 0;
+server int bd_NoPyroSergeant = 0;
+server int bd_NoDemonTechSoldier = 0;
+server int bd_NoRiotShieldGuy = 0;
+
+//Commando
+server int bd_NoChaingunMajor = 0;
+server int bd_NoPlasmaZombie = 0;
+server int bd_NoClassicCommando = 0;
+
+//Imp Variants
+server int bd_NoBrownImps = 0;
+server int bd_NoDarkImps = 0;
+server int bd_NoSavageImps = 0;
+
+//Imp replacer
+server int PB_ImpReplacer = 0;
+
+//Pinky Demon Variants
+server int bd_NoBloodDemon = 0;
+server int bd_NoMechDemon = 0;
+
+//Spectre Variants
+server int bd_VoidSpectre = 0;
+
+//Cacodemon Variants
+server int bd_NoMagCaco = 0;
+server int bd_NoAfrit = 0;
+
+//Pain Elemental Variants
+server int bd_NoSufferElemental = 0;
+server int bd_NoOverlord = 0;
+
+//Lost Soul Variants
+server int bd_NoPhantasm = 0;
+
+//Revenant Variants
+server int bd_NoBeamRevenant = 0;
+server int bd_NoDraugr = 0;
+
+//Arachnotron Variants
+server int bd_NoInfernoArachnotron = 0;
+server int bd_NoArachnotron2 = 0;
+server int bd_NoArachnophyte = 0;
+
+//Hell Knight Variants
+server int bd_NoCyberKnight = 0;
+server int bd_NoCyberPaladin = 0;
+
+//Baron Variants
+server int bd_NoCyberBaron = 0;
+server int bd_NoBelphegor = 0;
+server int bd_NoInfernus = 0;
+
+//Fatso Variants
+server int bd_NoDaedabus = 0;
+server int bd_NoVolcabus = 0;
+
+//Archvile Variants
+server int bd_NoIceVile = 0;
+server int bd_NoFleshwizard = 0;
+server int bd_NoHellion = 0;
+
+//Mastermind Variants
+server int bd_NoDemolisher = 0;
+server int bd_NoJuggernaut = 0;
+
+//Cyber Demon Variants
+server int bd_NoAnnihilator = 0;
+
+//Assholes
+server int bd_EnableEvilMarines = 0;
+
+//Weapon Toggles
+server int bd_NoLMG = 0;
+server int bd_NoMinigunUpgrade = 0;
+server int bd_NoAutoshotgunUpgrade = 0;
+server int bd_NoDBUpgrade = 0;
+server int bd_NoUpgrades = 0;
+server int bd_NoQuadSSG = 0;
+server int bd_NoPulseCannonUpgrade = 0;
+server int bd_NoRifleUpgrade = 0;
+server int bd_NoUnmakerUpgrade = 0; //Why would you want this disabled???
+server int bd_NoM2Upgrade = 0;
+
+user int pb_olddualssgfiresystem = 0; // For Those Who Want The Old DualSSG Firing System
+user int bd_UpgradeRevolver = 0;
+user int bd_UpgradeCarbine = 0;
+user int bd_UpgradeShotgun = 0;
+user int bd_UpgradeHMG = 0;
+user int bd_UpgradePlasma = 0;
+user int bd_UpgradeGL = 0;
+user int bd_RestoreCarbines = 0;
+user int bd_ADSHoldDown = 0;
+user int bd_SGAltAmmoSwap = 0;
+user int bd_SGPumpFromHip = 0;
+user int bd_RLOverloadCell = 0;
+server int bd_UnifiedExplosives = 0;
+
+
+server int bd_NoSMGWeapon = 0;
+server int bd_NoRevolverWeapon = 0;
+server int bd_NoASGWeapon = 0;
+server int bd_NoCSSGWeapon = 1;
+server int bd_NoHMGWeapon = 0;
+server int bd_NoCarbineWeapon = 0;
+server int bd_NoSuperGLWeapon = 0;
+server int bd_NoHeavyGLWeapon = 0;
+server int bd_NoM2PlasmaWeapon = 0;
+server int bd_NoFreezerWeapon = 0;
+server int bd_NoRailgunWeapon = 0;
+server int bd_NoBFGBeamWeapon = 0;
+server int bd_NoBlackholeWeapon = 0;
+
+//Weapon Skins
+user int bd_shotgunskin = 0;
+
+//STFU Marines
+server int bd_ShutTheFuckUp = 0;
+
+
+server int bd_NoHelmetAnimation = 0;
+
+//Motion Blur by Pixel Eater
+user bool mblur = false ; //Disabled in response to fan feedback and to prevent possible startup errors on mobile devices or low end PCs.
+user int mblur_samples = 5 ;
+user float mblur_strength = 64 ;
+user float mblur_recovery = 64 ;
+user int mblur_blendmode = 1 ;
+user bool mblur_autostop = true ;
+user float mblur_threshold = 30 ;
+user float mblur_recovery2 = 90 ;
+
+// Tilt++ CVars
+
+// Strafe tilting
+server bool sv_strafetilt = true;
+server bool sv_strafetiltinvert = false;
+server float sv_strafetiltspeed = 1.0;
+server float sv_strafetiltangle = 0.5;
+
+// Movement tilting
+server bool sv_movetilt = false;
+server float sv_movetiltspeed = 15.000;
+server float sv_movetiltangle = 0.015;
+server float sv_movetiltscalar = 0.2;
+
+// Turn tilting
+server bool sv_turntilt = true;
+server float sv_turntiltscalar = 1.5;
+server bool sv_turntiltinvert = false;
+
+// Underwater tilting
+server bool sv_underwatertilt = true;
+server float sv_underwatertiltspeed = 0.8;
+server float sv_underwatertiltangle = 0.2;
+server float sv_underwatertiltscalar = 1.0;
+
+// Death tilting
+server bool sv_deathtilt = true;
+
+
+//New Head Hitbox System
+server float hs_factor = 2.0;
+server bool	 hs_hitbox 	= true; 
+
+// Max Casings
+server int nashgore_maxcasings = 50;
+// NashGore CVARs
+server int nashgore_maxgore = 1024;
+server int nashgore_bloodtype = 0;
+server int nashgore_bloodamount = 255;
+server bool nashgore_spriteblood = false;
+server bool nashgore_bloodspurt = true;
+server int nashgore_gibtype = 0;
+server int nashgore_gibamount = 255;
+server bool nashgore_corpseblood = true;
+server bool nashgore_footprints = true;
+server bool nashgore_deathflip = true;
+server bool nashgore_squish = true;
+server bool nashgore_icedeath = true;
+server bool nashgore_splat = true;
+
+
+
+
+
+
+/////////////////////////////////
+//Hard-Coded Movement for Project Brutality
+server 	bool 	pb_hazardmovement 		= false;
+server	int		pb_movetype				= 0;
+server	float	pb_friction				= 1.6;
+server 	float	pb_maxgroundspeed		= 15.1;
+server 	float	pb_maxhopspeed			= 28;
+server	float	pb_walkspeed			= 0.5;
+server	float	pb_crouchspeed			= 0.5;
+server 	float	pb_strafemodifier		= 1.33;
+server	bool	pb_dropprevention		= false;
+
+server 	float 	pb_jumpheight			= 8.0;
+server	float	pb_setgravity			= 1.0;
+server 	bool 	pb_autojump 			= true;
+
+
+server 	int 	pb_doublejump 			= 2;
+server 	float 	pb_doublejumpheight 	= 1.0;
+server 	bool 	pb_wjdoublejumprenew	= false;
+
+
+server 	bool 	pb_elevatorjump			= false;
+server 	float 	pb_ejumpmultiplier		= 1.0;
+
+server  bool 	pb_landing				= true;
+server	float	pb_landingsens			= 6.0;
+server	float	pb_landingspeed			= 0.25;
+server	float	pb_minlanding			= 0.5;
+
+server	bool	pb_dash					= true;
+user	bool	pb_dasheffect			= true;
+user	bool	pb_doubletap			= false;		
+user	int		pb_maxtaptime			= 10;
+server	float	pb_dashboost			= 1.33;
+server	float	pb_dashheight			= 0.5;
+
+server	bool	pb_airdash				= false;
+server	float	pb_adashboost			= 10;
+server	float	pb_adashfriction		= 1;
+
+server	bool	pb_wjump				= false;
+server	float	pb_wjumpboost			= 1.5;
+server	float	pb_multipledashes		= 0.0;
+server	float	pb_wjumpheight			= 0.75;
+
+server	bool	pb_wslide				= false;
+server	float	pb_wslidevelz			= 0.9;
+
+
+server	bool	pb_crouchslide			= true;
+server 	int 	pb_cslidetype			= 0;
+server 	float 	pb_cslidestrength		= 1.5;
+server 	int 	pb_cslideduration		= 10;
+server 	float 	pb_qslideaccel			= 6.0;
+server 	int 	pb_qslideduration		= 8;
+
+//Ledge Grabbing
+server	bool	pb_ledgegrab			= true;
+
+//Grappling Hook
+server	int		pb_hook					= 0;
+server 	float 	pb_hookboost			= 1.5;
+
+
+
+
+
+/////////////////////////////////
+//General
+
+server	int		zm_movetype				= 0;
+server	float	zm_friction				= 8.0;
+server 	float	zm_maxgroundspeed		= 12;
+server 	float	zm_maxhopspeed			= 28;
+server	float	zm_walkspeed			= 0.7;
+server	float	zm_crouchspeed			= 0.7;
+server 	float	zm_strafemodifier		= 1.0;
+server	bool	zm_dropprevention		= false;
+
+////////////////
+//Jumping
+server 	float 	zm_jumpheight			= 5.5;
+server	float	zm_setgravity			= 0.56;
+server 	float 	pk_bhopjumpheight		= 0.85;
+server 	bool 	zm_autojump 			= true;
+
+//Double Jump
+server 	int 	zm_doublejump 			= 0;
+server 	float 	zm_doublejumpheight 	= 1.2;
+server 	bool 	zm_wjdoublejumprenew	= false;
+
+//Ramp Jump
+server 	bool 	zm_rampjump				= false;
+server 	float 	zm_rjumpmulti			= 1.0;
+
+//Elevator Jump
+server 	bool 	zm_elevatorjump			= false;
+server 	float 	zm_ejumpmultiplier		= 1.0;
+
+//Jump Landing
+server  bool 	zm_landing				= false;
+server	float	zm_landingsens			= 6.0;
+server	float	zm_landingspeed			= 0.25;
+server	float	zm_minlanding			= 0.5;
+
+////////////////
+
+//Dashing - WallJumping - WallSliding
+server	bool	zm_dash					= false;
+user	bool	zm_doubletap			= true;		
+user	int		zm_maxtaptime			= 10;
+server	float	zm_dashboost			= 1.5;
+server	float	zm_dashheight			= 0.75;
+
+server	bool	zm_airdash				= false;
+server	float	zm_adashboost			= 10;
+server	float	zm_adashfriction		= 1;
+
+server	bool	zm_wjump				= false;
+server	float	zm_wjumpboost			= 1.5;
+server	float	zm_multipledashes		= 0.0;
+server	float	zm_wjumpheight			= 0.75;
+
+server	bool	zm_wslide				= false;
+server	float	zm_wslidevelz			= 0.9;
+
+//CrouchSliding
+server	bool	zm_crouchslide			= false;
+server 	int 	zm_cslidetype			= 0;
+server 	float 	zm_cslidestrength		= 1.5;
+server 	int 	zm_cslideduration		= 13;
+server 	float 	zm_qslideaccel			= 6.0;
+server 	int 	zm_qslideduration		= 8;
+
+//Ledge Grabbing
+server	bool	zm_ledgegrab			= false;
+
+//Grappling Hook
+server	int		zm_hook					= 0;
+server 	float 	zm_hookboost			= 1.5;
+
+////////////////
+//Bobbing
+
+user	bool	zm_stillbob				= false;
+user	int		zm_fullbobspeed			= 8;
+
+//Sway
+user	bool	zm_yawsway				= true;
+user 	float	zm_yawswayspeed			= 2;
+user 	float	zm_yawswayrange			= 2;
+user 	float	zm_yawswayfriction		= 10;
+user	bool	zm_yawswaydirection		= false;
+
+//Y Offset
+user 	int		zm_offsetspeed			= 75;
+user 	int		zm_offsetmaxrange		= 30;
+user 	bool	zm_offsetdirection		= false;
+
+////////////////
+//Other
+server	int		zm_speedometer			= 0;
+
+/////////////////////////////////
+//Dusk
+server 	float	dsk_acceleration		= 1.5;
+
+/////////////////////////////////
+//Painkiller
+server 	float	pk_acceleration			= 1.0;
+
+/////////////////////////////////
+//Build Engine
+server	float	be_jumpanim				= 6.0;
+
+/////////////////////////////////
+// Quake
+server	int		q_strafetype			= 0;
+server	float	q_3airaccel				= 0.75;
+server	float	q_1airaccel				= 1.5;
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////**Spawner CVARS**///////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+// General Spawn CVars
+server	bool	pb_spawner_tiered	= false;
+
+//Shotgun Spawn
+server	int		pb_spawner_autoshotgun			= 0;
+server	int		pb_spawner_shotgunupgrade			= 0;
+server	int		pb_spawner_drum		= 0;
+
+
+
+
+
+
+
+
+/////////////////////////////////
+//PBVP Model Toggle
+
+Server	Bool	V5_MODELS			= false;
+Server	Bool	V5_Cull				= false;
+Server	Int		V5_MDist			= 900;
+
+////////////////////////////////
+
+user bool pb_weapon_crosshairs = false;

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -72,6 +72,17 @@ OptionValue "BrutalBlood"
 	666, "Overdrawn at Blood Bank"
 }
 
+OptionValue "ImpReplacer"
+{
+	0, "Zero"
+	64, "25%"
+	128, "50%"
+	192, "75%"
+	256, "100%"
+	
+}
+
+
 OptionValue "YesOrNo"
 {
 	0, "No"
@@ -664,7 +675,8 @@ OptionMenu "MonsterSpawns"
 	
 	Option "No Dark Variants", "bd_NoDarkImps", "YesOrNo"
 	StaticText " "
-	
+	Option "Replace Imps with Zombies:", "PB_ImpReplacer","ImpReplacer"
+	StaticText " "
 	StaticText "---------------Pinky Demon Variants---------------"
 	StaticText " "
 	Option "No Blood Demons", "bd_NoBloodDemon", "YesOrNo"

--- a/actors/SPAWNERS/MonsterSpawners/ImpSpawner.dec
+++ b/actors/SPAWNERS/MonsterSpawners/ImpSpawner.dec
@@ -4,6 +4,8 @@ Actor ImpSpawner replaces DoomImp
 	States
 	{
 	Spawn:
+		TNT1 A 1
+		TNT1 A 1 A_Jump(GetCvar("PB_ImpReplacer"),"ChainGunSpawn","ShotgunSpawn","ZombieSpawn")
 		TNT1 A 0 NoDelay A_SpawnItemEx("ImpPackSpawner",0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS | 288,0,tid)
 		TNT1 A 1 ACS_NamedExecuteAlways("StarterPackDynamicProgressionFix",0)
 		TNT1 A 1 ACS_NamedExecuteAlways("SpawnerScript",0)
@@ -106,6 +108,18 @@ Actor ImpSpawner replaces DoomImp
 		ReplaceTraditional:
 		TNT1 A 0 A_RadiusGive("IsNormalImp", 386, RGF_GIVESELF | RGF_MONSTERS | RGF_ITEMS | RGF_NOSIGHT, 1)
 		Stop
+	
+	//Imp Replacer
+	ChaingunSpawn:
+		TNT1 A 0 A_SpawnItemEx("ChaingunGuySpawner",0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS | 288,0,tid)
+		stop
+	ShotgunSpawn:
+		TNT1 A 0 A_SpawnItemEx("ShotgunnerSpawner",0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS | 288,0,tid)
+		stop
+	ZombieSpawn:
+		TNT1 A 0 A_SpawnItemEx("ZombieManSpawner",0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS | 288,0,tid)
+		stop
+	
 	}
 }
 


### PR DESCRIPTION
Some maps I feel like I would rather have a zombie instead of an imp, so I wrote this real tiny ditty to do just that.  Option to adjust this is in advanced monster spawns under imps.  WARNING:  Even set at 25% making an imp into a hitscanner makes the game a lot more difficult.

Uses existing spawn actors so spawner script will still function properly.

Someone who knows more than I do please review the cvar file as it shows the whole thing as updated when I only added a single cvar and comment at line 139/140.