### PR TITLE
Black hole updates and fixes.

### DIFF
--- a/actors/Weapons/Slot8/BFGMKIV.dec
+++ b/actors/Weapons/Slot8/BFGMKIV.dec
@@ -281,34 +281,24 @@ ACTOR PB_BFG9000: PB_Weapon Replaces BFG9000
 		Fire_Blackhole:
 			TNT1 A 0 A_JumpIfInventory("PB_Cell",100,1)
 			Goto FailedToFirePurple
-			TNT1 A 0 {
+			TNT1 A 0
+			{
 				A_StopSound(CHAN_WEAPON);
-				//A_StartSound("weapons/bh_primary1", CHAN_BODY);
-			///	A_StartSound("weapons/bh_primary2", CHAN_5);
-			///	A_StartSound("weapons/bfg_chargeloop", CHAN_6);
-			///	A_StartSound("DSVBH", CHAN_7);
 				A_StartSound("bh_Charge", CHAN_WEAPON,1.0, ATTN_NORM, false); //CHAN_WEAPON
-				
-				
 			}
 			023G ABCDEFGHIJKLMNOPQRSTUVWXYZ 1 BRIGHT 
 			024G ABCDEFGH 1 BRIGHT
-			TNT1 A 0 {
-	///			A_StartSound("weapons/bh_primary3", CHAN_6);
-				
-				
-			}
 			024G IJKLMNOPQRSTUVWXYZ 1 BRIGHT
 			025G ABCDEFGHIJKLMNOPQRSTUVWXYZ 1 BRIGHT PB_FireOffset
-			026G ABC 1 BRIGHT {
+			026G ABC 1 BRIGHT
+			{
 				A_FireCustomMissile("ShakeYourAss", 0, 0, 0, 0);
 				PB_FireOffset;
 			}
-			TNT1 A 0 {
-				//A_StopSound(CHAN_BODY);
+			TNT1 A 0
+			{
 				A_StopSound(CHAN_6);
 				A_StopSound(CHAN_7);
-		///		A_StartSound("DMC/Fire", CHAN_WEAPON);
 				A_FireCustomMissile("Blackhole_Ball",0,1,0,0);
 				A_TakeInventory("PB_Cell", 100);
 			}
@@ -470,8 +460,7 @@ ACTOR PB_BFG9000: PB_Weapon Replaces BFG9000
 	}
 }
 
-
-
+//BFG Black Hole mode alt fire
 ACTOR BlackHole_GravityBomb
 {
 	Projectile
@@ -493,79 +482,82 @@ ACTOR BlackHole_GravityBomb
 	+NODAMAGETHRUST
 	+EXTREMEDEATH
 	Species "Marines"
-	//DeathType Crush
-// 	Alpha 0.9
 	States
 	{
-	  Spawn:
-		TNT1 A 0 NoDelay A_StartSound("PLSBULB", CHAN_5, CHANF_LOOPING)
+		Spawn:
+			TNT1 A 0 NoDelay A_StartSound("PLSBULB", CHAN_5, CHANF_LOOPING)
 		Fly:
-			031G ABCDEFGHIJKLMNOPQRSTUVWXYZ 1 bright Light("BlackholeBallSmall"){
+			031G ABCDEFGHIJKLMNOPQRSTUVWXYZ 1 bright Light("BlackholeBallSmall")
+			{
 				A_SpawnItemEx("PurpleTrailSparksSmall", 0, 0, 0, 0, 0, 0, 0, 128);
 				A_SetRoll(roll-10);
 			}   
-			032G ABCD 1 bright Light("BlackholeBallSmall"){
+			032G ABCD 1 bright Light("BlackholeBallSmall")
+			{
 				A_SpawnItemEx("PurpleTrailSparksSmall", 0, 0, 0, 0, 0, 0, 0, 128);
 				A_SetRoll(roll-10);
 			}  
 			Loop
-	  Death:
-		TNT1 A 0 { 
-			A_SpawnItem("TinyBlackHoleSingularity");
-			A_RadiusThrust(-5000,800, RTF_NOIMPACTDAMAGE);
-			A_StopSound(CHAN_5);
-			A_StartSound("DSPBCN", CHAN_AUTO);
-			A_CustomMissile ("PurplePlasmaFire", 0, 0, random (0, 360), 2, random (0, 360));
-			A_CustomMissile ("PurpleShockWave", 0, 0, random (0, 360), 2, random (0, 360));
-			A_CustomMissile ("PurpleShockWave_Flat", 0, 0, random (0, 360), 2, random (0, 360));
+		Death:
+			TNT1 A 0
+			{ 
+				A_SpawnItem("TinyBlackHoleSingularity");
+				A_RadiusThrust(-5000,800, RTF_NOIMPACTDAMAGE);
+				A_StopSound(CHAN_5);
+				A_StartSound("DSPBCN", CHAN_AUTO);
+				A_CustomMissile ("PurplePlasmaFire", 0, 0, random (0, 360), 2, random (0, 360));
+				A_CustomMissile ("PurpleShockWave", 0, 0, random (0, 360), 2, random (0, 360));
+				A_CustomMissile ("PurpleShockWave_Flat", 0, 0, random (0, 360), 2, random (0, 360));
+			}
+			TNT1 AAAAA 0 A_CustomMissile ("PurplePlasmaParticle", 0, 0, random (0, 360), 2, random (0, 360))
+			031G ABCDEFGHIJK 1 BRIGHT Light("BlackholeBallSmall")
+			{
+				A_SetScale(ScaleX-0.01, ScaleY-0.01);
+				A_RadiusThrust(-10,800,0);
+			}
+			TNT1 A 0 A_Explode(220, 120, 0, 0, 120)
+			031G ABCDEFGHIJK 1 BRIGHT Light("BlackholeBallSmall") 
+			TNT1 A 1 Light("BlackholeBallSmall") {A_Blast (0,80,800,25);a_log ("the big bad wolf blew the house away");} //Push away even harder.
+			Stop
 		}
-		TNT1 AAAAA 0 A_CustomMissile ("PurplePlasmaParticle", 0, 0, random (0, 360), 2, random (0, 360))
-		031G ABCDEFGHIJK 1 BRIGHT Light("BlackholeBallSmall") {
-			A_SetScale(ScaleX-0.01, ScaleY-0.01);
-			A_RadiusThrust(-10,800, RTF_NOIMPACTDAMAGE);
-		}
-		TNT1 A 0 A_Explode(220, 120, 0, 0, 120, 0, 0, "NullPuff")
-		TNT1 AAAAAAAAAAAAAAAAAAAA 1 Light("BlackholeBallSmall")
-		Stop
-  }
 }
 
 ACTOR PurpleShockWave
 { 
-   Speed 0
-   Height 64 
-   Radius 32
-   Scale 1.3
-   RenderStyle add
-   Alpha 0.25
-   +NOINTERACTION
-   +NOGRAVITY 
-   States 
-   { 
-   Spawn: 
-     // SH0K ABCDEFGHIJKLMNOPQR 1 BRIGHT A_FadeOut(0.08)
-	  SH0K RQPONMLKJIHGFEDCBA 1 BRIGHT A_FadeIn(0.1)
-      Stop 
+	Speed 0
+	Height 64 
+	Radius 32
+	Scale 1.3
+	RenderStyle add
+	Alpha 0.25
+	+NOINTERACTION
+	+NOGRAVITY 
+	States 
+	{ 
+		Spawn: 
+			// SH0K ABCDEFGHIJKLMNOPQR 1 BRIGHT A_FadeOut(0.08)
+			SH0K RQPONMLKJIHGFEDCBA 1 BRIGHT A_FadeIn(0.1)
+			Stop 
 	}
 }
 
 ACTOR PurpleShockWave_Flat
 { 
-   Speed 0
-   Height 64 
-   Radius 32
-   Scale 1.3 
-   RenderStyle add
-   Alpha 0.25
-   +NOINTERACTION
-   +NOGRAVITY
-   +FLATSPRITE
-   States 
-   { 
-   Spawn: 
-     // SH0K ABCDEFGHIJKLMNOPQR 1 BRIGHT A_FadeOut(0.08)
-	  SH0K RQPONMLKJIHGFEDCBA 1 BRIGHT A_FadeIn(0.1)
-      Stop 
+	Speed 0
+	Height 64 
+	Radius 32
+	Scale 1.3 
+	RenderStyle add
+	Alpha 0.25
+	+NOINTERACTION
+	+NOGRAVITY
+	+FLATSPRITE
+	States 
+	{ 
+	Spawn: 
+		// SH0K ABCDEFGHIJKLMNOPQR 1 BRIGHT A_FadeOut(0.08)
+		SH0K RQPONMLKJIHGFEDCBA 1 BRIGHT A_FadeIn(0.1)
+		Stop 
 	}
 }
 
@@ -588,11 +580,9 @@ Actor BlackHoleSingularity : BFGExtra
 
 Actor TinyBlackHoleSingularity : BlackHoleSingularity 
 {
-  Alpha .9
-  Scale 1.35
+	Alpha .9
+	Scale 1.35
 }
-
-
 
 ACTOR BFG_BeamProjectile : MageWandMissile
 {
@@ -683,11 +673,12 @@ Actor Blackhole_Ball
 			TNT1 A 0 A_CustomMissile ("PurpleShockWave_Flat", 0, 0, random (0, 360), 2, random (0, 360))
 			TNT1 A 0 A_StopSound(CHAN_5)
 			TNT1 A 0 A_StartSound("weapons/bh_app", CHAN_5)
-			029G ABCDEFGHIJKLM 1 Bright Light("BlackholeBall") {
+			029G ABCDEFGHIJKLM 1 Bright Light("BlackholeBall")
+			{
 				A_SetScale(ScaleX-0.02, ScaleY-0.02);
 				Radius_Quake (8, 16, 0, 200, 0);//(intensity, duration, damrad, tremrad, tid)
 			}
-			TNT1 A 0 A_SpawnItem("PB_BlackHole",0,0,0)
+			TNT1 A 0 A_SpawnItemEx ("PB_BlackHole",0,0,0,0,0,0,0,SXF_SETTARGET) //Set the projectiles target AKA shooter as the black holes' source, for proper kill credit.
 			Stop
 		}
 }

--- a/actors/Weapons/Slot8/BlackHole.zc
+++ b/actors/Weapons/Slot8/BlackHole.zc
@@ -1,69 +1,71 @@
 class PB_BlackHole : Actor
 {
-  Default
-  {
-    Radius 20;
-    Height 20;
-    Speed 0;
-    Projectile;
-    +NOBLOCKMAP;
-    +DONTHARMSPECIES;
-    +NODAMAGETHRUST;
-    -THRUGHOST;
-    +Ripper;
-    +NOBOSSRIP;
-    +ForcePain;
-    +FORCEYBILLBOARD;
-    +FORCERADIUSDMG;
-    +NOEXTREMEDEATH;
-    +Friendly;
-    +DONTSPLASH;
-    +RollSprite;
-    RenderStyle "Normal";
-    DamageType "BlackHole";
-    Scale 0.05;
-    ReactionTime 360;
-    Obituary "%o got absorbed by the darkness.";
-  }
+	Default
+	{
+		Radius 20;
+		Height 20;
+		Speed 0;
+		Projectile;
+		+NOBLOCKMAP;
+		+DONTHARMSPECIES;
+		+NODAMAGETHRUST;
+		-THRUGHOST;
+		+Ripper;
+		+NOBOSSRIP;
+		+ForcePain;
+		+FORCEYBILLBOARD;
+		+FORCERADIUSDMG;
+		+NOEXTREMEDEATH;
+		+Friendly;
+		+DONTSPLASH;
+		+RollSprite;
+		RenderStyle "Normal";
+		DamageType "BlackHole";
+		Scale 0.05;
+		ReactionTime 360;
+		Obituary "%o got absorbed by the darkness.";
+	}
 	
-
+	Bool Succ;
+	
 	States
 	{
 		Spawn:
-		//	TNT1 A 0 A_StartSound("weapons/bh_sucksound", CHAN_7, CHANF_LOOPING);
 			TNT1 A 0;
 			TNT1 A 0 A_StartSound("bh_EXPLONG", CHAN_6, 1.0, ATTN_NORM, false);
 			TNT1 A 0 A_StartSound("bh_Sound", CHAN_7, 1.0, ATTN_NORM, false);
 			TNT1 A 0 A_SetScale(3.0);
-			QHOL ABCDEFGHIJKLMNOP 1 BRIGHT Light("BlackholeVoid") {
-				A_Explode(20,200);
-				A_RadiusThrust(-700,1200, RTF_NOIMPACTDAMAGE);
+			QHOL ABCDEFGHIJKLMNOP 1 BRIGHT Light("BlackholeVoid")
+			{
+				Succ = True;
+				//A_Explode(20,200);
+				//A_RadiusThrust(-700,1200, RTF_NOIMPACTDAMAGE);
 			}
 			
 			TNT1 A 0 A_SetRoll(0);
 		Exist:
 			VHOL ABCDEFGHIJKLMNOPQRSTUVWXYZ 1 Bright Light("BlackholeVoid") {
 				//A_SetRoll(roll-10);
-				A_Explode(20,200);
-				A_RadiusThrust(-700,1200, RTF_NOIMPACTDAMAGE);
+				//A_Explode(20,200);
+				//A_RadiusThrust(-700,1200, RTF_NOIMPACTDAMAGE);
 				A_CountDown();
 			}
 			WHOL ABCDEFGHIJKLMNOPQRSTUVWXYZ 1 Bright Light("BlackholeVoid") {
 				//A_SetRoll(roll-10);
-				A_Explode(20,200);
-				A_RadiusThrust(-700,1200, RTF_NOIMPACTDAMAGE);
+				//A_Explode(20,200);
+				//A_RadiusThrust(-700,1200, RTF_NOIMPACTDAMAGE);
 				A_CountDown();
 			}
 			ZHOL ABCDEFGHIJKLMNOPQR 1 Bright Light("BlackholeVoid") {
 				//A_SetRoll(roll-10);
-				A_Explode(20,200);
-				A_RadiusThrust(-700,1200, RTF_NOIMPACTDAMAGE);
+				//A_Explode(20,200);
+				//A_RadiusThrust(-700,1200, RTF_NOIMPACTDAMAGE);
 				A_CountDown();
 			}
 			
 			TNT1 A 0 A_Jump(249, 2);
-			TNT1 A 0 {
-				//A_StartSound("DMBall/Impact", CHAN_AUTO, CHANF_OVERLAP);
+			TNT1 A 0
+			{
 				A_SpawnItemEx("BlackHoleLightning", random(-120, 120), random(-120, 120), random(-5, 120));
 				A_Quake(8,4,0,400, "None");
 			}
@@ -76,84 +78,87 @@ class PB_BlackHole : Actor
 			TNT1 A 0 A_StartSound("BHole/Explosion", CHAN_AUTO);
 			TNT1 A 0 Bright A_SpawnItem("PurpleShockWave",0,0,0); //PurpleTrailSparks
 			BHOL AAAAAAAAAAAAAAAAAA 0 A_SpawnItemEx("PurpleTrailSparks", 0, 0, 0, 0, 0, 0, 0, 128);
-			EHOL ABCDEFGHIJKLMNO 1 Bright Light("BlackholeVoid"){
-				A_FadeOut(0.06);
-			}
+			EHOL ABCDEFGHIJKLMNO 1 Bright Light("BlackholeVoid") A_FadeOut(0.067);
 			Stop;
-	
 	}
 	
     override void Tick() 
     {
         Super.Tick();
-		
+		If (IsFrozen() || !Succ) Return; //Don't do this if frozen.
 
         // Define the pull radius and outer radius
-        double pullRadius = 1024.0;
-        double outerRadius = 256.0;
-        double scaleFactor = 60.0;  // Adjust this value to change the exponential effect
+        double pullRadius = 512.0;
+        double outerRadius = 1024.0;
+        double scaleFactor = 80.0;  // Adjust this value to change the exponential effect
+		double DeathRadius = 200; //[inkoalawetrust] The radius in which actors are harmed. Once we finally decide to move to 4.11, just use A_Explode with XF_THRUSTLESS and XF_CIRCULAR !
 
         ThinkerIterator it = ThinkerIterator.Create("Actor");
 
         Actor act;
-        while ( act = Actor(it.Next()) )
+        while (act = Actor(it.Next()))
         {
-            // Ensure it is really an Actor before proceeding
-            if (!act) continue;
+            // Ensure it exists, is not an item is not yourself, is not another black hole, and is actually affected by thrust.
+            if (!act || act is "Inventory" || act == self || act is "PB_BlackHole") continue;
 
-            // Calculate distance to the actor
-            double dx = pos.x - act.pos.x;
-            double dy = pos.y - act.pos.y;
-          //  double distance = sqrt(dx*dx + dy*dy);
-			double distance = Distance3D(act);
+			double distance = Distance3DSquared(act);
 
-            // Skip this iteration if actor is the BlackHole itself, out of range, or other specific conditions
-            if (act == self || distance > outerRadius || act is "PB_BlackHole" || act is "PlayerPawn") 
-            {
+            // Skip this iteration if out of range.
+            if (distance > OuterRadius*OuterRadius ) 
                 continue;
-            }
-
+			
+			double dx = pos.x - act.pos.x;
+			double dy = pos.y - act.pos.y;
+			Double DistSQ = Distance != 0 ? Distance / Distance : 0; //Un-squared distance
+			
+			//Fade screen to purple the closer the player is.
+			If (Act.Player)
+			{
+				Double Intensity = PB_Math.LinearMap (Distance3D (Act), PullRadius, 0, 0.0, 0.8); //Map the distance to the black hole to an alpha range of 0.0 to 0.8.
+				//console.printf ("player black hole fade intensity %.4f, intensity with alpha included is %.4f",intensity,intensity*alpha);
+				Let Urple = Color (0, 128, 0, 128);
+				Act.Player.BlendA = Intensity*Alpha; //Ignore the alpha component (Of the color variable).
+				Act.Player.BlendR = Urple.R;
+				Act.Player.BlendG = Urple.G;
+				Act.Player.BlendB = Urple.B;
+			}
+			
+			// [inkoalawetrust] Hurt everything, including monsters with NORADIUSDMG, since this technically isn't an explosion.
+			If (!Act.bMissile && !Act.bNoBlockmap)
+				Act.DamageMobj (Self,Target,GetRadiusDamage (Act,20,DistSQ),DamageType,DMG_THRUSTLESS);
+			
             // Logic for actors within the pull radius
-            if (distance <= pullRadius) 
+            if (distance <= PullRadius*PullRadius) 
             {
-                double force = exp(-(distance / scaleFactor));
-                
-             //   act.Vel.X += dx * force;
-             //   act.Vel.Y += dy * force;
-
+                Double MissileForce = Exp(-(DistSQ / (ScaleFactor * 0.0001)));
                 // If it's a projectile and close enough, just delete it
-                if (act.bMissile && distance < 60.0)
-                {
+                if (act.bMissile && distance < 60.0*60.0)
                     act.Destroy();
-                }
-				else if (act.bMissile && distance > 60.0)
+				else if (act.bMissile && distance > 60.0*60.0)
 				{
-					act.Vel.X += dx * force;
-					act.Vel.Y += dy * force;
+					act.Vel.X += dx * MissileForce;
+					act.Vel.Y += dy * MissileForce;
 				}
-				
-				
-				
+				else if (!act.bMissile && !act.bNoBlockmap)
+				{
+					Vector3 ActorForce = PB_Math.AngleToVector3D (AngleTo(Act),-PitchTo (Act,Height/2,Height/2),-Exp(-(DistSQ / ScaleFactor)));
+					//console.printf ("pushing non-projectile actor %s with a force of %.2f %.2f %.2f",act.getclassname(),actorforce);
+					Act.Vel += ActorForce;
+				}
             } 
             else 
             {
                 // Change the projectile's velocity for the slingshot effect
                 if (act.bMissile) 
                 {
-					
 					Vector2 slingVelocity = (dx, dy);
-                    double slingFactor = 0.05;  // Adjust to change the strength of the slingshot
+                    double slingFactor = 0.005;  // Adjust to change the strength of the slingshot
                     act.Vel.X += slingVelocity.x * slingFactor;
                     act.Vel.Y += slingVelocity.y * slingFactor;
-				//	 let dir = Level.Vec3Diff(act.pos, self.pos).Unit();
-				//	 act.vel = dir * 50;
+					//TODO: Shouldn't this also affect vertical velocity ?
                 }
             }
         }
     }
-
-
-
-
 }
 	

--- a/zscript/DeathFader.zc
+++ b/zscript/DeathFader.zc
@@ -13,13 +13,18 @@ class DeathFader : Inventory {
 	override void DoEffect()
 	{
 		Bool Deadass = IsDead (Owner);
-		if (counttoblack <= 2 && Deadass)
-			owner.A_SetBlend("black", 1.0, 5, "black", 1.0);
 		If (!Deadass)
 		{
-			Owner.A_SetBlend("black", 0, 0, "black", 0);
+			Owner.A_SetBlend("Black",0,0);
+			//[inkoalawetrust] BUG: STOP FUCKING FADING TO BLACK AFTER RESPAWNING OH MY GOD
+			If (Owner.Player)
+				Owner.Player.BlendA = Owner.Player.BlendR = Owner.Player.BlendG = Owner.Player.BlendB = 0.0; 
 			GoAwayAndDie();
+			Return;
 		}
+		
+		if (counttoblack <= 2 && Deadass)
+			owner.A_SetBlend("black", 1.0, 5, "black", 1.0);
 		counttoblack--;
 	}
 }

--- a/zscript/MathNMixins.zsc
+++ b/zscript/MathNMixins.zsc
@@ -5,6 +5,19 @@ class PB_Math abstract
 		double cosp = cos(pitch);
 		return (cos(angle)*cosp, sin(angle)*cosp, -sin(pitch)) * mag;
 	}
+	
+	//[inkoalawetrust] Written by Agent_Ash, makes the Val ranging from O_Min to O_Man be crushed down to the range of N_Min and N_Max.
+	//Useful for example for compressing distances to a range of 0 to 1.0.
+	ClearScope Static Double LinearMap (Double Val, Double O_Min, Double O_Max, Double N_Min, Double N_Max) 
+	{
+		Return (Val - O_Min) * (N_Max - N_Min) / (O_Max - O_Min) + N_Min;
+	}
+	
+	//CREDIT: RicardoLuis0
+	ClearScope Static Vector3 AngleToVector3D(Double Angle, Double Pitch, Double Len = 1.0)
+	{
+		Return (Cos(Angle)*Cos(Pitch)*Len,Sin(Angle)*Cos(Pitch)*Len,Sin(Pitch)*Len);
+	}
 }
 
 //[inkoalawetrust] CheckActorExists(), IsDead(), and IsInState() are copied from my KAI library.

--- a/zscript/PBHandler.zc
+++ b/zscript/PBHandler.zc
@@ -121,6 +121,7 @@ class PB_EventHandler : EventHandler
 		
 		Stats.Counters[PB_GlobalStats.Counter_LevelsCompleted]++;
 	}
+	
 	override void PlayerEntered(PlayerEvent e)
 	{
 		let plr = PlayerPawnBase(players[e.PlayerNumber].mo);
@@ -140,6 +141,19 @@ class PB_EventHandler : EventHandler
 		
 		/////////////////////
 	}
+	
+	//BUG: This somehow does not stop the death fader from fading the view to black even after resurrecting.
+	/*override void PlayerRespawned (PlayerEvent e)
+	{
+		let plr = PlayerPawnBase(players[e.PlayerNumber].mo);
+		if (plr)
+		{
+			Plr.A_TakeInventory ("PlayerIsDead",1);
+			Plr.A_TakeInventory ("DeathFader",1);
+			Plr.A_SetBlend("Black",0,0);
+			Plr.Player.BlendA = Plr.Player.BlendR = Plr.Player.BlendG = Plr.Player.BlendB = 0.0; 
+		}
+	}*/
 	
 	override void WorldLoaded(WorldEvent e)
 	{


### PR DESCRIPTION
- The BFGs' primary black hole alt fire has been overhauled, it now only uses the thinker iterator in Tick() for sucking all actors in, including non-projectiles like players and enemies (But ignores actors not on the blockmap). It also no longer sucks in items.
- Fixed the black holes' ranges, now the projectile slingshot effect actually works (Since the inner radius isn't larger than the outer radius). Also increased the inner pull radius from 256 map units to 512, and slightly buffed the strength of the pushing (The player can still easily run out of it).
- Updated the BFG 9000s' gravity bombs, now they also repulse actors away after pushing them in, and will also do impact damage on the victims pushed in or out of the bomb.
- Fixed some code formatting. Also made another attempt at fixing the post-respawn death fade bug to no avail.