### PR TITLE
Update shotshells

### DIFF
--- a/zscript/Effects/Casings.txt
+++ b/zscript/Effects/Casings.txt
@@ -190,7 +190,8 @@ Class ShotCaseSpawn : RifleCaseSpawn
 	{
 	Spawn:
 	    TNT1 A 0 ;
-		TNT1 A 1 A_SpawnProjectile("ShotgunCasing",0,0,random(-80,-100),CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH,random(40,60));
+		//TNT1 A 1 A_SpawnProjectile("ShotgunCasing",0,0,random(-80,-100),CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH,random(40,60));
+		TNT1 A 1 A_SpawnItemEX("ShotgunCasing",0,0,-7,frandom(3,5),frandom(3,4),frandom(8,11));
 		Stop;
 	}
 } 
@@ -234,7 +235,8 @@ Class ShotCaseSpawn2 : RifleCaseSpawn
 	{
  Spawn:
         TNT1 A 0;
-		TNT1 A 1 A_SpawnProjectile("ShotgunCasing2",0,0,random(-80,-100),CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH,random(40,60));
+		//TNT1 A 1 A_SpawnProjectile("ShotgunCasing2",0,0,random(-80,-100),CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH,random(40,60));
+		TNT1 A 1 A_SpawnItemEX("ShotgunCasing2",0,0,-7,frandom(3,5),frandom(3,4),frandom(8,11));
 		Stop;
  }
 }
@@ -245,7 +247,8 @@ Class ShotCaseSpawn3 : RifleCaseSpawn
 	{
  Spawn:
         TNT1 A 0;
-		TNT1 A 1 A_SpawnProjectile("ShotgunCasing3",0,0,random(-80,-100),CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH,random(40,60));
+		//TNT1 A 1 A_SpawnProjectile("ShotgunCasing3",0,0,random(-80,-100),CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH,random(40,60));
+		TNT1 A 1 A_SpawnItemEX("ShotgunCasing3",0,0,-7,frandom(3,5),frandom(3,4),frandom(8,11));
 		Stop;
  }
 }
@@ -859,10 +862,23 @@ Class ShotgunCasing : Actor
    States
    {
 		Spawn:
-			CAS2 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
+		TNT1 A 1;
+		TNT1 A 0 A_Jump(256,"SpinFast","SpinMedium","SpinSlow");
+		SpinFast:
+				CAS2 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
+				A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
+				A_SetRoll(roll+frandom(-80,-120));
+					}
+		SpinMedium:
+				CAS2 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
+				A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
+				A_SetRoll(roll+frandom(-25,-90));
+					}
+		SpinSlow:
+				CAS2 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
 				A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
 				A_SetRoll(roll+36);
-		}
+					}
 		Goto Death;
 		
 		Death:
@@ -1122,10 +1138,23 @@ Class ShotgunCasing2 : ShotgunCasing
    States
    {
 		Spawn:
-			CAS5 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
+				TNT1 A 0 A_Jump(256,"SpinFast","SpinMedium","SpinSlow");
+		SpinFast:
+				CAS5 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
+				A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
+				A_SetRoll(roll+frandom(-80,-120));
+					}
+		SpinMedium:
+				CAS5 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
+				A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
+				A_SetRoll(roll+frandom(-25,-90));
+					}
+		SpinSlow:
+				CAS5 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
 				A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
 				A_SetRoll(roll+36);
-		}
+					}
+		
 		Goto Death;
 		
 		Death:
@@ -1168,108 +1197,67 @@ Class ShotgunCasing2 : ShotgunCasing
    }
 }
 
-Class ShotgunCasing3 : Actor
+Class ShotgunCasing3 : ShotgunCasing
 {
-		override void BeginPlay(void)
-	{
-		ChangeStatNum(STAT_PB_BULLETS);
-		NashGoreStatics.QueueCasings();
-		Super.BeginPlay();
-	}
-   Default
-   {Height 12;
-   Radius 9;
-   Speed 6;
-   Scale 0.15;
-   +DOOMBOUNCE;
-   - NOGRAVITY;
-   +WINDTHRUST;
-   +CLIENTSIDEONLY;
-   +MOVEWITHSECTOR;
-   +MISSILE;
-   +NOBLOCKMAP;
-   -DROPOFF;
-   +NOTELEPORT;
-   +FORCEXYBILLBOARD;
-   +NOTDMATCH;
-   +GHOST;
-   +ROLLSPRITE;
-   Mass 1;
-   SeeSound "weapons/shell";
-   }
    States
    {
-    Spawn:
-      TNT1 A 0;
-	  
-	  Exist:
-	  TNT1 A 0 A_JumpIfInventory("Zoomed",1,"ShellSpin");
-      TNT1 A 0 A_SetRoll(roll + (20),SPF_INTERPOLATE);
-	  CAS6 G 1;
-	 ShellSpin:
-	  CAS6 G 1 
-	  {
-	  A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
-	  }
-	  TNT1 A 0 A_SetRoll(roll - (10),SPF_INTERPOLATE);
-	  TNT1 A 0 A_JumpIf(waterlevel > 1, "Disappear");
-	  Goto ShellSpin;
-   Death:
-      TNT1 A 0 A_SetRoll(0,SPF_INTERPOLATE);
-	  LCPJ A 0 A_Jump(256,"Rest1","Rest2","Rest3","Rest4","Rest5","Rest6","Rest7","Rest8");
-      Goto Rest1;
-    Rest1:
-	  CAS6 IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII 2 A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
-	  Rest1Dead:
-      CAS6 I 900;
-	  TNT1 A 0 A_JumpIf(ACS_NamedExecuteWithResult("ToggleBulletJanitor")==1,"Disappear");
-      loop;
-    Rest2:
-	  CAS6 JJJJJJJJJJJJJJJJJJJJJJJJJJJ 2 A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
-	  Rest2Dead:
-      CAS6 J 900;
-	  TNT1 A 0 A_JumpIf(ACS_NamedExecuteWithResult("ToggleBulletJanitor")==1,"Disappear");
-      loop;
-    Rest3:
-	  CAS6 KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK 2 A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
-	  Rest3Dead:
-      CAS6 K 900;
-	  TNT1 A 0 A_JumpIf(ACS_NamedExecuteWithResult("ToggleBulletJanitor")==1,"Disappear");
-      loop;
-    Rest4:
-	  CAS6 LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL 2 A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
-	  Rest4Dead:
-      CAS6 L 900;
-	  TNT1 A 0 A_JumpIf(ACS_NamedExecuteWithResult("ToggleBulletJanitor")==1,"Disappear");
-      loop;
-    Rest5:
-	  CAS6 MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM 2 A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
-	  Rest5Dead:
-      CAS6 M 900;
-	 TNT1 A 0 A_JumpIf(ACS_NamedExecuteWithResult("ToggleBulletJanitor")==1,"Disappear");
-      loop;
-    Rest6:
-	  CAS6 IIIIIIIIIIIIIIIIIIIIIIIIIII 2 A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
-	  Rest2Dead:
-      CAS6 I 900;
-	 TNT1 A 0 A_JumpIf(ACS_NamedExecuteWithResult("ToggleBulletJanitor")==1,"Disappear");
-      loop;
-    Rest7:
-	  CAS6 JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ 2 A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
-	  Rest7Dead:
-      CAS6 J 900;
-	 TNT1 A 0 A_JumpIf(ACS_NamedExecuteWithResult("ToggleBulletJanitor")==1,"Disappear");
-      loop;
-    Rest8:
-	  CAS6 KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK 2 A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
-	  Rest8Dead:
-      CAS6 K 900;
-	 TNT1 A 0 A_JumpIf(ACS_NamedExecuteWithResult("ToggleBulletJanitor")==1,"Disappear");
-	  loop;
-	  
-	  Disappear:
-	  TNT1 A 1;
-	  Stop;
+		Spawn:
+				TNT1 A 0 A_Jump(256,"SpinFast","SpinMedium","SpinSlow");
+		SpinFast:
+				CAS6 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
+				A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
+				A_SetRoll(roll+frandom(-80,-120));
+					}
+		SpinMedium:
+				CAS6 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
+				A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
+				A_SetRoll(roll+frandom(-25,-90));
+					}
+		SpinSlow:
+				CAS6 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
+				A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
+				A_SetRoll(roll+36);
+					}
+		
+		Goto Death;
+		
+		Death:
+		  TNT1 I 0 A_SetRoll(0);
+		  TNT1 A 0 A_Jump(256,"Case1","Case2","Case3","Case4","Case5","Case6","Case7","Case8","Case9","Case10");
+		Case1:
+			CAS6 K 1;
+			Goto Rest;
+		Case2:
+			CAS6 L 1;
+			Goto Rest;
+		Case3:
+			CAS6 M 1;
+			Goto Rest;
+		Case4:
+			CAS6 N 1;
+			Goto Rest;
+		Case5:
+			CAS6 O 1;
+			Goto Rest;
+		Case6:
+			CAS6 P 1;
+			Goto Rest;
+		Case7:
+			CAS6 Q 1;
+			Goto Rest;
+		Case8:
+			CAS6 R 1;
+			Goto Rest;
+		Case9:
+			CAS6 S 1;
+			Goto Rest;
+		Case10:
+			CAS6 T 1;
+			Goto Rest;
+		Rest:
+			"####" "###########################################" 2 A_SpawnItemEx("CasingSmoke",frandom(0.3,0.2),random(0,-1.0),0,0,0,frandom(0.5,0.1),0,SXF_CLIENTSIDE,0);
+			"####" "#" -1;
+			Stop;
    }
 }
 


### PR DESCRIPTION
-Changed how shotgun casings eject for the auto and pump shotguns.  They now eject forward quite a bit more.  I recommend trying out the command A_spawnitemex for future casing spawns as I found it to be the most controllable of the bunch.
-Shotgun shell hulls now can spin fast or slow at spawn based on a simple A_Jump added.
-For some reason the actor ShotgunCasing3 was using the old code and not the current stuff (hopefully not because of me).  I went ahead and updated it to match ShotgunCasing and ShotgunCasing2.