### PR TITLE
Some nice new casing spawning for the Carbine

### DIFF
--- a/actors/Weapons/Slot4/Carbine.dec
+++ b/actors/Weapons/Slot4/Carbine.dec
@@ -614,7 +614,7 @@ ACTOR Carbine : PB_Weapon
 			A_FireCustomMissile("ShakeYourAssMinor", 0, 0, 0, 0);
 			A_FireCustomMissile("YellowFlareSpawn",0,0,0,0);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("RifleCaseSpawn",5,0,8,-9);
+			PB_SpawnCasing("EmptyBrass",32,-2,30,Frandom(4,7),Frandom(6,9),Frandom(0,5));
 			A_Takeinventory("XRifleAmmo",1);
 			A_Giveinventory("CarbineBarrelHeat",10);
 			A_PlaySoundEx("Weapons/Rifle/SFire", "Weapon");
@@ -683,7 +683,7 @@ ACTOR Carbine : PB_Weapon
 			A_FireCustomMissile("ShakeYourAssMinor", 0, 0, 0, 0);
 			A_FireCustomMissile("YellowFlareSpawn",0,0,0,0);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("RifleCaseSpawn",5,0,8,-9);
+			PB_SpawnCasing("EmptyBrass",25,0,32,Frandom(1,3),Frandom(3,6),Frandom(2,4));
 			A_Takeinventory("XRifleAmmo",1);
 			A_Giveinventory("CarbineBarrelHeat",10);
 			A_PlaySoundEx("Weapons/Rifle/SFire", "Weapon");
@@ -753,7 +753,7 @@ ACTOR Carbine : PB_Weapon
 			A_FireCustomMissile("ShakeYourAssMinor", 0, 0, 0, 0);
 			A_FireCustomMissile("YellowFlareSpawn",0,0,0,0);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
-			A_FireCustomMissile("RifleCaseSpawn",5,0,8,-9);
+			PB_SpawnCasing("EmptyBrass",25,0,32,Frandom(1,3),Frandom(3,6),Frandom(2,4));
 			A_Takeinventory("XRifleAmmo",1);
 			A_Giveinventory("CarbineBarrelHeat",10);
 			A_PlaySoundEx("Weapons/Rifle/SFire", "Weapon");


### PR DESCRIPTION
Since the spawn casing code is now in PB here is the carbine Non-Akimbo with the new zscript code.  I did not test this, I did a one for one replacement of three lines and based the coordinates and velocities on my own build (same sprite, same zoom factor).