### PR TITLE
Work around the game hanging when a `PB_HelmetCommando` goes into `XDeath` state

### DIFF
--- a/actors/Monsters/T1-Grunts/HelmetCommando.dec
+++ b/actors/Monsters/T1-Grunts/HelmetCommando.dec
@@ -683,6 +683,7 @@ ACTOR PB_HelmetCommando: PB_Commando Replaces ChaingunGuy
         TNT1 A 0 A_CustomMissile ("ChainXDeath", 0, 0, random (0, 360), 2, random (0, 160))
         TNT1 AAAA 0 A_CustomMissile ("MuchBlood2", 50, 0, random (0, 360), 2, random (0, 160))
         TNT1 AAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 1
 		Stop
 		
 	Death.Cutless:


### PR DESCRIPTION
The game occasionally hangs when a `PB_HelmetCommando` is gibbed. The problem appears to be that all of the `XDeath` states have a duration of zero. This PR works around the problem by adding one non-instant state to the end of the `XDeath` sequence.

Why the game hangs, I don't know. This is only a workaround, not an actual fix for the bug, so please feel free to close this PR if you know what the actual bug is.

I'm running GZDoom 4.10.0.