### PR TITLE
Separate out Helmet Animation

### DIFF
--- a/actors/Weapons/BaseWeapon.dec
+++ b/actors/Weapons/BaseWeapon.dec
@@ -37,6 +37,7 @@ States
 		
 	Fire:
 	Ready:
+	SelectAnimation:
 		Goto GoingToReady
 	Deselect:
 		TNT1 A 1 A_Lower

--- a/actors/Weapons/Slot1/Axe.dec
+++ b/actors/Weapons/Slot1/Axe.dec
@@ -37,6 +37,7 @@ ACTOR PB_Axe : PB_Weapon
 	{
 		Ready:
 			TNT1 A 0 A_Giveinventory("HasCutingWeapon",1)
+			TNT1 A 0 PB_RespectIfNeeded
 			AX01 ABCDE 0
 			AX02 ABCDE 0
 			AX03 ABCDE 0

--- a/actors/Weapons/Slot2/REVOLVER.dec
+++ b/actors/Weapons/Slot2/REVOLVER.dec
@@ -60,6 +60,8 @@ ACTOR PB_Revolver  : PB_Weapon
 	PB_WeaponBase.UnloaderToken "RevolverHasUnloaded"
 	//Weapon.SisterWeapon DualMagnums
 	Inventory.AltHUDIcon "RVICA0"
+	PB_WeaponBase.respectItem "RespectRevolver"
+	
 	States
 	{  
 	
@@ -79,7 +81,7 @@ ACTOR PB_Revolver  : PB_Weapon
 		TNT1 A 0
 		TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
 		TNT1 A 0 A_JumpIfInventory("SwitchingFromDualWieldRevolver", 1, "FastSwitchFromDualWield2")
-		TNT1 A 0 A_JumpIfInventory("RespectRevolver", 1, "SelectAnimation")
+		TNT1 A 0 PB_RespectIfNeeded
 	WeaponRespect:
 		TNT1 A 0 {
 			A_Giveinventory("RespectRevolver",1);

--- a/actors/Weapons/Slot4/PBRIFLE.dec
+++ b/actors/Weapons/Slot4/PBRIFLE.dec
@@ -169,6 +169,8 @@ ACTOR Rifle : PB_Weapon
 	Tag "UAC-30 DMR"
 	PB_WeaponBase.UnloaderToken "HasUnloadedDMR"
 	Inventory.AltHUDIcon "RIFLA0"
+	PB_WeaponBase.respectItem "RespectRifle"
+	
 	States
 	{
 	Steady:
@@ -176,32 +178,9 @@ ACTOR Rifle : PB_Weapon
 	Goto Ready
 	
 	Ready:
-		TNT1 A 0
-		TNT1 A 2 A_JumpIf(ACS_NamedExecuteWithResult("ToggleHelmetAnimation",0,0,0)==1,"WeaponRespect")
-		TNT1 A 0 
-		TNT1 A 0 A_JumpIfInventory("IntroductionSequence",1,"WeaponRespect")
-		TNT1 A 0 {
-			A_GiveInventory("sae_extcam", 1);
-			A_GiveInventory("sae_deathcam", 1);
-			A_GiveInventory("IntroductionSequence",1);
-			A_GiveInventory("RifleSelected",1);
-			A_SetCrosshair(5);
-			}
-        TNT1 A 20 A_PlaySoundEx("IronSights","Auto")
-		TNT1 A 1 ACS_NamedExecute("ToggleHelmetAnimation", 0)
-		HLMT ABC 2
-		HLMT DEFGH 3
-		HLMT I 4 A_PlaySoundEx("HLMTPUT","Auto")
-		HLMT JKLMN 2
-		TNT1 A 0 A_PlaySoundEx("HLMTBEP","Auto")
-		HLMT O 3 A_PlaySoundEx("HLMTBPP","Auto")
-		TNT1 A 0 {
-			A_TakeInventory("sae_extcam", 1);
-			A_TakeInventory("sae_deathcam", 1);
-			}
-		HLMT PQRS 2
+		TNT1 A 0 A_GiveInventory("RifleSelected",1)
+		TNT1 A 0 PB_RespectIfNeeded
 	WeaponRespect:
-		TNT1 A 0 A_JumpIfInventory("RespectRifle",1,"SelectAnimation")
 		TNT1 A 0 A_SetCurrentRifleMode("NormalMode")
 		TNT1 A 0 {
 			A_SetCrosshair(5);

--- a/zscript/Weapons/BaseWeapon.zc
+++ b/zscript/Weapons/BaseWeapon.zc
@@ -13,6 +13,9 @@ class PB_WeaponBase : DoomWeapon
 	string lastGrenadeType;
 	property lastGrenadeType: lastGrenadeType;
 	
+	string respectInventoryItem;
+	property respectItem: respectInventoryItem;
+	
 	string rocketLauncherMode;
 	property rocketLauncherMode: rocketLauncherMode;
 	
@@ -356,9 +359,54 @@ class PB_WeaponBase : DoomWeapon
 		SetOrigin((Pos.X, Pos.Y, plr.LedgeHeightMax), True);
 	}
 	
+	action state PB_RespectIfNeeded()
+	{
+		Actor own = invoker.owner;
+		bool shouldHelmet = ACS_NamedExecuteWithResult("ToggleHelmetAnimation",0,0,0) == 0 && own.CountInv("IntroductionSequence") == 0;
+		bool shouldRespect = invoker.respectInventoryItem != "" && own.CountInv(invoker.respectInventoryItem) == 0;
+		
+		if (shouldHelmet)
+		{
+			own.GiveInventory("IntroductionSequence",1);
+			//Console.printf("Setting State: HelmetAnimation");
+			return invoker.resolveState("HelmetAnimation");
+		}
+		else if (shouldRespect)
+		{
+			//Console.printf("Setting State: WeaponRespect");
+			own.GiveInventory(invoker.respectInventoryItem,1);
+			return invoker.resolveState("WeaponRespect");
+		}
+		else
+		{
+			//Console.printf("Setting State: SelectAnimation");
+			return invoker.resolveState("SelectAnimation");
+		}
+	}
 
 	States
 	{
+		HelmetAnimation:
+			TNT1 A 0
+			{
+				A_GiveInventory("sae_extcam", 1);
+				A_GiveInventory("sae_deathcam", 1);
+				A_SetCrosshair(5);
+			}
+			TNT1 A 22 A_PlaySoundEx("IronSights","Auto");
+			HLMT ABC 2;
+			HLMT DEFGH 3;
+			HLMT I 4 A_PlaySoundEx("HLMTPUT","Auto");
+			HLMT JKLMN 2;
+			TNT1 A 0 A_PlaySoundEx("HLMTBEP","Auto");
+			HLMT O 3 A_PlaySoundEx("HLMTBPP","Auto");
+			TNT1 A 0 {
+				A_TakeInventory("sae_extcam", 1);
+				A_TakeInventory("sae_deathcam", 1);
+				}
+			HLMT PQRS 2 A_Raise(9999);
+			Goto SelectAnimation;
+		WeaponRespect:
 		Ready3:
 			TNT1 A 1 A_Jump(255, "Ready3");
 			Loop;	


### PR DESCRIPTION
- Separated out the "put on helmet" animation from the Rifle inspect animation. This should allow the player to start with ANY weapon, as long as the weapon is updated to work with the new function, and they will correctly put on the helmet.
- Added a new function called PB_RespectIfNeeded. This replaces the block in the Ready state (see Rifle for example). Will work with the PB_WeaponBase.RespectItem property to determine which inventory item to check. If it doesn't exist, it respects the weapon when selecting it. This should allow a cleaner implementation and centralises the requirements for weapon respecting. Now weapons only need to define a WeaponRespect state, an item to use for the PB_WeaponBase.RespectItem property, and call PB_RespectIfNeeded, and the function will handle the rest.
- Modified the Axe and Revolver to use this new function, as well as the Rifle. This is to facilitate a followup change allowing the player to choose their starting weapon loadout.