### PR TITLE
Weapon visual changes

### DIFF
--- a/actors/Player/PLAYER.dec
+++ b/actors/Player/PLAYER.dec
@@ -1040,6 +1040,7 @@ ACTOR Doomer : PlayerPawnBase Replaces DoomPlayer
 	{
     Spawn:
 		MARN A 1 
+		MARN A 0 A_overlay(-50, "spinloop")
 		MARN A 0 A_TakeInventory("PlayerIsDead", 1)
 		MARN A 0 A_TakeInventory("IsInvisible", 1)
 		MARN A 0 A_JumpIfInventory("CheckMarines", 1, "SpawnFriends")

--- a/zscript/PlayerPawn.zc
+++ b/zscript/PlayerPawn.zc
@@ -133,6 +133,11 @@ class PlayerPawnBase : PlayerPawn
 	double	YBob;
 	float	BobTime;
 	
+	//Weapon Rolling
+	const rolldrag = 0.15;
+	const rollvel = 0.20;
+	double currentRoll;
+	
 	///////////////////////////////////
 	//Painkiller only
 	
@@ -2589,6 +2594,26 @@ class PlayerPawnBase : PlayerPawn
 				}
 			}
 		}
+	}
+	//state used for tilting of weapon sprites
+	states
+	{
+		spinloop:
+		TNT1 A 0
+		{
+			if(health>=1)
+			{
+			double velang = atan2(vel.y, vel.x);
+			vector2 dir = (sin(-angle), cos(-angle));
+			vector2 velunit = vel.xy; //.unit()
+			//double delta = absAngle(velang, angle);
+			currentroll += (velunit dot dir) * rollvel;
+			currentroll *= rolldrag;
+			A_OverlayRotate(PSP_WEAPON, currentroll);
+			}
+		}
+		TNT1 A 1;
+		loop;
 	}
 }
 

--- a/zscript/TiltPlus/TiltPlusPlus.zc
+++ b/zscript/TiltPlus/TiltPlusPlus.zc
@@ -277,7 +277,7 @@ class Z_TiltMe : CustomInventory
 
 	override void Tick(void)
 	{
-		if (Owner && Owner is "PlayerPawn" && !Owner.CheckInventory("PB_LockScreenTilt",1))
+		if (Owner && Owner is "PlayerPawn") //&& !Owner.CheckInventory("PB_LockScreenTilt",1)) always do viewroll stuff
 		{
 			Tilt_CalcViewRoll();
 		}

--- a/zscript/Weapons/BaseWeapon.zc
+++ b/zscript/Weapons/BaseWeapon.zc
@@ -321,7 +321,17 @@ class PB_WeaponBase : DoomWeapon
 			A_SetCrosshair(0); // Set crosshair to universal user setting
 		}
 	}
-  
+	
+	//weapons should ALWAYS bob, fucking fight me -popguy
+	override void DoEffect()
+	{
+		super.DoEffect();
+		let player = owner.player;
+		if (player && player.readyweapon)
+		{
+			player.WeaponState |= WF_WEAPONBOBBING;
+		}
+	}
 	
 	action void A_SetOverlaySprite(int layer, String str)
         {


### PR DESCRIPTION
- makes weapons bob all the time, instead of just when ready and during _some_ animations
- makes view roll happen all the time, and stops weapon animations from locking it
- adds a subtle roll to sprites when strafing, tweaked enough to hopefully not cause any clipping at the bottom of sprites