### PR TITLE
Assorted patches

### DIFF
--- a/MODELS/Definitions/LegacyBlood.txt
+++ b/MODELS/Definitions/LegacyBlood.txt
@@ -71,6 +71,26 @@ Model PB_BloodSpot      // Name of actor in DECORATE
    FrameIndex BPDL D 0 0 
 }
 
+Model PB_BloodSpotTiny      // Name of actor in DECORATE
+{
+   Path "models/bloodspot"    // Path to model in PK3
+   Model 0 "bloodspot.md3"    // Model index, model file
+   Scale 6.0 6.0 1.0            // Scale values
+   ZOffset 0.01
+   
+   Skin 0 "bloodspothd2.png"     // Model index, texture (can be in any format supported by GZDoom)
+   FrameIndex BPDL A 0 0        
+   
+   Skin 0 "bloodspothd.png"     
+   FrameIndex BPDL B 0 0    
+   
+   Skin 0 "bloodspothd.png"     
+   FrameIndex BPDL C 0 0     
+   
+   Skin 0 "bloodspothd.png" 
+   FrameIndex BPDL D 0 0 
+}
+
 Model PB_BloodSpotCeiling     // Name of actor in DECORATE
 {
    Path "models/bloodspot"    // Path to model in PK3

--- a/zscript/Footsteps.zs
+++ b/zscript/Footsteps.zs
@@ -144,6 +144,10 @@ class PB_Footsteps : Actor
 			if (FLATS_GRAVEL[i] == texname)
 				return "step/gravel";
 		}
+		for (int i = 0; i < FLATS_WATER.Size(); i++) {
+			if (FLATS_WATER[i] == texname)
+				return "step/water";
+		}
 		return "step/default";
 	}
 	
@@ -179,7 +183,9 @@ class PB_Footsteps : Actor
 		};
 		
 		//"step/slime"
-		static const name FLATS_SLIME[] = {	"BDT_WFL", "BDT_BFL", "BDT_AFL", "BDT_SFL1", "BDT_SFL2", "BLOOD1", "BLOOD2", "BLOOD3", "NUKAGE1", "NUKAGE2", "NUKAGE3", "SLIME01", "SLIME02", "SLIME03", "SLIME04", "SLIME05", "SLIME06", "SLIME07", "SLIME08", "FWATER1", "FWATER2", "FWATER3", "FWATER4" };
+		static const name FLATS_SLIME[] = {	"BDT_WFL", "BDT_BFL", "BDT_AFL", "BDT_SFL1", "BDT_SFL2", "NUKAGE1", "NUKAGE2", "NUKAGE3", "SLIME01", "SLIME02", "SLIME03", "SLIME04", "SLIME05", "SLIME06", "SLIME07", "SLIME08" };
+		//"step/water"
+		static const name FLATS_WATER[] = { "FWATER1", "FWATER2", "FWATER3", "FWATER4", "BLOOD1", "BLOOD2", "BLOOD3" };
 		//"step/slimy"
 		static const name FLATS_SLIMY[] = { "SFLR6_1","SFLR6_4","SFLR7_1","SFLR7_4" };
 		//"step/lava"

--- a/zscript/Gore/NashGore/NashGoreBlood.zc
+++ b/zscript/Gore/NashGore/NashGoreBlood.zc
@@ -59,7 +59,7 @@ class NashGoreBloodBase : Blood replaces Blood
 
 		double ang = frandom(0, 360);
 
-		LineTrace(ang, 96, frandom(-90, 0), flags, 0, data: t);
+		LineTrace(ang, 32, frandom(-90, 0), flags, 0, data: t);
 
 		if (t.HitType == t.TRACE_HitCeiling)
 		{
@@ -860,7 +860,7 @@ class NashGoreBloodDrop : NashGoreBloodBase
 		TNT1 A 0
 		{
 			A_SpawnItemEx("NashGoreBloodFloorSplash", flags: BLOOD_FLAGS);
-			A_SpawnItemEx("PB_BloodSpot", flags: (BLOOD_FLAGS | SXF_TRANSFERPOINTERS) & ~SXF_NOCHECKPOSITION);
+			A_SpawnItemEx("PB_BloodSpotTiny", flags: (BLOOD_FLAGS | SXF_TRANSFERPOINTERS) & ~SXF_NOCHECKPOSITION);
 			if (random() < 180) A_StartSound("nashgore/blooddrop");
 		}
 		Stop;

--- a/zscript/Gore/PBBlood.zc
+++ b/zscript/Gore/PBBlood.zc
@@ -462,6 +462,14 @@ class PB_BloodSpot : NashGoreBloodPlane //replaces Brutal_BloodSpot // Temporary
 		}
 }
 
+class PB_BloodSpotTiny : PB_BloodSpot
+{
+	Default
+	{
+		Scale 0.2;
+	}
+}
+
 class PB_BloodSpotCeiling : PB_BloodSpot
 {
 	Default

--- a/zscript/PbWheel/ev_core_special.zsc
+++ b/zscript/PbWheel/ev_core_special.zsc
@@ -1274,10 +1274,10 @@ if (players[consoleplayer].ReadyWeapon == NULL)
          }
 			if(e.name == 'PBEquipSpecialOn')
 		{
+			wheelShow.Clear();
 
 			if (players[consoleplayer].mo.FindInventory("CantWeaponSpecial"))
 			{
-				wheelShow.Clear();
 				wheelIsOpen = false;
 				noWheel = true;
 				return;

--- a/zscript/PlayerPawn.zc
+++ b/zscript/PlayerPawn.zc
@@ -708,7 +708,7 @@ class PlayerPawnBase : PlayerPawn
 				return;
 			}
 		
-			else if(Player.OnGround && !BlockJump && !FindInventory("GoFatality"))
+			else if(Player.OnGround && !BlockJump)
 			{
 				Float JumpVelZ = pb_jumpheight;
 				Float JumpFac = GetPowerJump();
@@ -2365,6 +2365,9 @@ class PlayerPawnBase : PlayerPawn
 	{
 		Super.Tick();
 		
+		//Just to make sure NO TRACES of this softlocking motherfucker is left -generic name guy
+		A_SetInventory("GoFatality", 0);
+		
 		CheckTargetHitRegistration();
 		
 		//Screen Overlay Handlers
@@ -2680,7 +2683,7 @@ Class DEDashJump : Inventory 						///Dash and double jump code by TheCamaleonMa
 			GiveInventory("EvadeCheck", 1);
 		}
 		
-		if(Owner.CheckInventory("ExecutionToken", 1) || Owner.CheckInventory("GoFatality",1)) {
+		if(Owner.CheckInventory("ExecutionToken", 1)) {
 				Owner.vel.x = 0;
 				Owner.vel.y = 0;
 				DashTics = 0;

--- a/zscript/Weapons/BaseWeapon.zc
+++ b/zscript/Weapons/BaseWeapon.zc
@@ -338,8 +338,7 @@ class PB_WeaponBase : DoomWeapon
 		Melee_Equipment_Handler_Overlay:
 			TNT1 A 1 {
 				
-				if(JustPressed(BT_USER1) && !PB_usingMelee() && !PB_executingEnemy() && !PB_usingEquipment() &&
-				!CheckInventory("GoFatality",1) && !CheckInventory("CantDoAction",1)) 
+				if(JustPressed(BT_USER1) && !PB_usingMelee() && !PB_executingEnemy() && !PB_usingEquipment() && !CheckInventory("CantDoAction",1)) 
 				{
 					A_OverlayOffset(PSP_WEAPON, 0, 32);
 					PB_SetUsingEquipment(true);
@@ -347,8 +346,7 @@ class PB_WeaponBase : DoomWeapon
 					A_OverlayOffset(PSP_WEAPON, 0, 32);
 				}
 			
-				if(JustPressed(BT_USER2) && !PB_usingMelee() && !PB_executingEnemy() && !PB_usingEquipment() && !CheckInventory("Zoomed", 1)
-				&& !CheckInventory("GoFatality",1) && !CheckInventory("CantDoAction",1)) 
+				if(JustPressed(BT_USER2) && !PB_usingMelee() && !PB_executingEnemy() && !PB_usingEquipment() && !CheckInventory("Zoomed", 1) && !CheckInventory("CantDoAction",1)) 
 				{
 					A_OverlayOffset(PSP_WEAPON, 0, 32);
 					PB_SetUsingMelee(true);
@@ -359,8 +357,7 @@ class PB_WeaponBase : DoomWeapon
 			Loop;
 		KickHandler_Overlay:
 			TNT1 A 1 {
-				if(JustPressed(BT_USER4) && !PB_usingKick() && !PB_executingEnemy() && !CheckInventory("Zoomed", 1) && PB_MeleeAttackKickCheck() &&
-				!CheckInventory("GoFatality",1)) 
+				if(JustPressed(BT_USER4) && !PB_usingKick() && !PB_executingEnemy() && !CheckInventory("Zoomed", 1) && PB_MeleeAttackKickCheck())
 				{
 					PB_SetUsingKick(true);
 					A_OverlayOffset(-999, 0, 32);
@@ -576,9 +573,8 @@ class PB_WeaponBase : DoomWeapon
 			}
 			Goto FirstPersonLegsStand;
 
-		
+
 		Steady:
-			TNT1 A 1 A_JumpIfInventory("GoFatality",1,"Steady");
 			Goto GoingToReady;
 	}
 }

--- a/zscript/Weapons/BaseWeapon_Barrels.zsc
+++ b/zscript/Weapons/BaseWeapon_Barrels.zsc
@@ -88,7 +88,6 @@ extend class PB_WeaponBase //Barrels. Pope, why's your code so jank? It looks fu
 			BANE HIJKLMN 1;
 			TNT1 A 0 A_StartSound("weapons/fistwhoosh");
 			BANE ONLJH 1;
-			TNT1 A 0 A_JumpIfInventory("GoFatality",1,"Steady");
 			TNT1 A 0 PB_BarrelThrow("Barrel","Grab");
 			THRF ABCDEF 2;
 			goto GoingToReady;
@@ -98,7 +97,6 @@ extend class PB_WeaponBase //Barrels. Pope, why's your code so jank? It looks fu
 			BAFE HIJKLMN 1;
 			TNT1 A 0 A_StartSound("weapons/fistwhoosh");
 			BAFE ONLJH 1;
-			TNT1 A 0 A_JumpIfInventory("GoFatality",1,"Steady");
 			TNT1 A 0 PB_BarrelThrow("FlameBarrel","FGrab");
 			THRF ABCDEF 2;
 			goto GoingToReady;
@@ -108,14 +106,13 @@ extend class PB_WeaponBase //Barrels. Pope, why's your code so jank? It looks fu
 			BAIE HIJKLMN 1;
 			TNT1 A 0 A_StartSound("weapons/fistwhoosh");
 			BAIE ONLJH 1;
-			TNT1 A 0 A_JumpIfInventory("GoFatality",1,"Steady");
 			TNT1 A 0 PB_BarrelThrow("IceBarrel","IGrab");
 			THRF ABCDEF 2;
 			goto GoingToReady;
 		
 		//Place
 		PlaceBarrel:
-			TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady");
+			
 			BANE GFEDCBA 1;
 			PKPB HGFEDCBA 1;
 			TNT1 A 0 {
@@ -131,7 +128,7 @@ extend class PB_WeaponBase //Barrels. Pope, why's your code so jank? It looks fu
 			}
 			goto CompletePlacement;
 		PlaceFlameBarrel:
-			TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady");
+			
 			BAFE GFEDCBA 1;
 			PKPB HGFEDCBA 1;
 			TNT1 A 0 {
@@ -147,7 +144,7 @@ extend class PB_WeaponBase //Barrels. Pope, why's your code so jank? It looks fu
 			}
 			goto CompletePlacement;
 		PlaceIceBarrel:
-			TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady");
+			
 			BAIE GFEDCBA 1;
 			PKPB HGFEDCBA 1;
 			TNT1 A 0 {

--- a/zscript/Weapons/BaseWeapon_Functions.zsc
+++ b/zscript/Weapons/BaseWeapon_Functions.zsc
@@ -895,7 +895,7 @@ extend class PB_WeaponBase
 			"IdleFlameBarrel"
 		};
 		if (!(pbFlags & PBWEAP_UNLOADED)) pbFlags |= CheckUnloaded(invoker.UnloaderToken);
-		if (CountInv("GoFatality")>=1 || PB_executingEnemy())
+		if (PB_executingEnemy())
 		{
 			return ResolveState("Steady");
 		}

--- a/zscript/Weapons/BaseWeapon_Melee.zsc
+++ b/zscript/Weapons/BaseWeapon_Melee.zsc
@@ -72,7 +72,6 @@ extend class PB_WeaponBase
 				A_ZoomFactor(1.0);
 				A_GiveInventory("Kicking",1);
 				}
-			TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady");
 			TNT1 A 0 A_JumpIfInventory("CanSlideKick", 1, "SlideKick");
 			TNT1 A 0 A_JumpIf (vel.Z != 0, "AirKick");
 			TNT1 A 0 A_OverlayFlags(-999,PSPF_PLAYERTRANSLATED, true);


### PR DESCRIPTION
- Blood drops spawn a smaller floor splat instead of a full-sized one

- Blood ceiling spawn distance is now less ridiculous

- Added proper water footsteps

- Curbstomps no longer softlock the game, only makes the enemy invisible (not going through every enemy and pushing every single individual file for that)

- (Possibly futile) attempt to fix "array access out of bounds" bug with the weapon special wheel