### PR TITLE
Barrel tweaks and fixes

### DIFF
--- a/actors/Decorations/Barrels/BarrelEffects.dec
+++ b/actors/Decorations/Barrels/BarrelEffects.dec
@@ -479,6 +479,7 @@ ACTOR BarrelBlast
 	Spawn:
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		BBLA AAABC 2 BRIGHT
+	JustExplode:
 		TNT1 A 0 A_Stop
 		TNT1 A 0 A_AlertMonsters
 		TNT1 A 0 A_Scream
@@ -507,6 +508,15 @@ ACTOR BarrelBlast
 		BEXP DEFGHIJKLMNOPQR 2 BRIGHT 
 		Stop
 	}
+}
+
+Actor BarrelBlastThrown : BarrelBlast {
+	States
+	{
+	Spawn:
+		TNT1 A 1 A_Changeflag ("Shootable", false)
+		GOTO JUSTEXPLODE
+		}
 }
 
 ACTOR IceBarrelBlast
@@ -554,6 +564,7 @@ ACTOR IceBarrelBlast
 	Spawn:
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		BBLA DDDEF 2 BRIGHT
+	JustExplode:
 		TNT1 A 0 A_Stop
 		TNT1 A 0 A_AlertMonsters
 		TNT1 A 0 A_Scream
@@ -584,6 +595,14 @@ ACTOR IceBarrelBlast
 		Stop
 	}
 }
+
+actor IceBarrelBlastThrown : IceBarrelBlast {
+	States{
+		Spawn:
+		TNT1 A 1 A_Changeflag ("Shootable", false)
+		GOTO JUSTEXPLODE
+		}
+	}
 
 ACTOR FlameBarrelBlast
 {
@@ -625,6 +644,7 @@ ACTOR FlameBarrelBlast
 	Spawn:
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		FBAR KKKLM 2 BRIGHT
+	JustExplode:
 		TNT1 A 0 A_Stop
 		TNT1 A 0 A_AlertMonsters
 		TNT1 A 0 A_Scream
@@ -662,6 +682,13 @@ ACTOR FlameBarrelBlast
 	}
 }
 
+actor FlameBarrelBlastThrown : FlameBarrelBlast {
+	States{
+		Spawn:
+		TNT1 A 1 A_Changeflag ("Shootable", false)
+		GOTO JUSTEXPLODE
+		}
+	}
 actor StunBarrelBlast
 {
 +NOBLOCKMAP
@@ -691,35 +718,35 @@ ACTOR ThrowedBarrel
 	Speed 32
     Fastspeed 32
 	Damage 55
+	Health 30
 	+MISSILE
 	Gravity 0.6
     Scale 1.0
+	+Shootable
 	+FORCEXYBILLBOARD
-	DamageType Explosive
+	+ROLLSPRITE
+	+ROLLCENTER
+	+NOBLOOD
+	DamageType Explosive 
 	Alpha 1
 	States
 	{
 	Spawn:
-        BAR1 ABCDEF 2
+        BAR1 ABCDEF 2 A_SetRoll(roll+15, SPF_INTERPOLATE)
 		Loop
-		
+	Crash:
+	XDeath:
+	Bounce:
+		TNT1 A 0 A_Die	
     Death:
-        TNT1 A 0 A_SpawnItemEx ("BarrelBlast",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SETROLL(0)
+        TNT1 A 0 A_SpawnItemEx ("BarrelBlastThrown",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		Stop
 	}
 }
 
-ACTOR ThrowedBurningBarrel
+ACTOR ThrowedBurningBarrel : ThrowedBarrel
 {
-	Radius 10
-	Height 34
-	Speed 32
-    Fastspeed 32
-	Damage 55
-	+MISSILE
-	Gravity 0.6
-    Scale 1.0
-	+FORCEXYBILLBOARD
 	DamageType "Fire"
 	Alpha 1
 	States
@@ -730,59 +757,63 @@ ACTOR ThrowedBurningBarrel
 		TNT1 A 0 A_CustomMissile ("ImBallGettingReady2", 35, 0, random (0, 140), 2, random (0, 160))
 		EXPL AAA 0 A_SpawnItem("BurningEmberParticlesFloating_Bigger")
 		FBAR  A 3 BRIGHT A_SpawnItem("RedFlare3",0,32)
-
+		TNT1 A 0 A_SetRoll(roll+15, SPF_INTERPOLATE) 
 		TNT1 A 0 BRIGHT A_CustomMissile ("FastExplosionSmoke", 48, 0, random (40, 180), 2, random (50, 150))
 		TNT1 A 0 BRIGHT A_CustomMissile ("RealFlameTrailsSmallLong", 38, 0, random (40, 180), 2, random (50, 150))
 		TNT1 A 0 A_CustomMissile ("ImBallGettingReady2", 35, 0, random (0, 140), 2, random (0, 160))
 		EXPL AAA 0 A_SpawnItem("BurningEmberParticlesFloating_Bigger")
 		FBAR A 3 BRIGHT A_SpawnItem("RedFlare3",0,32)
+		TNT1 A 0 A_SetRoll(roll+15, SPF_INTERPOLATE)
 		TNT1 A 0 BRIGHT A_CustomMissile ("FastExplosionSmoke", 48, 0, random (40, 180), 2, random (50, 150))
 		TNT1 A 0 BRIGHT A_CustomMissile ("RealFlameTrailsSmallLong", 38, 0, random (40, 180), 2, random (50, 150))
 		TNT1 A 0 A_CustomMissile ("ImBallGettingReady2", 35, 0, random (0, 140), 2, random (0, 160))
 		EXPL AAA 0 A_SpawnItem("BurningEmberParticlesFloating_Bigger")
 		FBAR A 3 BRIGHT A_SpawnItem("RedFlare3",0,32)
+		TNT1 A 0 A_SetRoll(roll+15, SPF_INTERPOLATE)
 		TNT1 A 0 BRIGHT A_CustomMissile ("FastExplosionSmoke", 48, 0, random (40, 180), 2, random (50, 150))
 		TNT1 A 0 BRIGHT A_CustomMissile ("RealFlameTrailsSmallLong", 38, 0, random (40, 180), 2, random (50, 150))
 		TNT1 A 0 A_CustomMissile ("ImBallGettingReady2", 35, 0, random (0, 140), 2, random (0, 160))
 		EXPL AAA 0 A_SpawnItem("BurningEmberParticlesFloating_Bigger")
 	    FBAR A 3 BRIGHT A_SpawnItem("RedFlare3",0,32)
+		TNT1 A 0 A_SetRoll(roll+15, SPF_INTERPOLATE)
         TNT1 A 0 A_Playsound("props/redfire")
 		TNT1 A 0 BRIGHT A_CustomMissile ("FastExplosionSmoke", 48, 0, random (40, 180), 2, random (50, 150))
 		TNT1 A 0 BRIGHT A_CustomMissile ("RealFlameTrailsSmallLong", 30, 0, random (0, 360), 2, random (50, 150))
 		TNT1 A 0 A_CustomMissile ("ImBallGettingReady2", 35, 0, random (0, 140), 2, random (0, 160))
 		EXPL AAA 0 A_SpawnItem("BurningEmberParticlesFloating_Bigger")
 		FBAR A 3 BRIGHT A_SpawnItem("RedFlare3",0,32)
-
+		TNT1 A 0 A_SetRoll(roll+15, SPF_INTERPOLATE)
         Loop
 
+	Crash:
+	XDeath:
+	Bounce:
+		TNT1 A 0 A_Die	
+		
     Death:
-	    TNT1 A 0 A_SpawnItemEx ("FlameBarrelBlast",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SetRoll(0)
+	    TNT1 A 0 A_SpawnItemEx ("FlameBarrelBlastThrown",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		Stop
 	}
 }
 
-ACTOR ThrowedIceBarrel
+ACTOR ThrowedIceBarrel : ThrowedBarrel
 {
-	Radius 10
-	Height 34
-	Speed 32
-    Fastspeed 32
-	Damage 55
 	Damagetype "IceBeam"
-	+MISSILE
-	Gravity 0.6
-    Scale 1.0
-	+FORCEXYBILLBOARD
-	DamageType Explosive
 	Alpha 1
 	States
 	{
 	Spawn:
-        BARI I 2
+        BARI I 2 A_SetRoll(roll+15, SPF_INTERPOLATE)
 		Loop
-		
+	
+	Crash:
+	XDeath:
+	Bounce:
+		TNT1 A 0 A_Die	
     Death:
-        TNT1 A 0 A_SpawnItemEx ("IceBarrelBlast",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SetRoll(0)
+        TNT1 A 0 A_SpawnItemEx ("IceBarrelBlastThrown",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		Stop
 	}
 }

--- a/actors/Gore/BURN.dec
+++ b/actors/Gore/BURN.dec
@@ -2974,6 +2974,7 @@ ACTOR BurningDemon: BurningZombieMan
 		Stop
 		
 	Death2:
+	Death3:
 	TNT1 A 0 A_NoBlocking
 	TNT1 A 0 A_Scream
 	TNT1 A 0 A_playsound ("demon/pain")

--- a/actors/Weapons/Meatshields/BarrelThrower.dec
+++ b/actors/Weapons/Meatshields/BarrelThrower.dec
@@ -42,52 +42,39 @@ ACTOR BarrelThrower : PB_Weapon
 	Weapon.Sisterweapon "none"
 	States
 	{
+	
 		Ready:
-		Ready3:
-		TNT1 A 0 A_JumpIfInventory("HasBarrel", 1, "ReadyBarrel")
-		TNT1 A 0 A_JumpIfInventory("HasIceBarrel", 1, "ReadyIceBarrel")
-		TNT1 A 0 A_JumpIfInventory("HasBurningBarrel", 1, "ReadyBurningBarrel")
-	ReadyBarrel:
-		BANE ABCDEFG 1
-		TNT1 A 0 A_PlaySound("barrel/pain")
-		Goto IdleBarrel	
-	ReadyBurningBarrel:
-		BAFE ABCDEFG 1
-		TNT1 A 0 A_PlaySound("barrel/pain")
-		Goto IdleBurningBarrel	
-	ReadyIceBarrel:
-		BAIE ABCDEFG 1
-		TNT1 A 0 A_PlaySound("barrel/pain")
-		Goto IdleIceBarrel
+			BAIE A 0 A_JumpIfInventory("HasIceBarrel", 1,3)
+			BAFE A 0 A_JumpIf(CountInv("HasBurningBarrel") == 1, 2)
+			BANE A 0
+			"####" A 0 A_PlaySound("barrel/pain")
+			"####" ABCDEFG 1
+			goto ready3
 		
-	IdleBarrel:
-        THRG LKJIHIJKL 2 {
-			A_WeaponReady;
-			if(CountInv("Kicking") >= 1) {return state("DoKick");}
-			return state("");
-			}
+		WeaponSpecial:
+		Ready3:
+		TNT1 A 0 A_TakeInventory("GoWeaponSpecialAbility")
+		TNT1 A 0 A_JumpIfInventory("HasBarrel", 1, "IdleBarrel")
+		TNT1 A 0 A_JumpIfInventory("HasIceBarrel", 1, "IdleIceBarrel")
+		TNT1 A 0 A_JumpIfInventory("HasBurningBarrel", 1, "IdleBurningBarrel")
+		
+		IdleBarrel:
+        THRG LKJIHIJKL 2 A_DoPBWeaponAction
 		loop
 		
 	IdleBurningBarrel:
-        THRG DEFGFED 2 {
-			A_WeaponReady;
-			if(CountInv("Kicking") >= 1) {return state("DoKick");}
-			return state("");
-			}
+        THRG DEFGFED 2 A_DoPBWeaponAction
 		loop
 		
 	IdleIceBarrel:
-        THRG M 1 {
-			A_WeaponReady;
-			if(CountInv("Kicking") >= 1) {return state("DoKick");}
-			return state("");
-			}
+        THRG M 1 A_DoPBWeaponAction
 		loop
 		
 	Select:
 	    TNT1 A 0 A_TakeInventory("MeatAmmo", 100)
 		TNT1 A 0 A_Overlay(-10, "FirstPersonLegsStand")
-		
+		Goto SelectFirstPersonLegs
+	SelectContinue:
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Raise
 		TNT1 AAAAAAAA 1 A_Raise
 		Wait
@@ -95,6 +82,29 @@ ACTOR BarrelThrower : PB_Weapon
     Fire:
 		TNT1 A 0 A_JumpIfInventory("PowerStrength",1,"PreparingToThrow")
 		Goto AltFire
+	FlashKicking:
+	FLASHPUNCHING:
+		BAIE A 0 A_JumpIfInventory("HasIceBarrel", 1, 3)
+		BAFE A 0 A_JumpIfInventory("HasBurningBarrel", 1, 2)
+		BANE A 0
+		"####" IJKLMNOONMLKJI 1
+		STOP
+	
+	FlashAirKicking:
+		BAIE A 0 A_JumpIfInventory("HasIceBarrel", 1, 3)
+		BAFE A 0 A_JumpIfInventory("HasBurningBarrel", 1, 2)
+		BANE A 0
+		"####" IJKLMNOOOOONMLKJI 1
+		STOP
+	FlashSlideKicking:
+		BAIE A 0 A_JumpIfInventory("HasIceBarrel", 1, 3)
+		BAFE A 0 A_JumpIfInventory("HasBurningBarrel", 1, 2)
+		BANE A 0
+		"####" IJKLMNOOOOO 1
+		"####" OOOOOO 1
+	FlashSlideKickingStop:
+		"####" ONMLKJI 1
+		stop
 		
 	PreparingToThrow:
 		TNT1 A 0 A_JumpIfInventory("HasBarrel", 1, "FireBarrel")
@@ -105,7 +115,7 @@ ACTOR BarrelThrower : PB_Weapon
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
 		BANE ONLJH 1
 		TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
-		TNT1 A 0 A_FireCustomMissile("ThrowedBarrel", 0, 1, 0, 0)
+		TNT1 A 0 A_FireCustomMissile("ThrowedBarrel", 0, 1, 0, 0, FPF_NOAUTOAIM)
 		TNT1 A 0 A_TakeInventory("HasBarrel",1)
 		TNT1 A 0 A_TakeInventory("GrabbedBarrel",1)
         THRF ABCDEF 2
@@ -116,7 +126,7 @@ ACTOR BarrelThrower : PB_Weapon
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
 		BAFE ONLJH 1
 		TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
-		TNT1 A 0 A_FireCustomMissile("ThrowedBurningBarrel", 0, 1, 0, 0)
+		TNT1 A 0 A_FireCustomMissile("ThrowedBurningBarrel", 0, 1, 0, 0, FPF_NOAUTOAIM)
 		TNT1 A 0 A_TakeInventory("HasBurningBarrel",1)
 		TNT1 A 0 A_TakeInventory("GrabbedBarrel",1)
         THRF ABCDEF 2
@@ -128,7 +138,7 @@ ACTOR BarrelThrower : PB_Weapon
 		TNT1 A 0 A_PlaySound("weapons/fistwhoosh")
 		BAIE ONLJH 1
 		TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
-		TNT1 A 0 A_FireCustomMissile("ThrowedIceBarrel", 0, 1, 0, 0)
+		TNT1 A 0 A_FireCustomMissile("ThrowedIceBarrel", 0, 1, 0, 0, FPF_NOAUTOAIM)
 		TNT1 A 0 A_TakeInventory("HasIceBarrel",1)
 		TNT1 A 0 A_TakeInventory("GrabbedBarrel",1)
         THRF ABCDEF 2


### PR DESCRIPTION
Fixed barrels showing incorrect sprite when going to next level 
(Note: I was unable to fix the select animation after finishing the level, so this is intentional)
Tweaked thrown barrels, reduced some code, and they now explode after landing the floor. 
Thrown barrels are also shootable in the air now.