### PR TITLE
Zscript laser for SMG

### DIFF
--- a/actors/Weapons/Slot2/UACSMG.dec
+++ b/actors/Weapons/Slot2/UACSMG.dec
@@ -79,6 +79,17 @@ Actor LaserDotPerma : LaserDot
 		Loop
 	}
 }
+Actor LaserDotPermaGreen : LaserDot
+{
+	States
+	{
+	Melee:
+	Spawn:
+		LEYS G 2 BRIGHT
+		TNT1 A 0 A_SpawnItemEx("LaserAlertNearbyMonsters",0,0,0,0,0,0,0,288)
+		Loop
+	}
+}
 ACTOR LaserAlertNearbyMonsters : CustomInventory
 {	
 	Radius 600
@@ -137,14 +148,15 @@ ACTOR CompactSMG : PB_Weapon
 		{
 				if (CountInv("LaserSightActivated")==1 && CountInv("KeepLaserDeactivated") != 1)
 				{
-					A_SpawnLaserPuff;
+					A_SpawnLaserPuff(0.1,0.1,"LaserDotPerma");
 				}
 				else 
 				{
 					A_DestroyLaserPuff;
 				}
 		}
-		Loop
+		TNT1 A 0 A_DestroyLaserPuff()
+		Stop
 		
 	Ready:
 		TNT1 A 0
@@ -190,6 +202,7 @@ ACTOR CompactSMG : PB_Weapon
 		TNT1 A 0 A_JumpIfInventory("UACSMGHasUnloaded", 1, "UnloadedReady")
 	ReadyToFire:
 		A1F1 E 1 {
+			A_Overlay(-16,"LaserOverlay");
 			if (PressingFire() && PressingAltfire() && CountInv("SMGAmmo") > 0){
 					return state("Fire");
 			}
@@ -260,8 +273,6 @@ ACTOR CompactSMG : PB_Weapon
 	ReadyToFireDualWield:
 		TNT1 A 1 A_DoPBWeaponAction(WRF_ALLOWRELOAD|WRF_NOFIRE)
 		Loop
-		
-		
 		
 	IdleLeft_Overlay:
 		A2F2 I 1 {
@@ -396,8 +407,6 @@ ACTOR CompactSMG : PB_Weapon
 		}
 		Goto IdleRight_Overlay
 		
-		
-		
 	UnloadedReadyDualWield:
 		A2F3 Z 1 A_DoPBWeaponAction(WRF_ALLOWRELOAD, PBWEAP_UNLOADED)
 		Loop
@@ -414,10 +423,18 @@ ACTOR CompactSMG : PB_Weapon
 			}
 		TNT1 A 0 A_JumpIfInventory("DualWieldingSMGs", 1, "StopDualWield")
 		TNT1 A 0 A_JumpIfInventory("CompactSMG", 2,"SwitchToDualWield")
-		TNT1 A 0 A_Print("You need two submachine guns to dual wield!")
+		TNT1 A 0 
+			{
+				A_PlaySoundEx("LIGHTON", "Auto");
+				if(CountInv("LaserSightActivated")){A_SetInventory("LaserSightActivated",0); A_Log("Laser Deactivated");}
+				else{A_GiveInventory("LaserSightActivated",1); A_Log("Laser Activated");}
+			}
+		TNT1 A 0 A_Log("You need two submachine guns to dual wield!")
 		Goto Ready3
 	SwitchToDualWield:
 		TNT1 A 0 {
+			A_DestroyLaserPuff();
+			A_SetInventory("LaserSightActivated",0);
 			A_GiveInventory("DualWieldingSMGs", 1);
 			A_PlaySoundEx("weapons/smg_up", "Auto");
 			}
@@ -435,6 +452,7 @@ ACTOR CompactSMG : PB_Weapon
 	
 	Deselect:
 		TNT1 A 0 {
+			A_DestroyLaserPuff();
 			A_WeaponOffset(0,32);
 			A_SetRoll(0);
 			PB_HandleCrosshair(44);
@@ -725,6 +743,7 @@ ACTOR CompactSMG : PB_Weapon
 		
 	Reload:
 		TNT1 A 0 {
+			A_DestroyLaserPuff();
 			A_ZoomFactor(1.0);
 			A_Takeinventory("ADSmode",1);
 			A_Takeinventory("Zoomed",1);

--- a/zscript/Weapons/BaseWeapon.zc
+++ b/zscript/Weapons/BaseWeapon.zc
@@ -173,7 +173,7 @@ class PB_WeaponBase : DoomWeapon
 	{
 			if (CountInv("LaserSightActivated")==1 && CountInv("KeepLaserDeactivated") != 1)
 			{
-				invoker.A_SpawnLaserPuff();
+				//invoker.A_SpawnLaserPuff();
 			}
 			else 
 			{
@@ -184,16 +184,24 @@ class PB_WeaponBase : DoomWeapon
 	{
 		if (invoker.laseractor) invoker.laseractor.Destroy();
 	}
-	action Actor A_SpawnLaserPuff()
+	action Actor A_SpawnLaserPuff(Double jitteramountX,Double jitteramountY,String DotColor)
 	{
 		int integer;
-		[invoker.InvActor, invoker.integer] = LineAttack(angle,4096,pitch,0,'None',"InvisiblePuff",LAF_NORANDOMPUFFZ|LAF_NOINTERACT);
+		Double DotJitterX, DotJitterY;
+		Double FinalAngle, FinalPitch;
+		
+		DotJitterX = Frandom(-(jitteramountX),jitteramountX);
+		DotJitterY = Frandom(-(jitteramountY),jitteramountY);
+		FinalAngle = angle + DotJitterX;
+		FinalPitch = Pitch + DotJitterY; 
+		
+		[invoker.InvActor, invoker.integer] = LineAttack(Finalangle,4096,Finalpitch,0,'None',"InvisiblePuff",LAF_NORANDOMPUFFZ|LAF_NOINTERACT);
 		if (invoker.InvActor)
 		{
 			invoker.invactorpos = invoker.InvActor.pos;
 			invoker.InvActor.Destroy();
 		}
-		if (!invoker.laseractor) invoker.laseractor = Spawn("LaserDotPerma",invoker.invactorpos);
+		if (!invoker.laseractor) invoker.laseractor = Spawn(DotColor,invoker.invactorpos);
 		else invoker.laseractor.SetOrigin(invoker.invactorpos, true);
 		
 		return invoker.laseractor;


### PR DESCRIPTION
There is a Zscript laser that looks to be abandoned on the SMG, as there are no calls to it that I can see.  I did the following.

Added arguments for spawning the laser in zscript.  The arguments are for a jitter effect on the Angle and (obviously) are float values, then the pitch (A normal amount of jitter would be 0.1 but you can set to 0.0 for a steady puff).  The third argument is a string value of the puff you would like the laser to produce.  

Made following changes to SMG

-Changed laser overlay to be a single tic and stop instead of a loop.
-Added throughout the actor the destroy puff to make sure the laser puff is destroyed when needed
-the laser can be activated/deactivated by pressing weaponspecial when you have only one SMG.  If you have two you go into the dual wield and the way it is written it will kill off the laser until you have one SMG again.  I would be interested in having two lasers for each SMG, but I have not figured out a way to get the lineattack shifted over without adjusting angle and causing accuracy issues of the laser over distance (pretty much making parallax).

-This zscript function works great on the rocket launcher.  You will need to take every instance of "A_FireBullets(0,0,1,0,"GuidedLaser", FBF_NORANDOMPUFFZ)" and replace with "A_SpawnLaserPuff(0.1,0.1,"GuidedLaser")".  There should be 37 instances.  The only reason why I did not include it is that the puff is getting replaced faster than its persistence, creating a strong flickering effect which may turn off people.  You can try it yourself to see if you like it or not.

