### PR TITLE
Juggalo Menu Cleanup Branch

### DIFF
--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -1,6 +1,6 @@
 OptionMenu "OptionsMenu"
 {
-	Title "OPTIONS"
+	Title "GGZDOOM OPTIONS"
 	Submenu "Project Brutality Settings",		"PBSettings"
 	StaticText " "
 	Submenu "Customize Controls",		"CustomizeControls"
@@ -26,31 +26,15 @@ OptionMenu "PB_HUDOptions"
 {
 	Title "Project Brutality HUD Options"
 	
-	Option "Right To Left Ammo Bar", "PB_RTLAmmoBar", "YesNo"
-    StaticText "The Ammo bar will decrease away from the center of the screen.", "White"
+	Option "Ammo Bar Drains Left-To-Right", "PB_RTLAmmoBar", "YesNo"
+	Option "HUD bobbles when moving", "PB_HudDynamics", "YesNo"
+	Option "Helmet Corners", "pb_showhudvisor", "YesNo"
+	Option "Visor Glass", "pb_showhudvisorglass", "YesNo"
+	Option "Level Stats", "pb_showlevelstats", "YesNo"
 	StaticText " "
-
-	Option "HUD Lag", "PB_HudDynamics", "YesNo"
-    StaticText "The HUD will move according to the player speed, weapon bob, turning, and head location.", "White"
+	Slider "HUD Element Horizontal Position", "pb_hudxmargin", 0, 50, 1, 0
+	Slider "HUD Element Vertical Position", "pb_hudymargin", 0, 50, 1, 0
 	StaticText " "
-
-	Slider "HUD X Margin", "pb_hudxmargin", 0, 50, 1, 0
-	Slider "HUD Y Margin", "pb_hudymargin", 0, 50, 1, 0
-    StaticText "This determines the amount of indentation of the HUD in pixels.", "White"
-	StaticText "(in 320x240 pixels)", "White"
-	StaticText " "
-
-	Option "Show Visor Corners", "pb_showhudvisor", "YesNo"
-	StaticText "Toggle visor corners.", "White"
-	StaticText " "
-	
-	Option "Show Visor Glass", "pb_showhudvisorglass", "YesNo"
-	StaticText "Toggle visor glass.", "White"
-	StaticText " "
-	
-	Option "Show Level Statistics", "pb_showlevelstats", "YesNo"
-	StaticText "Show Level Statistics on the top left corner.", "White"
-
 }
 
 OptionMenu "TiltPlusPlusMenu"
@@ -124,166 +108,103 @@ OptionMenu "PBSettings"
 {
 	Title "Project Brutality Settings"
 	StaticText " "
-	
-	Submenu "Global Settings",		"GlobalSettings"
+	Submenu "Spawn Settings",		"GlobalSettings"
 	StaticText " "
 	//StaticText " "
 	Submenu "Gameplay Settings",		"GameplaySettings"
-	StaticText " "
-	Submenu "Weapon Settings",		"WeaponSettings"
 	StaticText " "
 	Submenu "Visual Settings",		"RenderingSettings"
 	StaticText " "
 	Submenu "HUD Settings",			"PB_HUDOptions"
 	StaticText " "
-	StaticText " "
-	Option "Festive Hat Simulator Mode", "PB_HatExtravaganza", "YesOrNo"
-	StaticText " "
 }
 
 OptionMenu "GlobalSettings"
 {
-	Title "--------- Global Settings ---------"
+	Title "--------- Spawn Settings ---------"
 	StaticText " "
+	StaticText "--------- Determine what type of weapons and enemies you'll encounter. ---------"
 	StaticText " "
-	Submenu "Spawn Preset Configuration",		"SpawnPresets"
+	Submenu "Global Spawn Rules",		"SpawnPresets"
 	StaticText " "
-	StaticText "Determine what type of weapons and enemies you'll encounter."
+	Submenu "Customize Monster Spawns",		"MonsterSpawns"
 	StaticText " "
-	Title "--------- Advanced Preferences ---------"
-	StaticText " "
-	Submenu "Advanced Monster Spawns",		"MonsterSpawns"
-	StaticText " "
-	Submenu "Advanced Weapon Spawns",		"WeaponSpawns"
+	Submenu "Customize Weapon Spawns",		"WeaponSpawns"
 	StaticText " "	
 }
 
 OptionMenu "SpawnPresets"
 {
-	Title "--------- Global Settings ---------"
+	Title "--------- Global Spawn Rules ---------"
 	StaticText " "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
+	Option "SPAWN RULE: ", "SpawnBalance","PBSpawnChoices"
 	StaticText " "
-	StaticText "Defines the playstyle, and nature of progression for each preset."
+	StaticText "--------- Dynamic Progression ---------", gold
+	StaticText "Subtle curving of tiers, with overlaps between the previous/new tier."
+	StaticText "When a tier begins, spawns from the previous tier and new tier have 50/50 spawn priority." 
+	StaticText "As maps in a tier (i.e maps 9-16) progress, these ratios gradually change, until the new tier is 100% of the spawn pool by the final map."
+	StaticText "This is the intended 'vanilla' setting for Project Brutality, when playing through standard IWADS or full megawads.", green
 	StaticText " "
-	Title "--------- Spawn Presets ---------"
+	StaticText "--------- Tiered Progression ---------", gold
+	StaticText "Hard skip from tier to tier. When a tier begins, there is no subtle curving - all spawns adhere to the active tier."
 	StaticText " "
-	Submenu " - Randomized Progression - ",		"DefaultSpawnMenu"
+	StaticText "--------- Randomized Progression --------", gold
+	StaticText "Hard skips from tier to tier, but in random order (i.e. Tier 3, Tier 1, Tier 2, Tier 4)"
 	StaticText " "
-	Submenu " - Tier 1 - ",		"Tier1SpawnMenu"
+	StaticText "--------- Tier 1 ---------", gold
+	StaticText "Play with just weapons and monsters from Tier 1"
 	StaticText " "
-	Submenu " - Tier 2 - ",		"Tier2SpawnMenu"
+	StaticText "--------- Tier 2 ---------", gold
+	StaticText "Play with just weapons and monsters from Tier 2"
 	StaticText " "
-	Submenu " - Tier 3 - ",		"Tier3SpawnMenu"
+	StaticText "--------- Tier 3 ---------", gold
+	StaticText "Play with just weapons and monsters from Tier 3"
 	StaticText " "
-	Submenu " - Tier 4 - ",		"Tier4SpawnMenu"
+	StaticText "--------- Tier 4 ---------",gold
+	StaticText "Play with just weapons and monsters from Tier 4"
 	StaticText " "
-	Submenu " - Tiered Progression - ",		"TieredProgressSpawnMenu"
+	StaticText "--------- Chaotic Random ---------", gold
+	StaticText "All monsters and weapons have equal weight. You may encounter anything at any time."
+	StaticText "This is the reccomended setting for single-map mods.", green
 	StaticText " "
-	Submenu " - DeathWish - ",		"DeathWishSpawnMenu"
+	StaticText "--------- Death Wish ---------", gold
+	StaticText "The Development Team's personal choice of what we consider the toughest monsters and weakest weapons. You've been warned."
 	StaticText " "
-	Submenu " - Chaotic Random - ",		"ChaoticSpawnMenu"
 	StaticText " "
+	StaticText "TIERING IS WRITTEN UNDER THE ASSUMPTION YOU ARE PLAYING A 32 MAP MEGAWAD. NEW TIERS BEGIN AT MAPS 9, 17, AND 25.", orange
 }
-
-OptionMenu "DefaultSpawnMenu"
-{
-	Title "--------- Spawn Presets ---------"
-	StaticText " - Randomized Progression - "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
-	StaticText "Balanced variety, with a mild Progression curve."
-	StaticText " Default recommended experience."
-}
-OptionMenu "Tier1SpawnMenu"
-{
-	Title "--------- Spawn Presets ---------"
-	StaticText " - Tier 1 - "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
-	StaticText "Similar to vanilla Doom."
-	StaticText "A few Zombie variants, no 'new' Weapons except Dual-Wielding."
-}
-OptionMenu "Tier2SpawnMenu"
-{
-	Title "--------- Spawn Presets ---------"
-	StaticText " - Tier 2 - "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
-	StaticText "Nearly the same as Tier 1."
-	StaticText "Slightly higher power Weapons and Enemies."		//This is actually easier than T1 because of the extra weapons available and pretty much no harder enemy variants.
-}
-OptionMenu "Tier3SpawnMenu"
-{
-	Title "--------- Spawn Presets ---------"
-	StaticText " - Tier 3 - "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
-	StaticText "Medium level of variation."
-	StaticText "About half of what Project Brutality has to offer."
-}
-OptionMenu "Tier4SpawnMenu"
-{
-	Title "--------- Spawn Presets ---------"
-	StaticText " - Tier 4 - "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
-	StaticText "The 'end-game' preset."
-	StaticText "The fairest balance of all Weapons and Enemy types."
-}
-OptionMenu "TieredProgressSpawnMenu"
-{
-	Title "--------- Spawn Presets ---------"
-	StaticText " - Tiered Progression - "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
-	StaticText "Fight through each Tier."
-	StaticText "Each tier is 6 levels long. (Splits at, 7, 13, and 21+)"
-
-}
-OptionMenu "DeathWishSpawnMenu"
-{
-	Title "--------- Spawn Presets ---------"
-	StaticText " - DeathWish - "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
-	StaticText "Beyond the last Tier."
-	StaticText "Very difficult Enemies, but better gear available."
-}
-OptionMenu "ChaoticSpawnMenu"
-{
-	Title "--------- Spawn Presets ---------"
-	StaticText " - Chaotic Random - "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
-	StaticText "Intensely Randomized."
-	StaticText "Equal weighting for all Monster and Enemy variants."
-}
-OptionMenu "PistolStartSpawnMenu"
-{
-	Title "--------- Spawn Presets ---------"
-	StaticText " - Pistol Starts - "
-	Option "Spawn Preset: ", "SpawnBalance","PBSpawnChoices"
-	StaticText "Start from Scratch."
-	StaticText "Lose all weapons each level, but goodies are common. "
-}
-
 OptionMenu "WeaponSpawns"
 {
-	Title	"--------- Advanced Weapon Spawns ---------"
-	Option "No Revolver", "pb_NoRevolverWeapon", "YesOrNo"
-	StaticText "This also disables the Deagle"
-	StaticText "See Disable Deagle upgrade in Weapon Settings for more info"
+	Title	"--------- Weapon Spawns ---------"
+	StaticText "--------Tier 2 Weapons--------", gold
+	Option "Revolver", "pb_NoRevolverWeapon", "OffOn"
+	Option "Auto-Shotgun", "pb_NoASGWeapon", "OffOn"
+	Option "Carbine", "pb_NoCarbineWeapon", "OffOn"
+	Option "Grenade Launcher", "pb_NoSuperGLWeapon", "OffOn"
+	Option "M2 Plasma Rifle", "pb_NoM2PlasmaWeapon", "OffOn"
 	StaticText " "
-	Option "No Submachine Gun", "pb_NoSMGWeapon", "YesOrNo"
+	StaticText "--------Tier 3 Weapons-------", gold
+	Option "Sub Machine Gun", "pb_NoSMGWeapon", "OffOn"
+	Option "Pump Shogtun Magazine /w Dragon's Breath Shells",				"pb_NoDBUpgrade", "OffOn"
+	Option "Quad-Barreled Shotgun",				"pb_NoQuadSSG", "OffOn"
+	Option "Heavy DMR",				"pb_NoRifleUpgrade", "OffOn"
+	Option "Nailgun", "pb_NoNailgunWeapon", "OffOn"
+	Option "Anti-Matter Pulse Cannon",				"pb_NoPulseCannonUpgrade", "OffOn"
+	Option "Cryo Rifle", "pb_NoFreezerWeapon", "OffOn"
+	Option "Rail Gun", "pb_NoRailgunWeapon", "OffOn"
 	StaticText " "
-	Option "No Autoshotgun", "pb_NoASGWeapon", "YesOrNo"
+	StaticText "--------Tier 4 Weapons--------", gold
+	Option "'Martian Raptor' Automag pistol",				"pb_nodeagle", "OffOn"
+	Option "Auto-Shotgun Drum Magazine",				"pb_NoAutoshotgunUpgrade", "OffOn"
+	Option "LMG",				"pb_NoLMG", "OffOn"
+	Option "Triple-Barreled Minigun Modification",				"pb_NoMinigunUpgrade", "OffOn"
+	Option "M2 Lightning Gun Module",				"pb_NoM2Upgrade", "OffOn"
+	Option "The Unmaker",				"pb_NoUnmakerUpgrade", "OffOn"
 	StaticText " "
-	Option "No Carbine", "pb_NoCarbineWeapon", "YesOrNo"
-	StaticText " "
-	Option "No Nailgun", "pb_NoNailgunWeapon", "YesOrNo"
-	StaticText " "	
-	Option "No Super Grenade Launcher", "pb_NoSuperGLWeapon", "YesOrNo"
-	StaticText " "
-	Option "No M2 Plasma Rifle", "pb_NoM2PlasmaWeapon", "YesOrNo"
-	StaticText " "
-	Option "No Freezer Rifle", "pb_NoFreezerWeapon", "YesOrNo"
-	StaticText " "
-	Option "No Rail Gun", "pb_NoRailgunWeapon", "YesOrNo"
-	StaticText " "	
-	Option "No Blackhole Generator", "pb_NoBlackholeWeapon", "YesOrNo"
+	StaticText "--------Important Notes--------", orange
+	StaticText "Disabling the Revolver also disables the 'Martian Raptor'"
+	StaticText "Disabling the Carbine also disables the LMG."
+	StaticText "Disabling the base Autoshotgun also disables its drum magazine."
 	StaticText " "
 }
 
@@ -297,9 +218,8 @@ OptionMenu "GameplaySettings"
 {
 	Title "---------Game Settings---------"
 	
-	
 	StaticText " "
-	Option "Specialized Weapon Crosshairs",	"pb_weapon_crosshairs", "OnOff"
+	Option "Unique Weapon Crosshairs",	"pb_weapon_crosshairs", "OnOff"
 	StaticText "Cross is unique for each weapon (overrides custom crosshair setting)"
 	StaticText " "
 	StaticText " "
@@ -314,27 +234,13 @@ OptionMenu "GameplaySettings"
 	StaticText " "
 	StaticText " "	
 	
-	Option "Weapon Special Wheel Freezes Time",	"py_weaponwheel_freeze", "OnOff"
-	StaticText "Weapon special wheel freezes time when opened."
+	Option "Weapon Wheel Freezes Time",	"py_weaponwheel_freeze", "OnOff"
+	Option "Weapon ADS Controls","pb_toggle_aim_hold", "AimingStyle" //Looks like we are using this newer line.
 	StaticText " "
-	StaticText " "
-	
-	Option "Aiming mode","pb_toggle_aim_hold", "AimingStyle" //Looks like we are using this newer line.
-	StaticText " "
-	StaticText " "
-	
-	Option "Player Grenade bounce type", "pb_grenadeimpact", "GrenadeBounceStyle"
-	StaticText "Allows frag grenades from the player to either explode on impact (such"
-	StaticText "as a wall, a ceiling, a floor, an enemy, etc.), don't bounce or bounce like normal."
-	StaticText "Sticky Grenades are not affected."
-	StaticText " "
-	StaticText " "
-	
-	Option "Super Grenade Launcher bounce type", "pb_sglgrenadeimpact", "GrenadeBounceStyle"
-	StaticText "Allows SuperGL grenades from the player to either explode on impact (such"
-	StaticText "as a wall, a ceiling, a floor, an enemy, etc.), don't bounce or bounce like normal."
-	StaticText "Sticky Grenades are not affected."
-	StaticText " "
+	StaticText "--------Grenade Bounce/Explosion Behavior"
+	Option "Hand Grenades", "pb_grenadeimpact", "GrenadeBounceStyle"
+	Option "Grenade Launcher", "pb_sglgrenadeimpact", "GrenadeBounceStyle"
+	StaticText "Grenade Launcher 'Sticky Bombs' not affected.", orange
 	StaticText " "
 	
 	//Option "DMR / HDMR Reticle Code Source?",	 "ReticleStyle", "ReticleCode" //For ACS style reticle
@@ -404,6 +310,40 @@ OptionMenu "GameplaySettings"
 	StaticText "$PB_RECOIL_EXTRA_DESC"
 	StaticText " "
 	StaticText " "	
+	
+	StaticText "-----------------Weapon Progression-----------------"
+	
+	StaticText " "
+	Option "Revolver upgrades Pistol",				"pb_UpgradeRevolver", "OnOff"
+	StaticText "No longer use the Pistol once you collect a revolver"
+	StaticText " "
+	
+	Option "Carbine upgrades DMR",				"pb_UpgradeCarbine", "OnOff"
+	StaticText "No longer use the DMR once you collect a Carbine"
+	StaticText " "
+	
+	Option "Autoshotgun upgrades Pump Shotgun",				"pb_UpgradeShotgun", "OnOff"
+	StaticText "No longer use the Pump Shotgun once you collect a Autoshotgun"
+	StaticText " "
+	
+	Option "Nailgun upgrades Minigun",				"pb_UpgradeNailgun", "OnOff"
+	StaticText "No longer use the Minigun when you collect a Nailgun"
+	StaticText " "
+	
+	StaticText "-----------------Weapon Misc-----------------"
+
+	Option "$PB_NO_M1PLASMACOOLDOWN", "pb_nocooldown", "YesNo"
+	StaticText "$PB_NO_M1PLASMACOOLDOWN_DESC"
+	StaticText "$PB_NO_M1PLASMACOOLDOWN_NOTICE", "darkgray"
+//	StaticText "$PB_NO_M1PLASMACOOLDOWN_EXTRA", "purple"
+	StaticText " "
+
+	Option "$PB_CRYOWARMUP", "pb_fastcryowarmup", "CryoWarmupOption"
+	StaticText "$PB_CRYOWARMUP_DESC"
+	StaticText "$PB_CRYOWARMUP_DESC2"
+	StaticText "$PB_CRYOWARMUP_DESC3"
+	StaticText "$PB_CRYOWARMUP_NO"
+	StaticText " "
 }
 
 OptionMenu "RenderingSettings"
@@ -546,262 +486,87 @@ OptionMenu "MBlurOpts"
 	Slider "Samples", "mblur_samples", 1, 100, 1, 0
 	Slider "Strength", "mblur_strength", 1, 500, 8, 2
 	Slider "Recovery", "mblur_recovery", 4, 100, 4, 1
-	Submenu "Advanced", "MBlurAdvOpts"
-}
-
-OptionMenu "WeaponSettings"
-{
-	Title "---------Weapon Settings---------"
-	
-	StaticText "-----------------Weapon Upgrades-----------------"
-	
-	Option "Completely Disable Weapon Upgrades",				"pb_NoUpgrades", "OnOff"
-	StaticText " "
-	
-	Option "Disable UAC349 LMG Upgrade",				"pb_NoLMG", "OnOff"
-	StaticText "Removes the LMG that upgrades the UAC41 Carbine"
-	StaticText " "
-	
-	Option "Disable Quad-Barrel Shotgun Upgrade",				"pb_NoQuadSSG", "OnOff"
-	StaticText "Removes the Quad Shotgun that upgrades the super shotgun"
-	StaticText " "
-	
-	Option "Disable Auto-Shotgun Upgrade",				"pb_NoAutoshotgunUpgrade", "OnOff"
-	StaticText "Removes the drum magazine upgrade for the automatic shotgun"
-	StaticText " "
-	StaticText " "
-	
-	Option "Disable Triple Minigun Upgrade",				"pb_NoMinigunUpgrade", "OnOff"
-	StaticText "Removes the triple-rotary upgrade for the minigun"
-	StaticText " "
-	
-	Option "Disable Pump Shotgun Upgrade",				"pb_NoDBUpgrade", "OnOff"
-	StaticText "Removes the magazine upgrade for the pump shotgun"
-	StaticText " "
-	StaticText " "
-	
-	Option "Disable Pulse Cannon Upgrade",				"pb_NoPulseCannonUpgrade", "OnOff"
-	StaticText "Removes the dark pulse cannon upgrade for the plasma gun"
-	StaticText " "
-	StaticText " "
-	
-	Option "Disable DMR Upgrade",				"pb_NoRifleUpgrade", "OnOff"
-	StaticText "Removes the underbarrel grenade launcher for the DMR"
-	StaticText " "
-	StaticText " "
-	
-	Option "Disable Unmaker Upgrade",				"pb_NoUnmakerUpgrade", "OnOff"
-	StaticText "Removes the Unmaker upgrade for the flame cannon"
-	StaticText " "
-	StaticText " "
-	
-	Option "Disable Lightning Gun Upgrade",				"pb_NoM2Upgrade", "OnOff"
-	StaticText "Removes the lightning upgrade for the m2 plasma rifle"
-	StaticText " "
-	StaticText " "
-	
-	Option "Disable Deagle Upgrade",				"pb_nodeagle", "OnOff"
-	StaticText "Disables the Deagle replacing the revolver"
-	StaticText "If you have No Revolver turned on, leave this option off"
-	StaticText "See No Revolver in Advanced Weapon Spawns for more details"
-	StaticText " "
-	
-	StaticText "-----------------Weapon Progression-----------------"
-	
-	StaticText " "
-	Option "Revolver upgrades Pistol",				"pb_UpgradeRevolver", "OnOff"
-	StaticText "No longer use the Pistol once you collect a revolver"
-	StaticText " "
-	
-	Option "Carbine upgrades DMR",				"pb_UpgradeCarbine", "OnOff"
-	StaticText "No longer use the DMR once you collect a Carbine"
-	StaticText " "
-	
-	Option "Autoshotgun upgrades Pump Shotgun",				"pb_UpgradeShotgun", "OnOff"
-	StaticText "No longer use the Pump Shotgun once you collect a Autoshotgun"
-	StaticText " "
-	
-	Option "Nailgun upgrades Minigun",				"pb_UpgradeNailgun", "OnOff"
-	StaticText "No longer use the Minigun when you collect a Nailgun"
-	StaticText " "
-	
-	StaticText "-----------------Weapon Misc-----------------"
-
-	Option "$PB_NO_M1PLASMACOOLDOWN", "pb_nocooldown", "YesNo"
-	StaticText "$PB_NO_M1PLASMACOOLDOWN_DESC"
-	StaticText "$PB_NO_M1PLASMACOOLDOWN_NOTICE", "darkgray"
-//	StaticText "$PB_NO_M1PLASMACOOLDOWN_EXTRA", "purple"
-	StaticText " "
-
-	Option "$PB_CRYOWARMUP", "pb_fastcryowarmup", "CryoWarmupOption"
-	StaticText "$PB_CRYOWARMUP_DESC"
-	StaticText "$PB_CRYOWARMUP_DESC2"
-	StaticText "$PB_CRYOWARMUP_DESC3"
-	StaticText "$PB_CRYOWARMUP_NO"
-	StaticText " "
+	Submenu "Advanced", "MBlurAdvOpts"	
 }
 ///////////////////////////////////////////////////////////////////////////////////////	
 OptionMenu "MonsterSpawns"
 {
 	Title	"---------Monster Spawns---------"
-	StaticText "---------------Zombiemen Variants---------------"
+	StaticText "---------------Zombiemen Variants---------------", gold
+	Option "Pistol Zombiemen", "pb_NoPistolZman", "OffOn"
+	Option "Helmet Zombiemen", "pb_NoHelmetZman", "OffOn"
+	Option "Zombie Scientist", "pb_NoZombieScientist", "OffOn"
+	Option "Carbine Zombie", "pb_NoCarbineZombie", "OffOn"
+	Option "Plasma Zombie", "pb_NoPlasmaZombie", "OffOn"
 	StaticText " "
-	Option "No Pistol Zombiemen", "pb_NoPistolZman", "YesOrNo"
-		
+	StaticText "---------------Sergeant Variants---------------", gold
+	Option "Helmet Sergeant", "pb_NoHelmetSergeant", "OffOn"
+	Option "Autoshotgun Sergeant", "pb_NoAutoshotgunSergeant", "OffOn"
+	Option "Quad-Shotgun Sergeant", "pb_NoQuadSergeant", "OffOn"
+	Option "Riot Shield Sergeant", "pb_NoRiotShieldGuy", "OffOn"
+	Option "Rocket Launcher Sergeant", "pb_NoRocketSergeant", "OffOn"
 	StaticText " "
-	Option "No Helmet Zombiemen", "pb_NoHelmetZman", "YesOrNo"
+	StaticText "---------------Commando Variants---------------", gold
+	Option "Nailgun Major", "pb_NoNailgunMajor", "OffOn"
+	Option "Demon Tech Soldier", "pb_NoDemonTechSoldier", "OffOn"
+	Option "Classic Chaingun Commando", "pb_NoClassicCommando", "OffOn"
+	Option "Z-SpecOps", "pb_NoZSpecOps", "OffOn"
 	StaticText " "
-	
-	Option "No Zombie Scientist", "pb_NoZombieScientist", "YesOrNo"
+	StaticText "---------------Imp Variants---------------", gold
+	Option "T1 - Imp", "pb_NoBrownImps", "OffOn"
 	StaticText " "
-	
-	Option "No Carbine Zombie", "pb_NoCarbineZombie", "YesOrNo"
+	Option "T2 - Savage", "pb_NoSavageImps", "OffOn"
 	StaticText " "
-	
-	Option "No Plasma Zombie", "pb_NoPlasmaZombie", "YesOrNo"
+	Option "T3a - Dark", "pb_NoDarkImps", "OffOn"
 	StaticText " "
-	
-	StaticText "---------------Sergeant Variants---------------"
+	StaticText "---------------Pinky Demon Variants---------------", gold
+	Option "T2 - Blood Demons", "pb_NoBloodDemon", "OffOn"
+	Option "T3 - Mech Demons", "pb_NoMechDemon", "OffOn"
 	StaticText " "
-	Option "No Helmet Sergeant", "pb_NoHelmetSergeant", "YesOrNo"
+	StaticText "---------------Spectre Variants---------------", gold
+	Option "T2 - Void Spectre", "pb_VoidSpectre", "OffOn"
 	StaticText " "
-	
-	Option "No Autoshotgun Sergeant", "pb_NoAutoshotgunSergeant", "YesOrNo"
+	StaticText "---------------Cacodemon Variants---------------", gold
+	Option "T2 - Inferno Caco", "pb_NoMagCaco", "OffOn"
+	Option "T3 - Afrit", "pb_NoAfrit", "OffOn"
 	StaticText " "
-	
-	
-	Option "No Quad-Shotgun Sergeant", "pb_NoQuadSergeant", "YesOrNo"
+	StaticText "---------------Pain Elemental Variants---------------", gold
+	Option "T2 - Suffering Elemental", "pb_NoSufferElemental", "OffOn"
 	StaticText " "
-	
-	Option "No Riot Shield Sergeant", "pb_NoRiotShieldGuy", "YesOrNo"
+	StaticText "---------------Lost Soul Variants---------------", gold
+	Option "T2 - Phantasm", "pb_NoPhantasm", "OffOn"
 	StaticText " "
-	
-	Option "No Rocket Launcher Sergeant", "pb_NoRocketSergeant", "YesOrNo"
+	StaticText "---------------Revenant Variants---------------", gold
+	Option "T2 - Beam Revenant", "pb_NoBeamRevenant", "OffOn"
+	Option "T3 - Draugr", "pb_NoDraugr", "OffOn"
 	StaticText " "
-		
-	
-	StaticText "---------------Commando Variants---------------"
+	StaticText "---------------Arachnotron Variants---------------", gold
+	Option "T2 - Inferno Arachnotron", "pb_NoInfernoArachnotron", "OffOn"
+	Option "T3 - Arachnophyte", "pb_NoArachnophyte", "OffOn"
+	Option "T4 - Elite Arachnotron", "pb_NoArachnotron2", "OffOn"
 	StaticText " "
-	Option "No Nailgun Major", "pb_NoNailgunMajor", "YesOrNo"
+	StaticText "---------------Hell Knight Variants---------------", gold
+	Option "T2 - Cyber Hell Knight", "pb_NoCyberKnight", "OffOn"
+	Option "T3 - Cyber Hell Paladin", "pb_NoCyberPaladin", "OffOn"
 	StaticText " "
-	
-	Option "No Demon Tech Soldier", "pb_NoDemonTechSoldier", "YesOrNo"
+	StaticText "---------------Baron of Hell Variants---------------", gold
+	Option "T2 - Cyber Baron", "pb_NoCyberBaron", "OffOn"
+	Option "T3 - Belphegor", "pb_NoBelphegor", "OffOn"
+	Option "T4 - Infernus", "pb_NoInfernus", "OffOn"
 	StaticText " "
-	
-	Option "No Classic Chaingun Commando", "pb_NoClassicCommando", "YesOrNo"
+	StaticText "---------------Mancubus Variants---------------", gold
+	Option "T2 - Daedabus", "pb_NoDaedabus", "OffOn"
+	Option "T3 - Volcabus", "pb_NoVolcabus", "OffOn"
 	StaticText " "
-	
-	Option "No Z-SpecOps", "pb_NoZSpecOps", "YesOrNo"
+	StaticText "---------------Archvile Variants---------------", gold
+	Option "T2 - Hellion", "pb_NoHellion", "OffOn"
 	StaticText " "
-	
-	StaticText "---------------Imp Variants---------------"
+	StaticText "---------------Spider Mastermind Variants---------------", gold
+	Option "T2 - Demolisher", "pb_NoDemolisher", "OffOn"
+	Option "T3 - Juggernaut", "pb_NoJuggernaut", "OffOn"
 	StaticText " "
-	Option "No Brown Variants", "pb_NoBrownImps", "YesOrNo"
-	StaticText " "
-	
-	Option "No Savage Variants", "pb_NoSavageImps", "YesOrNo"
-	StaticText " "
-	
-	Option "No Dark Variants", "pb_NoDarkImps", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Pinky Demon Variants---------------"
-	StaticText " "
-	Option "No Blood Demons", "pb_NoBloodDemon", "YesOrNo"
-	StaticText " "
-	
-	Option "No Mech Demons", "pb_NoMechDemon", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Spectre Variants---------------"
-	StaticText " "
-	Option "No Void Spectre", "pb_VoidSpectre", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Cacodemon Variants---------------"
-	StaticText " "
-	Option "No Inferno Caco", "pb_NoMagCaco", "YesOrNo"
-	StaticText " "
-	
-	Option "No Afrit", "pb_NoAfrit", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Pain Elemental Variants---------------"
-	StaticText " "
-	Option "No Suffering Elemental", "pb_NoSufferElemental", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Lost Soul Variants---------------"
-	StaticText " "
-	Option "No Phantasm", "pb_NoPhantasm", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Revenant Variants---------------"
-	StaticText " "
-	Option "No Beam Revenant", "pb_NoBeamRevenant", "YesOrNo"
-	StaticText " "
-	
-	StaticText " "
-	Option "No Draugr Revenant", "pb_NoDraugr", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Arachnotron Variants---------------"
-	StaticText " "
-	Option "No Inferno Arachnotron", "pb_NoInfernoArachnotron", "YesOrNo"
-	StaticText " "
-
-	Option "No Arachnophyte", "pb_NoArachnophyte", "YesOrNo"
-	StaticText " "
-	
-	StaticText " "
-	Option "No Elite Arachnotron", "pb_NoArachnotron2", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Hell Knight Variants---------------"
-	StaticText " "
-	Option "No Cyber Hell Knight", "pb_NoCyberKnight", "YesOrNo"
-	StaticText " "
-	
-	Option "No Cyber Hell Paladin", "pb_NoCyberPaladin", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Baron of Hell Variants---------------"
-	StaticText " "
-	Option "No Cyber Baron", "pb_NoCyberBaron", "YesOrNo"
-	StaticText " "
-	
-	Option "No Belphegor", "pb_NoBelphegor", "YesOrNo"
-	StaticText " "
-	
-	Option "No Infernus", "pb_NoInfernus", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Mancubus Variants---------------"
-	StaticText " "
-	Option "No Daedabus", "pb_NoDaedabus", "YesOrNo"
-	StaticText " "
-	
-	StaticText " "
-	Option "No Volcabus", "pb_NoVolcabus", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Archvile Variants---------------"
-	StaticText " "
-	Option "No Hellion", "pb_NoHellion", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Spider Mastermind Variants---------------"
-	StaticText " "
-	Option "No Demolisher", "pb_NoDemolisher", "YesOrNo"
-	StaticText " "
-	
-	StaticText " "
-	Option "No Juggernaut", "pb_NoJuggernaut", "YesOrNo"
-	StaticText " "
-	
-	StaticText "---------------Cyber Demon Variants---------------"
-	StaticText " "
-	Option "No Annihilator", "pb_NoAnnihilator", "YesOrNo"
+	StaticText "---------------Cyber Demon Variants---------------", gold
+	Option "T2 - Annihilator", "pb_NoAnnihilator", "OffOn"
 	StaticText " "
 }
 
@@ -1063,4 +828,3 @@ OptionValue "NashGoreGibTypes"
 	1, "$NASHGOREMNU_GIB_TYPE_NOSTICKYGIBS"
 	2, "$NASHGOREMNU_VANILLA"
 }
-


### PR DESCRIPTION
Removed recursive menu options in the 'global settings' (Spawn) menu that led to the same place.

Renamed the Global Settings menu to 'Spawn Settings", as well as changed the description and variables for the monster and weapon spawns. Did not change any CVar values, but rewrote in such a way so there are no 'double negatives'. On now means on and Off  now means off.

Added proper descriptions to the spawn logic rules, and the menu for it is just a single option. (FIGURE OUT DYNAMIC TOOLTIPS TO HAVE A SINGLE DESCRIPTION CHANGE WHEN THE USER CYCLES OPTIONS)

Cleaned up HUD settings submenu to appear much cleaner, made descriptions clear and concise

Removed the 'Festive Hat' option from the menu, (CVar is still present for Popguy - he wants to make it dynamically appear when a user's computer is in December)

Removed the 'weapon settings' submenu, and migrated the options from it to Spawn and Gameplay settings. Respectively, these were

1 - Weapon Disables from 'weapon' settings' are now migrated into spawn settings> Customize weapon spawns 2 Weapon Progression, Plasma Rifle, and Cyro Rifle settings from 'weapon settings' migrated into Gameplay Settings.

Color-coded all subtitles gold, to be more in line with other settings such as the Tilt++ and PB keybind menus

Downsized the 2 grenade settings in 'Gameplay Settings' to be uniform and appear as one section.