### PR TITLE
Fix special deaths for weapons

### DIFF
--- a/actors/Weapons/Slot3/SSG.dec
+++ b/actors/Weapons/Slot3/SSG.dec
@@ -354,7 +354,7 @@ ACTOR PB_SSG : PB_weapon //Replaces SuperShotgun
 			if(CountInv("LeftSSGAmmo") == 1) {
 				A_AlertMonsters;
 				//A_FireBullets(9, 6, 10, 7, "ShotgunPuff");
-				PB_FireBullets("PB_10GAPellet",9,6,0,0,6);
+				PB_FireBullets("PB_10GAPellet_LP",9,6,0,0,6);
 				A_PlaySoundEx("weapons/shh2", "Weapon");
 				A_FireCustomMissile("GunFireSmokE", 0, 0, -3, 0, 0, 0);
 				A_FireCustomMissile("GunFireSmoke", 0, 0, -5, 0, 0, 0);
@@ -367,7 +367,7 @@ ACTOR PB_SSG : PB_weapon //Replaces SuperShotgun
 			else {
 				A_AlertMonsters;
 				//A_FireBullets (12, 6, 20, 7, "ShotgunPuff");
-				PB_FireBullets("PB_10GAPellet",18,6,0,0,6);
+				PB_FireBullets("PB_10GAPellet_LP",18,6,0,0,6);
 				A_FireCustomMissile("GunFireSmokE", 0, 0, 3, 0, 0, 0);
 				A_FireCustomMissile("GunFireSmoke", 0, 0, 5, 0, 0, 0);
 				A_PlaySoundEx("SSHFIRE", "Weapon");
@@ -415,7 +415,7 @@ ACTOR PB_SSG : PB_weapon //Replaces SuperShotgun
 			if(CountInv("SSGAmmoCounter") == 1){
 				A_AlertMonsters;
 				//A_FireBullets(9, 6, 10, 7, "ShotgunPuff");
-				PB_FireBullets("PB_10GAPellet",9,6,0,0,6);
+				PB_FireBullets("PB_10GAPellet_LP",9,6,0,0,6);
 				A_PlaySoundEx("weapons/shh2", "Weapon");
 				A_FireCustomMissile("GunFireSmokE", 0, 0, -3, 0, 0, 0);
 				A_FireCustomMissile("GunFireSmoke", 0, 0, -5, 0, 0, 0);
@@ -427,7 +427,7 @@ ACTOR PB_SSG : PB_weapon //Replaces SuperShotgun
 			else {
 				A_AlertMonsters;
 				//A_FireBullets (12, 6, 20, 7, "ShotgunPuff");
-				PB_FireBullets("PB_10GAPellet",18,6,0,0,6);
+				PB_FireBullets("PB_10GAPellet_LP",18,6,0,0,6);
 				A_FireCustomMissile("GunFireSmokE", 0, 0, -3, 0, 0, 0);
 				A_FireCustomMissile("GunFireSmoke", 0, 0, -5, 0, 0, 0);
 				A_PlaySoundEx("SSHFIRE", "Weapon");
@@ -525,7 +525,7 @@ ACTOR PB_SSG : PB_weapon //Replaces SuperShotgun
         SHO9 A 1 BRIGHT {
 			A_GunFlash;
 			//A_FireBullets (12, 6, 20, 7, "ShotgunPuff");
-			PB_FireBullets("PB_10GAPellet",18,6,0,0,6);
+			PB_FireBullets("PB_10GAPellet_LP",18,6,0,0,6);
 			A_FireCustomMissile("GunFireSmokE", 0, 0, 2, 0, 0, 0);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, -2, 0, 0, 0);
 			A_PlaySoundEx("SSHFIRE", "Weapon");
@@ -568,7 +568,7 @@ ACTOR PB_SSG : PB_weapon //Replaces SuperShotgun
 		SHTA A 1 BRIGHT {
 			A_GunFlash;
 			//A_FireBullets(9, 6, 10, 7, "ShotgunPuff");
-			PB_FireBullets("PB_10GAPellet",9,6,0,0,6);
+			PB_FireBullets("PB_10GAPellet_LP",9,6,0,0,6);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, 2, 0, 0, 0);
 			A_PlaySoundEx("weapons/shh2", "Weapon");
 			A_TakeInventory("SSGAmmoCounter", 1);
@@ -596,7 +596,7 @@ ACTOR PB_SSG : PB_weapon //Replaces SuperShotgun
 		SHTA C 1 BRIGHT {
 			A_GunFlash;
 			//A_FireBullets(9, 6, 10, 7, "ShotgunPuff");
-			PB_FireBullets("PB_10GAPellet",9,6,0,0,6);
+			PB_FireBullets("PB_10GAPellet_LP",9,6,0,0,6);
 			A_FireCustomMissile("GunFireSmoke", 0, 0, -2, 0, 0, 0);
 			A_PlaySoundEx("weapons/shh2", "Weapon");
 			A_TakeInventory("SSGAmmoCounter", 1);

--- a/zmapinfo.txt
+++ b/zmapinfo.txt
@@ -6,6 +6,7 @@ map TITLEMAP "PB_Introduction"
 map PBTEST "Testing Grounds"
 {
 	AllowRespawn
+        Sky1 = "SKY1", 0.1
 }
 
 ClearSkills

--- a/zscript/Weapons/Projectiles/BulletDef.HighCal.zsc
+++ b/zscript/Weapons/Projectiles/BulletDef.HighCal.zsc
@@ -14,7 +14,7 @@ class PB_556x45mmAP : PB_556x45mm
 	{
 		PB_Projectile.RipperCount 5;
 		Obituary "%o was torn to shreds by %k.";
-		Damagetype "Cutless";
+		Damagetype "Minigun";
 	}
 }
 

--- a/zscript/Weapons/Projectiles/BulletDef.Shell.zsc
+++ b/zscript/Weapons/Projectiles/BulletDef.Shell.zsc
@@ -31,6 +31,17 @@ class PB_10GAPellet : PB_Projectile
 	}
 }
 
+class PB_10GAPellet_LP : PB_Projectile
+{
+	Default
+	{
+		PB_Projectile.BaseDamage 30;
+		PB_Projectile.RipperCount 2;
+		Damagetype "SSG";
+		Obituary "%o was blown up inside out by %k.";
+	}
+}
+
 class PB_8GAPellet : PB_Projectile
 {
 	Default

--- a/zscript/Weapons/Projectiles/BulletProjectile.zsc
+++ b/zscript/Weapons/Projectiles/BulletProjectile.zsc
@@ -20,11 +20,11 @@ class PB_Projectile : FastProjectile abstract
 		{
 			//Console.Printf("Critical");
 			scaled_damage = scaled_damage * ((ptrPBMon) ? ptrPBMon.dmgTorsoMult : 1.1);
-			dmgtype = "TorsoHitbox";
+			dmgtype = damagetype;
 			if (Pos.Z > victim.Pos.Z + victim.Height * ((ptrPBMon) ? ptrPBMon.posHeadHB : 0.80))
 			{
 				//Console.Printf("Headshot");
-				dmgtype = "HeadHitbox";
+				dmgtype = "Head";
 				//A_StartSound("headshotmarker", CHAN_AUTO, CHAN_UI);
 				scaled_damage = scaled_damage * ((ptrPBMon) ? ptrPBMon.dmgHeadMult : 1.25);
 			}
@@ -39,14 +39,14 @@ class PB_Projectile : FastProjectile abstract
 			{
 				//Console.Printf("Dick Shot");
 				//A_StartSound("apenshotmarker", CHAN_AUTO, CHAN_UI);
-				dmgtype = "DickHitbox";
+				dmgtype = "Dick";
 				scaled_damage = scaled_damage * ((ptrPBMon) ? ptrPBMon.dmgDickMult : 0.95);
 			}
 			else
 			{
 				//Console.Printf("Legshot");
 				//A_StartSound("apenshotmarker", CHAN_AUTO, CHAN_UI);
-				dmgtype = "LegHitbox";
+				dmgtype = "Leg";
 				scaled_damage = scaled_damage * ((ptrPBMon) ? ptrPBMon.dmgLegMult : 0.8);
 			}
 		}
@@ -54,13 +54,13 @@ class PB_Projectile : FastProjectile abstract
 		{
 			//Console.Printf("Armshot");
 			//A_StartSound("apenshotmarker", CHAN_AUTO, CHAN_UI);
-			dmgtype = "ArmHitbox";
+			dmgtype = "Arm";
 			scaled_damage = scaled_damage * ((ptrPBMon) ? ptrPBMon.dmgArmMult : 0.7);
 		}
 		else
 		{
 			//A_StartSound("bodyshotmarker", CHAN_AUTO, CHAN_UI);
-			dmgtype = "LowTorsoHitbox";
+			dmgtype = damagetype;
 			scaled_damage = scaled_damage * ((ptrPBMon) ? ptrPBMon.dmgLowTorsoMult : 1);
 		}
 		


### PR DESCRIPTION
Previously broken because they were always overriden by the torso hitboxes.

Also fixes monsters not reacting to the new hitbox system.