### PR TITLE
Pinky Demon fast speed buff and ASG altfire exploit fixed

### DIFF
--- a/actors/Monsters/T2-Pinkies/DEMONS.dec
+++ b/actors/Monsters/T2-Pinkies/DEMONS.dec
@@ -23,8 +23,8 @@ ACTOR PB_Demon: Demon Replaces Demon
 	Height 56
 	Radius 22
 	Mass 400
-    Speed 9
-    FastSpeed 11 //yes, his fast speed is slower because it would make him sanic fast if it was default.
+    Speed 10
+    FastSpeed 21 //yes, his fast speed is slower because it would make him sanic fast if it was default.
 	SpawnID 1500
 	PainChance "Siphon", 255
 	PainChance "Saw", 200

--- a/actors/Monsters/T2-Pinkies/MeanDemon.dec
+++ b/actors/Monsters/T2-Pinkies/MeanDemon.dec
@@ -2,8 +2,8 @@ Actor PB_MeanDemon : Demon Replaces Demon
 {
 	Health 300
 	PainChance 140
-	Speed 11
-    FastSpeed 13
+	Speed 13
+    FastSpeed 25
 	Radius 30
 	Height 56
 	Mass 650

--- a/actors/Monsters/T2-Pinkies/MeanDemon.dec
+++ b/actors/Monsters/T2-Pinkies/MeanDemon.dec
@@ -28,7 +28,7 @@ Actor PB_MeanDemon : Demon Replaces Demon
 	PainChance "Kick", 256
 	PainChance "ExtremePunches", 256
 	DeathSound "demon/Death"
-	ActiveSound "demon/sg2act"
+	ActiveSound "demon/active"
 	DropItem "DemonStrengthRune" 4
 	DropItem "HasteSphere" 3
 	DropItem "DoubleSphere" 2

--- a/actors/Monsters/T2-Pinkies/MechDemon.dec
+++ b/actors/Monsters/T2-Pinkies/MechDemon.dec
@@ -14,7 +14,7 @@ ACTOR PB_MechDemon: Demon Replaces Demon
 	Radius 22
 	Mass 400
     Speed 12
-    FastSpeed 13 //yes, his fast speed is slower because it would make him sanic fast if it was default. NO IT'S NOT.
+    FastSpeed 25 //yes, his fast speed is slower because it would make him sanic fast if it was default. NO IT'S NOT.
 	SpawnID 1530
 	PainChance "Saw", 200
 	PainChance "Cut", 200

--- a/actors/Monsters/T2-Pinkies/VOIDSPECTRE.dec
+++ b/actors/Monsters/T2-Pinkies/VOIDSPECTRE.dec
@@ -70,7 +70,7 @@ ACTOR PB_VoidSpectre: PB_Demon Replaces Spectre
 	Radius 22
 	Mass 400
 	 Speed 15
-    FastSpeed 17 //yes, his fast speed is slower because it would make him sanic fast if it was default
+    FastSpeed 25 //yes, his fast speed is slower because it would make him sanic fast if it was default
 	SpawnID 1540
     damagefactor "Crush", 10.0
 	damagefactor "Avoid", 0.0

--- a/actors/Weapons/Slot3/AUTOSHOTGUN.dec
+++ b/actors/Weapons/Slot3/AUTOSHOTGUN.dec
@@ -960,6 +960,7 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 					A_GunFlash;
 					PB_WeaponRecoil(-2.04,+1.1);
 				}
+				TNT1 A 0 A_Takeinventory("AutoShotgunAmmo",2)
 				TNT1 AAAAAAAA 0 BRIGHT A_FireCustomMissile("ShotgunParticles", random(-17,17), 0, -1, random(-17,17))
 				AUMD B 1 BRIGHT { 
 					if (CountInv("AutoShotgunAmmo") == 24 ) {A_SetWeaponSprite("AU24");}
@@ -982,14 +983,14 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 				AUMD D 1 {
 					if (CountInv("AutoShotgunAmmo") == 24 ) {A_SetWeaponSprite("AU24");}
 					if (CountInv("AutoShotgunAmmo") == 1 )  {A_SetWeaponSprite("AU01");}
-					Return A_DoPBWeaponAction(WRF_NOPRIMARY, WRF_NOSECONDARY, WRF_NOBOB);
+					Return A_DoPBWeaponAction(WRF_NOFIRE|WRF_NOBOB);
 					}
 				AUMD EF 1 {
 					if (CountInv("AutoShotgunAmmo") == 24 ) {A_SetWeaponSprite("AF24");}
 					if (CountInv("AutoShotgunAmmo") == 23 ) {A_SetWeaponSprite("AF23");}
 					if (CountInv("AutoShotgunAmmo") == 2 )  {A_SetWeaponSprite("AF02");}
 					if (CountInv("AutoShotgunAmmo") == 1 )  {A_SetWeaponSprite("AF01");}
-					Return A_DoPBWeaponAction(WRF_NOPRIMARY, WRF_NOSECONDARY, WRF_NOBOB);
+					Return A_DoPBWeaponAction(WRF_NOFIRE|WRF_NOBOB);
 					}
 				AUMD G 1 {
 					if (CountInv("AutoShotgunAmmo") == 24 ) {A_SetWeaponSprite("AF24");}
@@ -998,7 +999,7 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 					if (CountInv("AutoShotgunAmmo") == 3 )  {A_SetWeaponSprite("AF03");}
 					if (CountInv("AutoShotgunAmmo") == 2 )  {A_SetWeaponSprite("AF02");}
 					if (CountInv("AutoShotgunAmmo") == 1 )  {A_SetWeaponSprite("AF01");}
-					Return A_DoPBWeaponAction(WRF_NOPRIMARY, WRF_NOSECONDARY, WRF_NOBOB);
+					Return A_DoPBWeaponAction(WRF_NOFIRE|WRF_NOBOB);
 					}
 				AUMD H 1 {
 					if (CountInv("AutoShotgunAmmo") == 24 ) {A_SetWeaponSprite("AF24");}
@@ -1006,7 +1007,7 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 					if (CountInv("AutoShotgunAmmo") == 3 )  {A_SetWeaponSprite("AF03");}
 					if (CountInv("AutoShotgunAmmo") == 2 )  {A_SetWeaponSprite("AF02");}
 					if (CountInv("AutoShotgunAmmo") == 1 )  {A_SetWeaponSprite("AF01");}
-					Return A_DoPBWeaponAction(WRF_NOPRIMARY, WRF_NOSECONDARY, WRF_NOBOB);
+					Return A_DoPBWeaponAction(WRF_NOFIRE|WRF_NOBOB);
 					}
 				AUMD I 1 {
 					if (CountInv("AutoShotgunAmmo") == 24 ) {A_SetWeaponSprite("AF24");}
@@ -1014,9 +1015,8 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 					if (CountInv("AutoShotgunAmmo") == 3 )  {A_SetWeaponSprite("AF03");}
 					if (CountInv("AutoShotgunAmmo") == 2 )  {A_SetWeaponSprite("AF02");}
 					if (CountInv("AutoShotgunAmmo") == 1 )  {A_SetWeaponSprite("AF01");}
-					Return A_DoPBWeaponAction(WRF_NOPRIMARY, WRF_NOSECONDARY, WRF_NOBOB);
+					Return A_DoPBWeaponAction(WRF_NOFIRE|WRF_NOBOB);
 					}
-				TNT1 A 0 A_Takeinventory("AutoShotgunAmmo",1)
 				AUMD G 1 {
 					if (CountInv("AutoShotgunAmmo") == 24 ) {A_SetWeaponSprite("AF24");}
 					if (CountInv("AutoShotgunAmmo") == 23 ) {A_SetWeaponSprite("AF23");}
@@ -1024,7 +1024,7 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 					if (CountInv("AutoShotgunAmmo") == 3 )  {A_SetWeaponSprite("AF03");}
 					if (CountInv("AutoShotgunAmmo") == 2 )  {A_SetWeaponSprite("AF02");}
 					if (CountInv("AutoShotgunAmmo") == 1 )  {A_SetWeaponSprite("AF01");}
-					Return A_DoPBWeaponAction(WRF_NOPRIMARY, WRF_NOSECONDARY, WRF_NOBOB);
+					Return A_DoPBWeaponAction(WRF_NOFIRE|WRF_NOBOB);
 					}
 				AUMD H 1 {
 					if (CountInv("AutoShotgunAmmo") == 24 ) {A_SetWeaponSprite("AF24");}
@@ -1032,7 +1032,7 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 					if (CountInv("AutoShotgunAmmo") == 3 )  {A_SetWeaponSprite("AF03");}
 					if (CountInv("AutoShotgunAmmo") == 2 )  {A_SetWeaponSprite("AF02");}
 					if (CountInv("AutoShotgunAmmo") == 1 )  {A_SetWeaponSprite("AF01");}
-					Return A_DoPBWeaponAction(WRF_NOPRIMARY, WRF_NOSECONDARY, WRF_NOBOB);
+					Return A_DoPBWeaponAction(WRF_NOFIRE|WRF_NOBOB);
 					}
 				AUMD I 1 {
 					if (CountInv("AutoShotgunAmmo") == 24 ) {A_SetWeaponSprite("AF24");}
@@ -1040,9 +1040,8 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 					if (CountInv("AutoShotgunAmmo") == 3 )  {A_SetWeaponSprite("AF03");}
 					if (CountInv("AutoShotgunAmmo") == 2 )  {A_SetWeaponSprite("AF02");}
 					if (CountInv("AutoShotgunAmmo") == 1 )  {A_SetWeaponSprite("AF01");}
-					Return A_DoPBWeaponAction(WRF_NOPRIMARY, WRF_NOSECONDARY, WRF_NOBOB);
+					Return A_DoPBWeaponAction(WRF_NOFIRE|WRF_NOBOB);
 					}
-				TNT1 A 0 A_Takeinventory("AutoShotgunAmmo",1)	
 				TNT1 A 0 A_JumpIfInventory("AutoShotgunAmmo",1,"Pump")
 				Goto Ready3
 		


### PR DESCRIPTION
Pinky Demons and Spectres fast speed increased to more respectable to Vanilla Doom Nightmare fast speed
Fixed an exploit with the upgraded ASG Altfire which spamming the right mouse button doesn't deplete the ASG ammo.