### PR TITLE
Fixed black holes sucking in teleport destinations

### DIFF
--- a/actors/Effects/TELEPORTS.dec
+++ b/actors/Effects/TELEPORTS.dec
@@ -49,12 +49,13 @@ ACTOR BrutalTeleportDest: TeleportDest Replaces TeleportDest
 	-BLOODSPLATTER
 	+BLOODLESSIMPACT 
 	+FORCERADIUSDMG
+	+DONTTHRUST
 	Damagetype "TeleportRemover"
 	States
 	{
 	Death:
 	Spawn:
-	TNT1 A 0
+	TNT1 A 0 NoDelay A_ChangeLinkFlags (True) // DO NOT STAY IN THE GODDAMN BLOCKMAP
 	TNT1 A 0 A_SpawnItem("TeleportRemovalThing")
 	
 	Live:
@@ -74,6 +75,7 @@ ACTOR TeleportRemovalThing
 	+FORCERADIUSDMG
 	+FLOORCLIP
 	+DONTSPLASH
+	+NOBLOCKMAP +DONTTHRUST //[inkoalawetrust] Why the fuck were teleport destinations in the blockmap ?
 	Mass 9999
 	Radius 0
 	Height 0
@@ -82,7 +84,7 @@ ACTOR TeleportRemovalThing
 	{
 	Death:
 	Spawn:
-	TNT1 A 0
+	TNT1 A 0 NoDelay A_ChangeLinkFlags (True) // DO NOT STAY IN THE GODDAMN BLOCKMAP
 	TNT1 A 5
 	TNT1 A 0 A_Explode(3, 32, 0)
 	TNT1 A 0 ThrustThingZ(0,-30,0,1)

--- a/actors/Weapons/Slot8/BlackHole.zc
+++ b/actors/Weapons/Slot8/BlackHole.zc
@@ -160,11 +160,9 @@ class PB_BlackHole : Actor
 				{
 					Vector3 ActorForce = PB_Math.AngleToVector3D (AngleTo(Act),-PitchTo (Act,Height/2,Height/2),-Exp(-(Distance / ScaleFactor)) );
 					//console.printf ("pushing non-projectile actor %s with a force of %.2f %.2f %.2f",act.getclassname(),actorforce);
-				//	Act.Vel += ActorForce.PlusZ (Act.GetGravity()); //Also counter gravity when succ.
+					//Act.Vel += ActorForce.PlusZ (Act.GetGravity()); //Also counter gravity when succ.
 				
 					//Act.Vel += ActorForce;
-					
-
 					
 					//Console.Printf("Actor %s is added", act.GetClass());
 					if (affectedActors.Find(act) == affectedActors.Size())
@@ -173,8 +171,6 @@ class PB_BlackHole : Actor
 						act.bTHRUACTORS = True;
 						act.bTHRUSPECIES = True;
 					}
-					
-
 
 					double actorForceMagnitude = Exp(-(distance / scaleFactor)); // You may need to adjust the function and scaleFactor
 
@@ -185,13 +181,11 @@ class PB_BlackHole : Actor
 					dy /= length;
 					dz /= length;
 					
-
 					// Apply the force to the actor's velocity
 					Act.Vel.X += dx * actorForceMagnitude;
 					Act.Vel.Y += dy * actorForceMagnitude;
 					//Act.Vel.Z += dz ;
 					Act.Vel.Z += ActorForce.z ;
-
 				}
 				else if (act.Player)
 				{


### PR DESCRIPTION
This commit fixes black holes sucking and being able to delete teleport destinations, and breaking teleporters as a result. For some reason teleport destinations ended up in the blockmap despite having +NOBLOCKMAP.