### PR TITLE
GZdoom 4.5.0 List Menu Update

### DIFF
--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -815,6 +815,7 @@ OptionValue "HealthPackColor"
 
 ListMenu "MainMenu"
 {
+	Size Clean
 	IfGame(Doom, Chex)
 	{
 		StaticPatch 80, -10, "M_DOOMPB"
@@ -858,6 +859,7 @@ ListMenu "MainMenu"
 
 ListMenu "PlayerclassMenu"
 {
+	Size Clean
 	StaticTextCentered 160, 15, "Select Game Mode"
 	Position 71, 50
 	Selector "M_SKULL1", -30, -8
@@ -865,6 +867,7 @@ ListMenu "PlayerclassMenu"
 
 ListMenu "SkillMenu"
 {
+	Size Clean
 	StaticTextCentered 160, 15, "Select Difficulty"
 	Position 21, 50
 	Selector "M_SKULL1", -30, -8


### PR DESCRIPTION
A real simple one.  ListMenus have sizing issues after GZdoom 4.5.0 because now a size parameter needs to be made for each and every listmenu.  "Size Clean" would be the most universal command for this so I added it to the three listmenus in menudef.

Now the listmenus should looks like they did prior to the new version of GZdoom.