### PR TITLE
Zscript Action State for directly spawning shell casings and magazines

### DIFF
--- a/actors/Weapons/Slot4/PBRIFLE.dec
+++ b/actors/Weapons/Slot4/PBRIFLE.dec
@@ -676,7 +676,8 @@ ACTOR Rifle : PB_Weapon
 			A_PlaySoundEx("weapons/rifle", "Weapon");
 			A_FireCustomMissile("YellowFlareSpawn",0,0,0,0);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("RifleCaseSpawn",5,0,8,-9);
+			//A_FireCustomMissile("RifleCaseSpawn",5,0,8,-9);
+			PB_SpawnCasing("EmptyBrass",28,0,30,3,Frandom(5,8),Frandom(1,4));
 			A_Takeinventory("RifleAmmo",1);
 			A_AlertMonsters;
 			A_ZoomFactor(0.98);

--- a/zscript/Effects/Casings.txt
+++ b/zscript/Effects/Casings.txt
@@ -418,10 +418,22 @@ Class EmptyBrass : Actor
 		Spawn:
 			TNT1 A 0;
 			TNT1 A 0 A_Jump(16, "SpawnSmoking");
-			CAS3 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {
-			A_SetRoll(roll+36);
-		}
-		Goto Death;
+			TNT1 A 0 A_Jump(256,"Spawn1","Spawn2","Spawn3");
+		Spawn1:
+			CAS3 ABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGH  1 {
+				A_SetRoll(roll+16);
+			}
+			Goto Death;
+		Spawn2:
+			CAS3 BCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHA  1 {
+				A_SetRoll(roll+32);
+			}
+			Goto Death;
+		Spawn3:
+			CAS3 CDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHAB  1 {
+				A_SetRoll(roll+72);
+			}
+			Goto Death;
 		SpawnSmoking:
 			TNT1 A 0 { smoking = 1;}
 			CAS3 ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ 2 {

--- a/zscript/Weapons/BaseWeapon.zc
+++ b/zscript/Weapons/BaseWeapon.zc
@@ -50,6 +50,15 @@ class PB_WeaponBase : DoomWeapon
             PB_WeaponRecoilBasic(pitchDelta, angleDelta);
 	}
 	
+	//This will allow for direct spawning of shell casings and empty magazines without using an intermediary actor.
+	//I highly recommend making cvars for each of the perameters for location and velocity to edit and test live, and with those numbers transpose into the final code.
+	//upon request I also have code for the tactical lean mod out there.
+	Action State PB_SpawnCasing(String Missile,Double ShellX,Double ShellY,Double ShellZ,Double ShellV_X,Double ShellV_Y,Double ShellV_Z)
+	{
+		A_SpawnItemEX(Missile,cos(pitch)*ShellX,ShellY,((ShellZ)*players[consoleplayer].Crouchfactor)-(sin(pitch)*ShellX),ShellV_X,ShellV_Y,ShellV_Z,0,SXF_ABSOLUTEVELOCITY || SXF_TRANSFERPITCH,0);
+	Return Null;
+	}
+	
 	//Checks if the owner has a berserk
 	bool OwnerHasBerserk()
 	{


### PR DESCRIPTION
UPDATE:  I am so sick of how the casings come out of the rifle I quickly made a change to add a random factor to the initial spawn of the casing, and I placed this new action state into the plain fire state in the rifle.  Hopefully you can see the difference in how much better it looks, while also using less code.

This does not actually do anything in its current state.  You will have to replace lines in decorate of A_FireCustomMissile of the shell casing to PB_SpawnCasing.  All this code does is pass along the numbers and the actor you would like to spawn to a A_Spawnitemex that has pitch and crouch correction calculations built in (essentially why the intermediate actor is used currently).  

The advantages to this code is the intermediate actor is no longer needed, and since using A_FireCustomMissile will send the spawning casing out a distance even at zero tics, you can place the actor to spawn right up on top of the players screen.  Also by having the spawn being direct, quick and precise adjusting of the casing is possible.  I recommend making temporary cvars for the location and velocities to adjust on the fly live, and once you have the right numbers just transpose directly into the weapon actor.