### PR TITLE
Update PBRIFLE.dec

### DIFF
--- a/actors/Weapons/Slot4/PBRIFLE.dec
+++ b/actors/Weapons/Slot4/PBRIFLE.dec
@@ -798,14 +798,10 @@ ACTOR Rifle : PB_Weapon
 		H0F1 ABCDE 0
 		R0F8 A 1 BRIGHT {
 			
-			if (CountInv("DMRUpgraded") == 1) {
-				A_Overlay(-40, "MuzzleFlashHandler");
-				A_SetWeaponSprite("H0F1");
-				}
-			else{
-				A_Overlay(-40, "MuzzleFlashHandler");
-				}
-		
+			A_Overlay(-40, "MuzzleFlashHandler");
+			
+			if (CountInv("DMRUpgraded") == 1) {A_SetWeaponSprite("H0F1");}
+
 			if(GetCvar("PB_alttracer") >=1)
 				{
 				 A_RailAttack(0, 0, 0, none,none, RGF_SILENT|RGF_NOPIERCING|RGF_EXPLICITANGLE, 0, none,0.1,0.1,700,0,1,1.0,"Tracer_Trail",-6,0,0);


### PR DESCRIPTION
Very fast Code update for JMartinez.  In reference to the alternate tracer code starting on line 805, I see nothing wrong with it.  There is a railattack that is called when the CVAR is turned on, and the bullet is fired with no tracer actor called.  When the CVAR is off you get the normal bullet/tracer.