### PR TITLE
Hotfix for carbine burst

### DIFF
--- a/actors/Weapons/Slot4/Carbine.dec
+++ b/actors/Weapons/Slot4/Carbine.dec
@@ -743,11 +743,9 @@ ACTOR Carbine : PB_Weapon
 				A_SetAngle(angle-0.12, SPF_INTERPOLATE);
 				}
 			}
-		4A2F C 1 
+		4A2F C 1 A_ZoomFactor(1.5)
+		TNT1 A 0
 		{
-			//A_WeaponReady(WRF_NOPRIMARY);
-			A_ZoomFactor(1.5);
-			
 			if(GetCvar("pb_toggle_aim_hold")) 
 			{
 				if(JustReleased(BT_ALTATTACK))


### PR DESCRIPTION
Added a single TNT1 A 0 to the end of fire2 with all of the fire control code such that it will execute at the end of the third tic instead of the beginning.  Silly issue to be honest.