### PR TITLE
Morph VM Abort Fix

### DIFF
--- a/zscript/Player/ZSPlayer.zsc
+++ b/zscript/Player/ZSPlayer.zsc
@@ -149,6 +149,10 @@ class PB_PlayerPawn : PlayerPawnBase
     Spawn:
         PLAY A 1
         {
+            let psp = player.FindPSprite(PSP_WEAPON);
+            let pspOverlay = player.FindPSprite(OverlayID());
+            if (!psp||!pspOverlay)
+                return;
             ForceMoveUnlock();
             A_Overlay(-50,"spinloop");
             A_TakeInventory("PlayerIsDead",1);


### PR DESCRIPTION
Added null checks to the player spawn state to prevent the overlay calling to a non-existent player sprite.