### PR TITLE
Added CheckReplacee()

### DIFF
--- a/zscript/PBHandler.zc
+++ b/zscript/PBHandler.zc
@@ -288,4 +288,43 @@ class PB_EventHandler : EventHandler
 			EventHandler.SendNetworkEvent("PB_MonthCheck", HatMonthInt);
 		}
 	}
+	
+	//
+	// for correct special level monster handling
+	//
+	// [J1H0] This is basically telling "x is a replacement for y" so if a level special (like Doom II map07) requires all 'y' to die to activate a platform it'll also count for 'x'
+	//	*this doesnt include all current pb monsters, just the ones that usually cause errors for replacing the og monster (and impeding you finish the level correctly)
+	override void CheckReplacee(ReplacedEvent e)
+	{
+		switch(e.replacement.getclassname())
+		{
+			//cyberdemon
+			case 'PB_Annihilator': e.replacee = 'Cyberdemon'; Break;
+			case 'PB_Cyberdemon': e.replacee = 'Cyberdemon'; Break;
+			
+			//mastermind
+			case 'PB_Demolisher': e.replacee = 'SpiderMastermind'; Break;
+			case 'PB_Juggernaut': e.replacee = 'SpiderMastermind'; Break;
+			case 'PB_Mastermind': e.replacee = 'SpiderMastermind'; Break;
+			
+			//barons
+			case 'PB_Infernus': e.replacee = 'BaronOfHell'; Break;
+			case 'PB_CyberBaron': e.replacee = 'BaronofHell'; Break;
+			case 'PB_Belphegor': e.replacee = 'BaronofHell'; Break;
+			case 'PB_Baron': e.replacee = 'BaronofHell'; Break;
+			
+			//spiders
+			case 'PB_Arachnophyte': e.replacee = 'Arachnotron'; Break;
+			case 'PB_Arachnotron': e.replacee = 'Arachnotron'; Break;
+			case 'Aracnorb': e.replacee = 'Arachnotron'; Break;
+			case 'PB_EliteArachnotron': e.replacee = 'Arachnotron'; Break;
+			case 'PB_InfernalArachnotron': e.replacee = 'Arachnotron'; Break;
+			
+			//mancubi
+			case 'PB_Daedabus': e.replacee = 'Fatso'; Break;
+			case 'PB_Mancubus': e.replacee = 'Fatso'; Break;
+			case 'PB_Volcabus': e.replacee = 'Fatso'; Break;
+		}
+	}
+	
 }


### PR DESCRIPTION
Added CheckReplacee() to the pb event handler

So all pb monster variants count for levels that needs an specific monster. 
This fixes map07 walls lowering before all mancubi died, or E1M8 lowering the walls before the two barons died, and prevents possible errors of that kind regarding those monsters

-this doesnt include all the pb monsters yet, just those involved in the levels mentioned above and bosses.