### PR TITLE
Fixed idiotic LMG truncation warning

### DIFF
--- a/actors/Weapons/Slot4/LMG.dec
+++ b/actors/Weapons/Slot4/LMG.dec
@@ -118,7 +118,7 @@ ACTOR MicroMissileProjectile
 			A_SpawnItemEx ("RocketExplosion",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);
 			A_StopSound(CHAN_BODY);
 			A_StartSound("FAREXPL", CHAN_AUTO,CHANF_OVERLAP,0.5,0,1.1);
-			Radius_Quake (1.5, 4, 0, 7, 0);
+			Radius_Quake (2, 4, 0, 7, 0);
 			A_CustomMissile("BigRicoChet");
 			A_SpawnItem ("BigRicoChet", 0, -30);
 			A_SpawnItemEx ("DetectFloorCrater",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);


### PR DESCRIPTION
Fixed a dumb truncation warning on the Radius_Quake, since apparently it only takes integer values.