### PR TITLE
Picking up a backpack reloads the flamethrower

### DIFF
--- a/actors/Weapons/Slot9/Flamethrower.dec
+++ b/actors/Weapons/Slot9/Flamethrower.dec
@@ -1345,7 +1345,7 @@ ACTOR FlamerAmmo : Ammo
 {
    Inventory.Amount 90
    Inventory.MaxAmount 90
-   Ammo.BackpackAmount 90
+   Ammo.BackpackAmount 0
    Ammo.BackpackMaxAmount 90
    +INVENTORY.IGNORESKILL
 }


### PR DESCRIPTION
Picking up an ammo backpack has the side effect of instantly reloading the flamethrower. This PR fixes that.