### PR TITLE
Insert Bullets Action in Zscript

### DIFF
--- a/zscript/Weapons/BaseWeapon.zc
+++ b/zscript/Weapons/BaseWeapon.zc
@@ -62,6 +62,17 @@ class PB_WeaponBase : DoomWeapon
 	Return Null;
 	}
 	
+	//An example of this action: PB_AmmoIntoMag("RifleAmmo","NewClip",30) 
+	action void PB_AmmoIntoMag(String AmmoMag_Action,String AmmoPool_Action,int MagazineMaxFill_Action)//A way to perform pretty much take all of the "Insertbullets" states and turn it into a function
+		{
+			invoker.AmmoMag = AmmoMag_Action;
+			invoker.AmmoPool = AmmoPool_Action;
+			invoker.MagazineMaxFill = MagazineMaxFill_Action;
+			
+			A_Overlay(-97,"InsertBullets_Zscript");
+		}
+	
+	
 	//Checks if the owner has a berserk
 	bool OwnerHasBerserk()
 	{
@@ -437,6 +448,20 @@ class PB_WeaponBase : DoomWeapon
 	
 	States
 	{	
+		InsertBullets_Zscript:
+			TNT1 A 0 A_JumpifInventory(invoker.AmmoMag,invoker.MagazineMaxFill,"InsertBullets_Zscript_Stop");
+			TNT1 A 0 A_JumpIf(!CountInv(invoker.AmmoPool),"InsertBullets_Zscript_Stop");
+			TNT1 A 0 
+				{
+					A_GiveInventory(invoker.AmmoMag,1);
+					A_TakeInventory(invoker.AmmoPool,1);
+				}
+		Loop;
+	
+		InsertBullets_Zscript_Stop:	
+			TNT1 A 0;
+			Stop;
+		
 		HelmetAnimation:
 			TNT1 A 0
 			{


### PR DESCRIPTION
This is also to find out how to send a PR to the staging branch.  This is just an action in the base weapon (Zscript) as an alternative to the "InsertBullets" loop used in nearly every weapon.  With this you just insert the actor acting as the magazine, the actor to pull inventory from, and the maximum number for that magazine.  Since a loop is no longer needed in the weapon actor itself you can simply call this (and add logic for +1 magazine reloads) and move on.