### PR TITLE
Replace deprecated flag INTERHUBSTRIP

### DIFF
--- a/zscript/Decorations/PBKeys.zc
+++ b/zscript/Decorations/PBKeys.zc
@@ -7,7 +7,7 @@ class PB_Key : CustomInventory
 		+NOTDMATCH;
 		+DONTGIB;
 		+FLOORCLIP;
-		+INVENTORY.INTERHUBSTRIP;
+		Inventory.InterHubAmount 0;
 		Inventory.PickupSound "misc/k_pkup";
 		scale 0.3;
 	}


### PR DESCRIPTION
Removes warning in console:
`zscript/decorations/pbkeys.zc, line 10: Deprecated flag 'Inventory.InterHubStrip' used`

Inventory.InterHubAmount _value_
Sets the maximum amount the player can keep of this item when traveling between hubs or non-hub levels. The default value of one replicates the original behavior of Heretic. This property replaces the deprecated INVENTORY.INTERHUBSTRIP.
Source: https://zdoom.org/wiki/Actor_properties#Inventory.InterHubAmount
