### PR TITLE
framework reduction

### DIFF
--- a/CVARINFO
+++ b/CVARINFO
@@ -532,6 +532,7 @@ Server	Bool	V5_Quake3			=false;
 server 	float	V5_Q3Spin			=5.0;
 server 	float	V5_Q3Zoff			=16.0;
 server 	float	V5_Q3Bob			=0.5;
+server	noarchive	bool	V5_Mlock	=False;
 
 ////////////////////////////////
 

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -450,26 +450,37 @@ OptionMenu "PBVPOptions"
 	StaticText " "
 	StaticText "Models will only render in when inside the set culling distance"
 	StaticText " "
-	Option "[Q3A]Quake 3 Style Animations(WIP)",			"V5_Quake3",	"OnOff"
+	Option "[QSA]Quake 3 Style Animations(WIP)",			"V5_Quake3",	"OnOff"
 	StaticText " "
 	StaticText "Makes Weapons, Keys, and small pickups float and spin a la Quake 3"
 	StaticText " "
-	StaticText "----------Q3A Settings---------"
-	StaticText "Mess with at your own risk ;D"
+	StaticText "----------QSA Settings---------"
 	StaticText " "
-	TextField "Spin speed (default 5)", "V5_Q3Spin" , "V5_Quake3"
+	Option "Spin", "V5_Q3Spin" , "Q3SpinSpeed" ,"V5_Quake3"
 	StaticText " "
-	StaticText "Degrees per frame, can be negative, 0 disables spin"
+	Option "Floating", "V5_Q3Zoff" ,"Q3floating","V5_Quake3"
 	StaticText " "
-	TextField "bob strength (default 0.5)", "V5_Q3Bob" , "V5_Quake3"
+	Option "Bobbing", "V5_Q3Bob" , "Q3Bobbing","V5_Q3Zoff"
 	StaticText " "
-	StaticText "Strength of bob, higher value = larger sine wave peaks, 0 disables bobbing"
-	StaticText " "
-	TextField "float height (default 16)", "V5_Q3Zoff" , "V5_Quake3"
-	StaticText " "
-	StaticText "float hieght relative to ground, can be negative, but not recommended, 0 is on ground"
-	StaticText "if items disappear, make sure this is not set too high or low"
-	StaticText " "
+}
+OptionValue "Q3SpinSpeed"
+{
+	-5,"Reverse"
+	0,	"No spin"
+	5, "Normal"
+}
+
+OptionValue "Q3Bobbing"
+{
+	0,	"Off"
+	0.5, "Quake (Half)"
+	1, "Full Bob"
+}
+
+OptionValue "Q3Floating"
+{
+	0,	"Off"
+	16, "On"
 }
 
 //Motion Blur Options by Pixel Eater

--- a/zscript/PBVP/PBVP.zc
+++ b/zscript/PBVP/PBVP.zc
@@ -1,123 +1,171 @@
 Extend class PB_WeaponBase
 {
+	int spincycle;
 	action void A_PbvpFramework(String str)
 	{
-			if ( GetCvar( "V5_MODELS" ) == 1 ){
-				If ( GetCVar( "V5_Cull" ) == 0 ) {
-					A_SetSpawnSprite(str);
-					If ( GetCvar( "V5_Quake3" ) == 1 ){
-						A_settics(1); 
-						bFLOATBOB = true;
-						FloatBobStrength = V5_Q3Bob;
-						A_setangle(normalize180(angle) + V5_Q3Spin,SPF_INTERPOLATE); 
-						SetZ(floorz + V5_Q3Zoff); 
-						A_ScaleVelocity( 0.95 );
-					}
-					else{
-						bFLOATBOB=false;
-						A_setangle(angle,SPF_INTERPOLATE);
-					}
+		if ( GetCvar( "V5_MODELS" ) == 1 ){
+			If ( GetCVar( "V5_Cull" ) == 0 || !CHECKRANGE( V5_MDist , TRUE) ) {
+				A_SetSpawnSprite(str);
+				If ( GetCvar( "V5_Quake3" ) == 1 ){
+					invoker.spincycle = V5_Q3Spin ? invoker.spincycle + 1 : 0;
+					A_settics(1); 
+					bFLOATBOB = V5_Q3Zoff ? true : false;
+					FloatBobStrength = V5_Q3Bob;
+					A_setangle(normalize180(angle) + V5_Q3Spin,SPF_INTERPOLATE); 
+					SetZ(floorz + V5_Q3Zoff); 
+					A_ScaleVelocity( V5_Q3Zoff ? 0.95 : 1 );
+					return;
 				}
-				else {
-					if( !A_CHECKRANGE( V5_MDist , "NULL", TRUE) ) {
-						A_SetSpawnSprite(str);
-						If ( GetCvar( "V5_Quake3" ) == 1 ){
-							A_settics(1); 
-							bFLOATBOB = true; 
-							FloatBobStrength = V5_Q3Bob; 
-							A_setangle(normalize180(angle) + V5_Q3Spin,SPF_INTERPOLATE); 
-							SetZ(floorz + V5_Q3Zoff); 
-							A_ScaleVelocity( 0.95 );
-						}
-						else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
-					}
-					else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
-				}
+				return;
 			}
-			else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+			return;
+		}
+		else{
+			bFLOATBOB=false;
+			A_setangle( V5_Mlock ? angle - ( invoker.spincycle * V5_Q3Spin ) : angle,SPF_INTERPOLATE);
+			invoker.spincycle = 0;
+			return;
+		}
+		return;
 	}
 	action void A_PbvpInterpolate()
 	{
 		If ( GetCVar( "V5_MODELS" ) == 1 && GetCvar( "V5_Quake3" ) == 1 ){
-			If ( GetCVar( "V5_Cull" ) == 0 ) {SetZ(floorz + V5_Q3Zoff); A_ScaleVelocity( 0.95 );}
-			else{
-				if( A_CHECKRANGE( V5_MDist , "NULL", TRUE) ) {bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+			If ( GetCVar( "V5_Cull" ) == 0 ) {
+				SetZ(floorz + V5_Q3Zoff);  
+				A_ScaleVelocity( V5_Q3Zoff ? 0.95 : 1 );
+				return;
 			}
+			else if( CHECKRANGE( V5_MDist , TRUE) ) {
+				bFLOATBOB=false;
+				A_setangle( V5_Mlock ? angle - ( invoker.spincycle * V5_Q3Spin ) : angle,SPF_INTERPOLATE);
+				invoker.spincycle = 0;
+				return;
+			}
+			return;
 		}
-		else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+		else{
+			bFLOATBOB=false;
+			A_setangle( V5_Mlock ? angle - ( invoker.spincycle * V5_Q3Spin ) : angle,SPF_INTERPOLATE);
+			invoker.spincycle = 0;
+			return;
+		}
+		return;
+	}	
+	States
+	{
+		PBVP:
+			VAX0 ABCDEFGHIJKLMNOPQR 0; VAX1 ABCDEFGHIJKLMNOPQR 0; VAX2 ABCDEFGHIJKLMNOPQR 0; VAX3 ABCDEFGHIJKLMNOPQR 0;
+			VSAW A 0; VEGT A 0; VVIC A 0; V4E0 Z 0; VTFL A 0; VMP4 A 0; VHTC A 0; VSMU A 0; VGN2 A 0; VQSG A 0; VUSC A 0; V9SC A 0; VIFL A 0;
+			VB00 Z 0; VLMP A 0; VBUS D 0; VNGN F 0; VG0Z A 0; VGUN A 0; VRKT Z 0; VSGL Z 0; VDUN A 0; VLAS A 0; VPLC A 0; V2PR AB 0;
+			VRCG A 0; VFRP A 0; VBGP A 0; VCAN A 0; VPRD Z 0; VRDA X 0; VRPU A 0; VNHD A 0; VBKY ABC 0; VRKY ABC 0; VYKY ABC 0; VHFL A 0;
+		Loop;
 	}
 }
 
 Extend class PB_UpgradeItem
 {
+	int spincycle;
 	action void A_PbvpFramework(String str)
 	{
-			if ( GetCvar( "V5_MODELS" ) == 1 ){
-				If ( GetCVar( "V5_Cull" ) == 0 ) {
-					A_SetSpawnSprite(str);
-					If ( GetCvar( "V5_Quake3" ) == 1 ){
-						A_settics(1); bFLOATBOB = true; FloatBobStrength = V5_Q3Bob; A_setangle(normalize180(angle) + V5_Q3Spin,SPF_INTERPOLATE); SetZ(floorz + V5_Q3Zoff); A_ScaleVelocity( 0.95 );
-					}
-					else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
-				}
-				else {
-					if( !A_CHECKRANGE( V5_MDist , "NULL", TRUE) ) {
-						A_SetSpawnSprite(str);
-						If ( GetCvar( "V5_Quake3" ) == 1 ){
-							A_settics(1); bFLOATBOB = true; FloatBobStrength = V5_Q3Bob; A_setangle(normalize180(angle) + V5_Q3Spin,SPF_INTERPOLATE); SetZ(floorz + V5_Q3Zoff); A_ScaleVelocity( 0.95 );
-						}
-						else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
-					}
-					else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+		if ( GetCvar( "V5_MODELS" ) == 1 ){
+			If ( GetCVar( "V5_Cull" ) == 0 || !CHECKRANGE( V5_MDist , TRUE) ) {
+				A_SetSpawnSprite(str);
+				If ( GetCvar( "V5_Quake3" ) == 1 ){
+					invoker.spincycle = V5_Q3Spin ? invoker.spincycle + 1 : 0;
+					A_settics(1); 
+					bFLOATBOB = V5_Q3Zoff ? true : false;
+					FloatBobStrength = V5_Q3Bob;
+					A_setangle(normalize180(angle) + V5_Q3Spin,SPF_INTERPOLATE); 
+					SetZ(floorz + V5_Q3Zoff); 
+					A_ScaleVelocity( V5_Q3Zoff ? 0.95 : 1 );
 				}
 			}
-			else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+		}
+		else{
+			bFLOATBOB=false;
+			A_setangle( V5_Mlock ? angle - ( invoker.spincycle * V5_Q3Spin ) : angle,SPF_INTERPOLATE);
+			invoker.spincycle = 0;
+		}
 	}
 	action void A_PbvpInterpolate()
 	{
 		If ( GetCVar( "V5_MODELS" ) == 1 && GetCvar( "V5_Quake3" ) == 1 ){
-			If ( GetCVar( "V5_Cull" ) == 0 ) {SetZ(floorz + V5_Q3Zoff); A_ScaleVelocity( 0.95 );}
-			else{
-				if( A_CHECKRANGE( V5_MDist , "NULL", TRUE) ) {bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+			If ( GetCVar( "V5_Cull" ) == 0 ) {
+				SetZ(floorz + V5_Q3Zoff);  
+				A_ScaleVelocity( V5_Q3Zoff ? 0.95 : 1 );
+			}
+			else if( CHECKRANGE( V5_MDist , TRUE) ) {
+				bFLOATBOB=false;
+				A_setangle( V5_Mlock ? angle - ( invoker.spincycle * V5_Q3Spin ) : angle,SPF_INTERPOLATE);
+				invoker.spincycle = 0;
 			}
 		}
-		else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+		else{
+			bFLOATBOB=false;
+			A_setangle( V5_Mlock ? angle - ( invoker.spincycle * V5_Q3Spin ) : angle,SPF_INTERPOLATE);
+			invoker.spincycle = 0;
+		}
+	}	
+	States
+	{
+		PBVP:
+			VAX0 ABCDEFGHIJKLMNOPQR 0; VAX1 ABCDEFGHIJKLMNOPQR 0; VAX2 ABCDEFGHIJKLMNOPQR 0; VAX3 ABCDEFGHIJKLMNOPQR 0;
+			VSAW A 0; VEGT A 0; VVIC A 0; V4E0 Z 0; VTFL A 0; VMP4 A 0; VHTC A 0; VSMU A 0; VGN2 A 0; VQSG A 0; VUSC A 0; V9SC A 0; VIFL A 0;
+			VB00 Z 0; VLMP A 0; VBUS D 0; VNGN F 0; VG0Z A 0; VGUN A 0; VRKT Z 0; VSGL Z 0; VDUN A 0; VLAS A 0; VPLC A 0; V2PR AB 0;
+			VRCG A 0; VFRP A 0; VBGP A 0; VCAN A 0; VPRD Z 0; VRDA X 0; VRPU A 0; VNHD A 0; VBKY ABC 0; VRKY ABC 0; VYKY ABC 0; VHFL A 0;
+		Loop;
 	}
 }
 
 Extend class PB_Key
 {
+	int spincycle;
 	action void A_PbvpFramework(String str)
 	{
-			if ( GetCvar( "V5_MODELS" ) == 1 ){
-				If ( GetCVar( "V5_Cull" ) == 0 ) {
-					A_SetSpawnSprite(str);
-					If ( GetCvar( "V5_Quake3" ) == 1 ){
-						A_settics(1); bFLOATBOB = true; FloatBobStrength = V5_Q3Bob; A_setangle(normalize180(angle) + V5_Q3Spin,SPF_INTERPOLATE); SetZ(floorz + V5_Q3Zoff); A_ScaleVelocity( 0.95 );
-					}
-					else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
-				}
-				else {
-					if( !A_CHECKRANGE( V5_MDist , "NULL", TRUE) ) {
-						A_SetSpawnSprite(str);
-						If ( GetCvar( "V5_Quake3" ) == 1 ){
-							A_settics(1); bFLOATBOB = true; FloatBobStrength = V5_Q3Bob; A_setangle(normalize180(angle) + V5_Q3Spin,SPF_INTERPOLATE); SetZ(floorz + V5_Q3Zoff); A_ScaleVelocity( 0.95 );
-						}
-						else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
-					}
-					else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+		if ( GetCvar( "V5_MODELS" ) == 1 ){
+			If ( GetCVar( "V5_Cull" ) == 0 || !CHECKRANGE( V5_MDist , TRUE) ) {
+				A_SetSpawnSprite(str);
+				If ( GetCvar( "V5_Quake3" ) == 1 ){
+					invoker.spincycle = V5_Q3Spin ? invoker.spincycle + 1 : 0;
+					A_settics(1); 
+					bFLOATBOB = V5_Q3Zoff ? true : false;
+					FloatBobStrength = V5_Q3Bob;
+					A_setangle(normalize180(angle) + V5_Q3Spin,SPF_INTERPOLATE); 
+					SetZ(floorz + V5_Q3Zoff); 
+					A_ScaleVelocity( V5_Q3Zoff ? 0.95 : 1 );
 				}
 			}
-			else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+		}
+		else{
+			bFLOATBOB=false;
+			A_setangle( V5_Mlock ? angle - ( invoker.spincycle * V5_Q3Spin ) : angle,SPF_INTERPOLATE);
+			invoker.spincycle = 0;
+		}
 	}
 	action void A_PbvpInterpolate()
 	{
 		If ( GetCVar( "V5_MODELS" ) == 1 && GetCvar( "V5_Quake3" ) == 1 ){
-			If ( GetCVar( "V5_Cull" ) == 0 ) {SetZ(floorz + V5_Q3Zoff); A_ScaleVelocity( 0.95 );}
-			else{
-				if( A_CHECKRANGE( V5_MDist , "NULL", TRUE) ) {bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+			If ( GetCVar( "V5_Cull" ) == 0 ) {
+				SetZ(floorz + V5_Q3Zoff);  
+				A_ScaleVelocity( V5_Q3Zoff ? 0.95 : 1 );
+			}
+			else if( CHECKRANGE( V5_MDist , TRUE) ) {
+				bFLOATBOB=false;
+				A_setangle( V5_Mlock ? angle - ( invoker.spincycle * V5_Q3Spin ) : angle,SPF_INTERPOLATE);
+				invoker.spincycle = 0;
 			}
 		}
-		else{bFLOATBOB=false;A_setangle(angle,SPF_INTERPOLATE);}
+		else{
+			bFLOATBOB=false;
+			A_setangle( V5_Mlock ? angle - ( invoker.spincycle * V5_Q3Spin ) : angle,SPF_INTERPOLATE);
+			invoker.spincycle = 0;
+		}
+	}	
+	States
+	{
+		PBVP:
+			VBKY ABC 0; VRKY ABC 0; VYKY ABC 0;
+		Loop;
 	}
 }


### PR DESCRIPTION
revised framework code with built-in cache list and angle reset code. angle reset is off by default, does not archive, and is meant for map making. I would like to figure out how to make items placed by mappers not be affected by QSA. I feel this could be useful for the campaign especially.
Q3A has been renamed to QSA(quake style animation)
less destructive QSA customization settings