### PR TITLE
cleanup of zscript item integration

### DIFF
--- a/DECORATE
+++ b/DECORATE
@@ -67,7 +67,7 @@ Actor IsTacticalClass : Inventory {} //Fake item to fix the lag.
 #include "actors/Items/Ammo/Cellpack.dec"
 
 //Powerups
-#include "actors/Items/Powerups/SpecialPowerups.dec"
+#include "actors/Items/SpecialPowerups.dec"
 #include "actors/Items/GenericHealth.dec"
 
 //DECORATIONS

--- a/actors/Items/SpecialPowerups.dec
+++ b/actors/Items/SpecialPowerups.dec
@@ -27,7 +27,7 @@ Actor UpgradeSpawner
 	BackpackSpawn:
 		TNT1 A 0
 		
-		//TNT1 A 0 A_SpawnItemEx("PB_HeavyBackpack",0,0,0,0,0,0,0,288)
+		TNT1 A 0 A_SpawnItemEx("PB_Backpack",0,0,0,0,0,0,0,288)
 		Stop
 		
 	SpawnLMG:
@@ -71,14 +71,14 @@ Actor UpgradeSpawner
 		TNT1 A 1 ACS_NamedExecuteAlways("ToggleRifleUpgrade", 0, 0, 0, 0)//Check if Upgrades are disabled
 		TNT1 A 0 A_SpawnItemEx("RifleUpgrade",0,0,0,0,0,0,0,288)
 		Stop
-		
+	/*	
 	SpawnPB_UnmakerUpgrade:
 		TNT1 A 0
 		TNT1 A 1 ACS_NamedExecuteAlways("PBUpgradeChecker_UnmakerUpgrade", 0, 0, 0, 0)//Check if already having existing upgrades
 		TNT1 A 1 ACS_NamedExecuteAlways("ToggleUnmakerUpgrade", 0, 0, 0, 0)//Check if Upgrades are disabled
 		TNT1 A 0 A_SpawnItemEx("PB_Unmaker",0,0,0,0,0,0,0,288)
 		Stop
-		
+	*/
 	SpawnM2Upgrade:
 		TNT1 A 0
 		TNT1 A 1 ACS_NamedExecuteAlways("PBUpgradeChecker_M2Upgrade", 0, 0, 0, 0)//Check if already having existing upgrades

--- a/actors/Monsters/T2-Pinkies/MeanDemon.dec
+++ b/actors/Monsters/T2-Pinkies/MeanDemon.dec
@@ -34,8 +34,8 @@ Actor PB_MeanDemon : Demon Replaces Demon
 	PainChance "ExtremePunches", 256
 	DeathSound "demon/Death"
 	ActiveSound "demon/active"
-	DropItem "HasteSphere" 3
-	DropItem "DoubleSphere" 2
+	DropItem "PB_Haste" 3
+	DropItem "PB_DoomSphere" 2
 	BloodType "Brutal_Blood", "BloodSPlatterReplacer", "Brutal_Blood"
 	DamageFactor "CauseObjectsToSplash", 0.0
 	DropItem "Demonpickup" 150

--- a/actors/Monsters/T3-Arachnos/EliteArachnotron.dec
+++ b/actors/Monsters/T3-Arachnos/EliteArachnotron.dec
@@ -20,8 +20,8 @@ ACTOR PB_EliteArachnotron: Arachnotron replaces Arachnotron
 	DamageFactor "Blood", 0.0 DamageFactor "BlueBlood", 0.0 DamageFactor "GreenBlood", 0.0
 	damagefactor "TeleportRemover", 0.0
 	
-	DropItem "DoubleSphere" 7
-	DropItem "HasteSphere" 2
+	DropItem "PB_DoomSphere" 7
+	DropItem "PB_Haste" 2
 	DropItem "Demonpickup2" 255
 	DropItem "Demonpickup" 55
 	DropItem "Demonpickup" 55

--- a/actors/Monsters/T3-Arachnos/InfernalArachnotron.dec
+++ b/actors/Monsters/T3-Arachnos/InfernalArachnotron.dec
@@ -19,8 +19,8 @@ ACTOR PB_InfernalArachnotron: Arachnotron replaces Arachnotron
 	DamageFactor "Blood", 0.0 DamageFactor "BlueBlood", 0.0 DamageFactor "GreenBlood", 0.0
 	damagefactor "TeleportRemover", 0.0
 	
-	DropItem "HasteSphere" 8
-	DropItem "DoubleSphere" 7
+	DropItem "PB_Haste" 8
+	DropItem "PB_DoomSphere" 7
 	DropItem "Demonpickup2" 255
 	DropItem "Demonpickup" 55
 	DropItem "Demonpickup" 55

--- a/actors/Monsters/T3-Fats/Daedabus.dec
+++ b/actors/Monsters/T3-Fats/Daedabus.dec
@@ -44,8 +44,8 @@ Actor PB_Daedabus replaces Fatso
 	damagefactor "HEAD", 3
 	damagefactor "TeleportRemover", 0.0
 	
-	DropItem "HasteSphere" 4
-	DropItem "DoubleSphere" 4
+	DropItem "PB_Haste" 4
+	DropItem "PB_DoomSphere" 4
 	Species "BigFatAss"
 	+DONTHARMSPECIES
 	+DONTHARMCLASS

--- a/actors/Monsters/T3-Fats/Volcabus.dec
+++ b/actors/Monsters/T3-Fats/Volcabus.dec
@@ -32,8 +32,8 @@ Actor PB_Volcabus : Fatso replaces Fatso
     damagefactor "HEAD", 3
 	damagefactor "TeleportRemover", 0.0
 	
-	DropItem "HasteSphere" 4
-	DropItem "DoubleSphere" 4
+	DropItem "PB_Haste" 4
+	DropItem "PB_DoomSphere" 4
 	Species "BigFatAss"
 	+DONTHARMSPECIES
     +DONTHARMCLASS

--- a/actors/Monsters/T3-Floaters/InfernalCaco.dec
+++ b/actors/Monsters/T3-Floaters/InfernalCaco.dec
@@ -37,8 +37,8 @@ ACTOR PB_InfernalCaco : PainElemental replaces Cacodemon
 	Obituary "%o was deep fried by an Infernal Cacodemon."
 	
 	
-	DropItem "HasteSphere" 4
-	DropItem "DoubleSphere" 2
+	DropItem "PB_Haste" 4
+	DropItem "PB_DoomSphere" 2
 	DamageFactor "Blood", 0.0 DamageFactor "BlueBlood", 0.0 DamageFactor "GreenBlood", 0.0
 	damagefactor "killme", 0.0
 	damagefactor "TeleportRemover", 0.0

--- a/actors/Monsters/T4-Nobles/CyberBaron.dec
+++ b/actors/Monsters/T4-Nobles/CyberBaron.dec
@@ -30,8 +30,8 @@ ACTOR PB_CyberBaron replaces BaronofHell
 	damagefactor "killme", 0.0
     BloodType "NashGoreBlood_Green", "NashGoreBlood_Green", "NashGoreBlood_Green"
 	
-	DropItem "HasteSphere" 8
-	DropItem "DoubleSphere" 7
+	DropItem "PB_Haste" 8
+	DropItem "PB_DoomSphere" 7
   PainChance "Kick", 200
   PainChance "ExtremePunches", 200
   PainChance "Head", 255

--- a/actors/Monsters/T4-Nobles/CyberKnight.dec
+++ b/actors/Monsters/T4-Nobles/CyberKnight.dec
@@ -46,8 +46,8 @@ Actor PB_CyberKnight: Hellknight Replaces HellKnight
      Species "Noble"
    +DONTHARMSPECIES
 	
-	DropItem "HasteSphere" 6
-	DropItem "DoubleSphere" 5
+	DropItem "PB_Haste" 6
+	DropItem "PB_DoomSphere" 5
 	SeeSound "monster/bruSit" 
 	PainSound "baron/pain" 
 	DeathSound "monster/brudth"

--- a/actors/Monsters/T4-Nobles/CyberPaladin.dec
+++ b/actors/Monsters/T4-Nobles/CyberPaladin.dec
@@ -48,8 +48,8 @@ ACTOR PB_CyberPaladin replaces Hellknight
     Species "Noble"
 	
 	
-	DropItem "HasteSphere" 6
-	DropItem "DoubleSphere" 5
+	DropItem "PB_Haste" 6
+	DropItem "PB_DoomSphere" 5
 	DropItem "Demonpickup2" 90
     DropItem "Demonpickup" 196
 	States

--- a/actors/Monsters/T4-Viles/ARCHVILE.dec
+++ b/actors/Monsters/T4-Viles/ARCHVILE.dec
@@ -54,8 +54,8 @@ ACTOR PB_Archvile: Archvile Replaces Archvile
 	damagefactor "Blood", 0.0 damagefactor "BlueBlood", 0.0 damagefactor "GreenBlood", 0.0
 	
 	
-	DropItem "DoubleSphere" 5
-	DropItem "HasteSphere" 2
+	DropItem "PB_DoomSphere" 5
+	DropItem "PB_Haste" 2
 	
 	DropItem "Demonpickup2" 255
 	DropItem "Demonpickup2" 25

--- a/actors/Monsters/T4-Viles/FleshWizard.dec
+++ b/actors/Monsters/T4-Viles/FleshWizard.dec
@@ -22,8 +22,8 @@ painsound "wizard/pain"
 deathsound "wizard/death"
 activesound "wizard/active"
 
-	DropItem "HasteSphere" 7
-	DropItem "DoubleSphere" 7
+	DropItem "PB_Haste" 7
+	DropItem "PB_DoomSphere" 7
 	DropItem "Demonpickup2" 255
  DropItem "Demonpickup2" 255
 	PainChance "Stun", 255

--- a/actors/Monsters/T4-Viles/Hellion.dec
+++ b/actors/Monsters/T4-Viles/Hellion.dec
@@ -37,7 +37,7 @@ BloodType "Brutal_Blood", "BloodSPlatterReplacer", "SawBlood"
 	damagefactor "TeleportRemover", 0.0
 	
 	
-	DropItem "DoubleSphere" 5
+	DropItem "PB_DoomSphere" 5
 	
 	DropItem "Demonpickup2" 255
 	DropItem "Demonpickup2" 25

--- a/actors/Monsters/T4-Viles/IceVile.dec
+++ b/actors/Monsters/T4-Viles/IceVile.dec
@@ -34,8 +34,8 @@ ACTOR PB_Icevile Replaces Archvile
 	DamageFactor "Ice", 0.0
 	DamageFactor "Freeze", 0.0//THE BASTARD CAN'T BE KILLED BY THE CryoRifle
 	
-	DropItem "HasteSphere" 7
-	DropItem "DoubleSphere" 7
+	DropItem "PB_Haste" 7
+	DropItem "PB_DoomSphere" 7
 	DropItem "Demonpickup2" 255
 	DropItem "Demonpickup2" 255
 	DamageFactor "Saw", 0.8

--- a/actors/Monsters/Tz-Bosses/ANNIHILATOR.dec
+++ b/actors/Monsters/Tz-Bosses/ANNIHILATOR.dec
@@ -46,8 +46,8 @@ ACTOR PB_Annihilator: Cyberdemon Replaces Cyberdemon
 	PainChance "Cut", 2
 	PainChance "Saw", 2
 	PainChance "Disintegrate", 5
-	DropItem "HasteSphere" 25
-	DropItem "DoubleSphere" 25
+	DropItem "PB_Haste" 25
+	DropItem "PB_DoomSphere" 25
     BloodType "Brutal_Blood"
 DamageFactor "Blood", 0.0 DamageFactor "BlueBlood", 0.0 DamageFactor "GreenBlood", 0.0
 	

--- a/actors/SPAWNERS/ItemSpawners/AmmoSpawners.dec
+++ b/actors/SPAWNERS/ItemSpawners/AmmoSpawners.dec
@@ -9,3 +9,9 @@ actor PB_ClipBoxSpawner : RandomSpawner replaces Clipbox
 	DropItem "PB_HighCalBox",255,67
 	DropItem "PB_LowCalBox",255,33
 }
+
+actor PB_BackpackSpawner : RandomSpawner replaces Backpack
+{
+	Dropitem "PB_Backpack",255,75
+	Dropitem "UpgradeSpawner",255,25
+}

--- a/actors/SPAWNERS/WeaponSpawners/BFG9000WeaponSpawners.dec
+++ b/actors/SPAWNERS/WeaponSpawners/BFG9000WeaponSpawners.dec
@@ -24,16 +24,18 @@ Actor BFGWeaponSpawner : SpawnerBase replaces BFG9000
 		DiceTier3:
 		DiceTier4:
 		DiceDeathWish:
-			Goto SpawnPB_BFG9000
-
+			TNT1 A 0 A_Jump(20,"SpawnUnmaker")
+			TNT1 A 0 A_Jump(255,"SpawnBFG9000")
 		SpawnPB_BFG9000:
 			ReplaceVanilla:
 			ReplaceToggle:
-			
 			ReplaceVanilla:
 			//TNT1 A 1 A_RadiusGive("IsNearBFG", 480, RGF_GIVESELF | RGF_CUBE | RGF_MONSTERS | RGF_ITEMS | RGF_NOSIGHT, 1)
 			TNT1 A 0 A_SpawnItemEx("PB_BFG9000",0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS | 288,0,tid)
 			Stop
+		SpawnUnmaker:
+			TNT1 A 0 A_SpawnItemEx("PB_Unmaker",0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS | 288,0,tid)
+			stop
 		SpawnBuzzsaw:
 			TNT1 A 0 A_Jump(200,"SkipNaziCheck")
 			TNT1 A 0 A_SpawnItemEx("PB_MG42",0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS | 288,0,tid)

--- a/actors/Weapons/Slot3/SHOTGUN.dec
+++ b/actors/Weapons/Slot3/SHOTGUN.dec
@@ -1007,7 +1007,7 @@ ACTOR PB_Shotgun : PB_Weapon Replaces Shotgun
 			A_WeaponOffset(0,32);
 		}
 		TNT1 A 0 A_JumpIfInventory("PumpshotgunMagazine", 1, "MagPump")
-		TNT1 A 0 A_JumpIf(CountInv("PowerStrength") && GetCvar("pb_SGPumpFromHip") >= 1, "PumpFromHip")
+		TNT1 A 0 A_JumpIf(CountInv("PB_PowerStrength") && GetCvar("pb_SGPumpFromHip") >= 1, "PumpFromHip")
 		SHTG BCDEFGHIJ 1 A_SetRoll(roll-0.1,SPF_INTERPOLATE)
 	P1Begin:
 	    SHTA K 0
@@ -1204,7 +1204,7 @@ ACTOR PB_Shotgun : PB_Weapon Replaces Shotgun
 		}
 		TNT1 A 0 
 		{
-		 If (CountInv("PowerStrength") >=1 ){PB_WeaponRecoilBasic(-0.25);return state("BerserkAltPump1");}
+		 If (CountInv("PB_PowerStrength") >=1 ){PB_WeaponRecoilBasic(-0.25);return state("BerserkAltPump1");}
 		 else {PB_WeaponRecoilBasic(-0.2);} //this line was moved somehow in the conflict
 		 return state("");
 	    }

--- a/actors/Weapons/Slot9/Flamethrower.dec
+++ b/actors/Weapons/Slot9/Flamethrower.dec
@@ -179,7 +179,7 @@ Actor PB_FlamethrowerUpgrade : CustomInventory
 +INVENTORY.ALWAYSPICKUP
 Inventory.PickupSound "FLMDRAW"
 Scale 0.5
-Inventory.PickupMessage "You got the UAC-M3 Flamethrower upgrade! (Slot 7)"
+Inventory.PickupMessage "You got the UAC-M3 Flamethrower upgrade! (Slot 8)"
 States
 {
 Spawn:
@@ -195,7 +195,7 @@ Stop
 }
 }
 
-Actor PB_FlamethrowerMancubusPB_Fuel : CustomInventory
+Actor PB_FlamethrowerMancubusGas : CustomInventory
 {
 	+INVENTORY.ALWAYSPICKUP
 	Inventory.PickupSound "FLMDRAW"
@@ -229,7 +229,7 @@ ACTOR PB_Flamethrower : PB_Weapon
      +WEAPON.NOAUTOAIM
 	+FLOORCLIP
 	+DONTGIB
-	Inventory.PickupMessage "You got the UAC-M3 Flamethrower! (Slot 7)"
+	Inventory.PickupMessage "You got the UAC-M3 Flamethrower! (Slot 8)"
 	Tag "UAC-M3 Flamethrower"
 	PB_WeaponBase.OffsetRecoilX 1.75
 	PB_WeaponBase.OffsetRecoilY 1.5

--- a/zscript/Items/Ammo/AmmoDemon.zsc
+++ b/zscript/Items/Ammo/AmmoDemon.zsc
@@ -5,7 +5,7 @@ class PB_DTech : PB_Ammo replaces demonpickup
 		Scale 0.15;
         RenderStyle "Add";
         Tag "Demon Energy";
-        Inventory.Amount 20;
+        Inventory.Amount 10;
         Inventory.MaxAmount 300;
         Inventory.PickupSound "demonsoulpickup";
         Ammo.BackpackAmount 60;
@@ -13,12 +13,18 @@ class PB_DTech : PB_Ammo replaces demonpickup
 		PB_Ammo.ammotype "dtech";
 		+FLOATBOB
 		floatbobstrength .4;
+		+INVENTORY.ALWAYSPICKUP
     }
 	
 	override void DoPickupSpecial(actor toucher)
     {
         toucher.GiveInventory("PB_ArmorBonus",1);
         Super.DoPickupSpecial(toucher);
+    }
+	override string PickupMessage()
+    {
+        if(!res) return "";
+        return Super.PickupMessage();
     }
 }
 
@@ -27,7 +33,7 @@ class PB_DTechLarge : PB_DTech replaces demonpickup2
     Default
     {
         Scale 0.25;
-        Inventory.Amount 40;
+        Inventory.Amount 20;
     }
     
     override void DoPickupSpecial(actor toucher)

--- a/zscript/Items/Ammo/AmmoPacks.zsc
+++ b/zscript/Items/Ammo/AmmoPacks.zsc
@@ -1,4 +1,4 @@
-class PB_Backpack : Backpack replaces Backpack
+class PB_Backpack : Backpack
 { 
 	mixin PB_BetterPickupSound;
 	


### PR DESCRIPTION
-change names of haste and quad actors in monsters -added upgradespawner back onto backpack spawns (new spawner made to have random chance favoring vanilla backpack spawn) -removed unmaker from upgradespawner, moved to BFG spawner at low rates -mancubus cannon drop fix
-shotgun berserk pump fix
-demon ammo always pickup (also half the ammo granted)