### PR TITLE
Fix Slider Drops Decal

### DIFF
--- a/DECALDEF
+++ b/DECALDEF
@@ -853,7 +853,6 @@ fader LiquidFaderFast
 
 slider Drops
 {
-   DistX 0
    DistY -320
    SlideStart 0.01
    SlideTime 15


### PR DESCRIPTION
DistX or DistY can't be 0. Removed DistX to get rid of log error. Thanks generic for helping me pin it down.