### PR TITLE
Fixed MG42 crosshair minor bug

### DIFF
--- a/actors/Weapons/Slot4/MG42.dec
+++ b/actors/Weapons/Slot4/MG42.dec
@@ -257,7 +257,7 @@ ACTOR PB_MG42 : PB_Weapon
 		A_Overlay(5, "BeltUnzoomFlash");
 		A_ZoomFactor(1);
 		A_PlaySound("MG42HEAT");
-		PB_HandleCrosshair(75);
+		PB_HandleCrosshair(50);
 		}
 		MRGZ DCB 1
 		Goto Overheat+1
@@ -268,7 +268,7 @@ ACTOR PB_MG42 : PB_Weapon
 		A_PlaySoundEx("IronSights", "Auto");
 		A_Overlay(5, "BeltUnzoomFlash");
 		A_ZoomFactor(1);
-		PB_HandleCrosshair(75);
+		PB_HandleCrosshair(50);
 		}
 	MRGZ DCB 1
 	Goto BarrelChange+2
@@ -429,7 +429,7 @@ ACTOR PB_MG42 : PB_Weapon
 		A_PlaySoundEx("IronSights", "Auto");
 		A_Overlay(5, "BeltUnzoomFlash");
 		A_ZoomFactor(1);
-		PB_HandleCrosshair(75);
+		PB_HandleCrosshair(50);
 		}
 		MRGZ DCB 1
 		Goto Ready3


### PR DESCRIPTION
Fixed crosshair issue with MG42, should now go back to the proper crosshair when unzooming.