### PR TITLE
equipment wheel fix

### DIFF
--- a/zscript/PbWheel/ev_core_special.zsc
+++ b/zscript/PbWheel/ev_core_special.zsc
@@ -1303,7 +1303,7 @@ if (players[consoleplayer].ReadyWeapon == NULL)
 			{
 				if(wheelShow.Size()>0)
 				{
-					int curSelMod = wheelShow[currentSelection];
+					int curSelMod; if (currentSelection >= wheelShow.Size()) { curSelMod = wheelShow[0]; } else { curSelMod = wheelShow[currentSelection]; }
 					players[consoleplayer].mo.A_GiveInventory(wheelSpecials[curSelMod].specialName);
 					players[consoleplayer].mo.A_GiveInventory("ToggleEquipment");
 					S_StartSound("menu/choose",5);


### PR DESCRIPTION
Final fix (based on Darkneece's fix, did the weapon special but somehow I forgot the equipment) just in case a console vm abort occurs with the wheel again.
Fixes #826 