### PR TITLE
Added option for player hand grenades

### DIFF
--- a/CVARINFO
+++ b/CVARINFO
@@ -26,6 +26,7 @@ server int pb_disablenewguns = 0;
 
 server int pb_disablenewenemies = 0;
 server bool pb_cyberdemondeath = false;
+server bool pb_grenadeimpact = false;
 
 //DMR Reticle Related stuff.
 Server noarchive float TestX1 = 0.0;

--- a/DetailedCredits.txt
+++ b/DetailedCredits.txt
@@ -286,6 +286,10 @@ Kinnerokhn (aka Kinnero) and Metalman
 
 Kinnerokhn - Updated Demon Strength Rune sprites
 
+Kamil - For his amazing work on optimizing sprites and
+fixing some minor issues in the mod, along with pointing
+out various bugs (post credit)
+
 SkeletronMK666 - Fixed Shotgun guy boot color on some head shot death sprites, fixed MP40 pickup
 
 Edward Marlus - Certain sound changes and MP40 pickup sprite

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -299,6 +299,12 @@ OptionMenu "GameplaySettings"
 	StaticText " "
 	StaticText " "
 	
+	Option "Player Frag Greandes explode on impact", "pb_grenadeimpact", "YesNo"
+	StaticText "Allows frag grenades from the player to explode on impact (such"
+	StaticText "as a wall, a ceiling, a floor, an enemy, etc.)"
+	StaticText " "
+	StaticText " "
+	
 	//Option "DMR / HDMR Reticle Code Source?",	 "ReticleStyle", "ReticleCode" //For ACS style reticle
 	//StaticText " "
 	//StaticText " "

--- a/actors/Decorations/Barrels/NukageBarrel.dec
+++ b/actors/Decorations/Barrels/NukageBarrel.dec
@@ -24,7 +24,7 @@ ACTOR NukageBarrel : SwitchableDecoration
 +NOICEDEATH
 +LOOKALLAROUND
 +SHOOTABLE
-+GHOST
+//+GHOST //This flag makes projectiles like the mancubus fireball phase through the barrel. Why the fuck was this added?
 +SOLID
 +PUSHABLE
 +SLIDESONWALLS
@@ -210,6 +210,7 @@ ACTOR NukageBarrel : SwitchableDecoration
 		TNT1 A 0 A_SpawnItemEx ("BarrelDent1",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
 		
 		Stop
+	
 		
 	Death.Ice:
 	Death.Freeze:
@@ -235,9 +236,7 @@ ACTOR NukageBarrel : SwitchableDecoration
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
-		TNT1 A 0 A_SpawnItemEx ("FlameBarrel",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
-		
-		Stop
+		Goto Death.ExplosiveImpact
 	
 	Death.cut:
 	Death.saw:
@@ -435,9 +434,7 @@ ACTOR BarrelCut : NukageBarrel
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
-		TNT1 A 0 A_SpawnItemEx ("FlameBarrelCut",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
-		
-		Stop
+		Goto Death.ExplosiveImpact
 		
 	}
 }
@@ -544,9 +541,7 @@ ACTOR BarrelHoles : BarrelCut
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
-		TNT1 A 0 A_SpawnItemEx ("FlameBarrelHoles",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
-		
-		Stop
+		Goto Death.ExplosiveImpact
 	}
 }
 
@@ -732,9 +727,7 @@ ACTOR BarrelDent1 : NukageBarrel
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
-		TNT1 A 0 A_SpawnItemEx ("FlameBarrelDent1",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
-		
-		Stop
+		Goto Death.ExplosiveImpact
 		
 	}
 }
@@ -926,9 +919,7 @@ ACTOR BarrelDent2 : BarrelDent1
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
-		TNT1 A 0 A_SpawnItemEx ("FlameBarrelDent2",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
-		
-		Stop
+		Goto Death.ExplosiveImpact
 		
 	}
 }
@@ -1123,9 +1114,7 @@ ACTOR BarrelBloody : NukageBarrel
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
-		TNT1 A 0 A_SpawnItemEx ("FlameBarrelBloody",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
-		
-		Stop
+		Goto Death.ExplosiveImpact
 	
 	Death.cut:
 	Death.saw:
@@ -1265,8 +1254,7 @@ ACTOR BarrelBloodyCut : BarrelCut
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
-		TNT1 A 0 A_SpawnItemEx ("FlameBarrelBloodyCut",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)	
-		Stop
+		Goto Death.ExplosiveImpact
 		
 	Death.Blackhole:
 		BRGV A 0 A_JumpIfInventory("GreenBloodSplatterz",1,3)
@@ -1465,7 +1453,7 @@ ACTOR BarrelBloodyHoles : BarrelBloody
 		FBRB A 0 A_JumpIfInventory("BlueBloodSplatterz", 1, 2)
 		FBAR A 0
 		"####" F 0 A_SpawnItemEx ("FlameBarrelBloodyHolesLoad",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION|SXF_TRANSFERSPRITEFRAME)	
-		Stop
+		Goto Death.ExplosiveImpact
 		
 	Death.Blackhole:
 		BRGV A 0 A_JumpIfInventory("GreenBloodSplatterz",1,3)
@@ -1692,9 +1680,7 @@ ACTOR BarrelBloodyDent1 : BarrelBloody
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
-		TNT1 A 0 A_SpawnItemEx ("FlameBarrelBloodyDent1",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
-		
-		Stop
+		Goto Death.ExplosiveImpact
 		
 	Death.Blackhole:
 		BRGV A 0 A_JumpIfInventory("GreenBloodSplatterz",1,3)
@@ -1909,8 +1895,7 @@ ACTOR BarrelBloodyDent2 : BarrelBloody
 		TNT1 A 0 A_Changeflag ("Shootable", false)
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
-		TNT1 A 0 A_SpawnItemEx ("FlameBarrelBloodyDent2",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
-		Stop
+		Goto Death.ExplosiveImpact
 		
 	}
 }

--- a/actors/Player/PLAYER.dec
+++ b/actors/Player/PLAYER.dec
@@ -1306,6 +1306,8 @@ ACTOR Doomer : PlayerPawnBase Replaces DoomPlayer
         Goto Pain
 		
 	Pain.Freeze:
+	Pain.Ice:
+	Pain.Frost:
 	TNT1 A 0 A_JumpIfHealthLower(14, "FreezePlayer")
 	PLAY G 3
 	Goto See
@@ -1332,7 +1334,7 @@ ACTOR Doomer : PlayerPawnBase Replaces DoomPlayer
 		TNT1 A 0 A_PlaySound ("DSBOTTLE")
 		TNT1 AAAAAA 0 A_CustomMissile ("IceDust", 48, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("IceBlood", 48, 0, random (0, 360), 2, random (0, 160))
-		FZD1 C -1
+		FZD1 C -1// A_FreezeDeath
 		Stop
 	
 	//Classic Death

--- a/actors/Weapons/EXPLOSIVES.dec
+++ b/actors/Weapons/EXPLOSIVES.dec
@@ -555,7 +555,7 @@ States    {
 	TNT1 A 0
 	TNT1 A 0 A_SpawnItem("WhiteShockwaveBig")
 	TNT1 A 2
-		TNT1 A 0 A_Explode(225,200)
+		TNT1 A 0 A_Explode(200,200)
         Stop}}
 		
 actor KamikazeeExplosion: RocketExplosion

--- a/actors/Weapons/EXPLOSIVES.dec
+++ b/actors/Weapons/EXPLOSIVES.dec
@@ -555,7 +555,7 @@ States    {
 	TNT1 A 0
 	TNT1 A 0 A_SpawnItem("WhiteShockwaveBig")
 	TNT1 A 2
-		TNT1 A 0 A_Explode(250,250)
+		TNT1 A 0 A_Explode(225,200)
         Stop}}
 		
 actor KamikazeeExplosion: RocketExplosion

--- a/actors/Weapons/EXPLOSIVES.dec
+++ b/actors/Weapons/EXPLOSIVES.dec
@@ -555,8 +555,7 @@ States    {
 	TNT1 A 0
 	TNT1 A 0 A_SpawnItem("WhiteShockwaveBig")
 	TNT1 A 2
-		TNT1 A 0 A_Explode(160,180)
-		TNT1 A 0 A_Explode(200,90)
+		TNT1 A 0 A_Explode(250,250)
         Stop}}
 		
 actor KamikazeeExplosion: RocketExplosion

--- a/actors/Weapons/Throwables.dec
+++ b/actors/Weapons/Throwables.dec
@@ -435,6 +435,7 @@ ACTOR ThrownGrenade1
 	+DontHurtSpecies
 	+DontHarmSpecies
 	+NoExtremeDeath
+	+UseBounceState
 	DamageType "ExplosiveImpact"
 	BounceFactor 0.5
 	WallBounceFactor 0.25
@@ -445,19 +446,29 @@ ACTOR ThrownGrenade1
 	States
 	{
 	Spawn:
-		TNT1 A 0
-		GRND ABCDEFGA 2
+		GRND ABCD 2
+		TNT1 A 0 A_GiveInventory("GrenadeTime",1)
+		GRND EFGA 2
 		TNT1 A 0 A_StopSound(5)
-		TNT1 A 0 A_GiveInventory("GrenadeTime", 1)
 		TNT1 A 0 A_JumpIfInventory("GrenadeTime", 3, "Explode")
 		Loop
+	
+	Bounce:
+	Bounce.Floor:
+	Bounce.Ceiling:
+	Bounce.Wall:
+		TNT1 A 0
+		TNT1 A 0 A_JumpIfInventory("GrenadeTime", 3, "Explode")
+		TNT1 A 0 A_JumpIf(GetCvar("pb_grenadeimpact"),"Explode")
+		Goto Spawn
 
 	Death:
 		TNT1 A 0
 		TNT1 A 0
+		TNT1 A 0 A_JumpIf(GetCvar("pb_grenadeimpact"),"Explode")
 	    GRND G 17
+		TNT1 A 0 A_GiveInventory("GrenadeTime",1)
 		TNT1 A 0 A_StopSound(5)
-		TNT1 A 0 A_GiveInventory("GrenadeTime", 1)
 		TNT1 A 0 A_JumpIfInventory("GrenadeTime", 3, "Explode")
 		Loop
 			
@@ -553,6 +564,7 @@ ACTOR EnemyThrownGrenade : HandGrenadeAnother
     +BOUNCEONACTORS
 	+NOEXTREMEDEATH
 	+DONTHURTSPECIES
+	-UseBounceState
 	Species "Zombieman"
 	+MTHRUSPECIES
 	+THRUSPECIES
@@ -562,6 +574,21 @@ ACTOR EnemyThrownGrenade : HandGrenadeAnother
    Speed 16
    States
    {
+	Spawn:
+		GRND ABCDEFGA 2
+		TNT1 A 0 A_GiveInventory("GrenadeTime",1)
+		TNT1 A 0 A_StopSound(5)
+		TNT1 A 0 A_JumpIfInventory("GrenadeTime", 3, "Explode")
+		Loop
+
+	Death:
+		TNT1 A 0
+		TNT1 A 0
+	    GRND G 17
+		TNT1 A 0 A_GiveInventory("GrenadeTime",1)
+		TNT1 A 0 A_StopSound(5)
+		TNT1 A 0 A_JumpIfInventory("GrenadeTime", 3, "Explode")
+		Loop
    Explode:
 		TNT1 A 0 A_SpawnItemEx("FootStep6", 0, 0, 40, 0, 0)
 		TNT1 A 0 A_Stop
@@ -573,7 +600,7 @@ ACTOR EnemyThrownGrenade : HandGrenadeAnother
 		GRND G 25
 		TNT1 A 0 A_StopSound(6)
 		EXPL A 0 Radius_Quake (2, 16, 0, 15, 0)//(intensity, duration, damrad, tremrad, tid)
-		TNT1 A 0 A_SpawnItemEx ("HandGrenadeExplosionEnemy",0,0,30,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SpawnItemEx ("HandGrenadeExplosion",0,0,30,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		TNT1 A 0 A_SpawnItem("WhiteShockwave")
 		TNT1 A 0 A_SpawnItem ("BigRicoChet", 0, -30)
 		TNT1 A 0 A_SpawnItemEx ("NewGroundExplosionSmoke",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
@@ -785,6 +812,7 @@ ACTOR ThrownStunGrenade : ThrownGrenade1
 	DeathSound "none"
 	Obituary "%o ate %k grenade."
 	+ROLLSPRITE 
+	-UseBounceState
 	States
 	{
 		Spawn:


### PR DESCRIPTION
Added an option to allow player hand grenades to explode on impact, located in Gameplay Options in the PB settings. This setting is OFF by default.