### PR TITLE
Fixed rippers and improved the nailgun projectiles.

### DIFF
--- a/zmapinfo.txt
+++ b/zmapinfo.txt
@@ -235,7 +235,7 @@ DoomEdNums
 	23078 = PB_DemonTechZombie
 	23079 = PB_NailgunMajor
 	23080 = PB_ZSpecOps
-	23081 = PB_Imp
+	23081 = PB_Imp1
 	23082 = DNImpVariant1
 	23083 = DNImpVariant2
 	23084 = DNImpVariant3

--- a/zscript/MathNMixins.zsc
+++ b/zscript/MathNMixins.zsc
@@ -1,6 +1,6 @@
 class PB_Math abstract
 {
-	static vector3 VecFromAngles(double angle, double pitch, double mag = 1.)
+	ClearScope Static Vector3 VecFromAngles (double angle, double pitch, double mag = 1.)
 	{
 		double cosp = cos(pitch);
 		return (cos(angle)*cosp, sin(angle)*cosp, -sin(pitch)) * mag;
@@ -17,6 +17,32 @@ class PB_Math abstract
 	ClearScope Static Vector3 AngleToVector3D(Double Angle, Double Pitch, Double Len = 1.0)
 	{
 		Return (Cos(Angle)*Cos(Pitch)*Len,Sin(Angle)*Cos(Pitch)*Len,Sin(Pitch)*Len);
+	}
+	
+	Enum Vec3RelFlags
+	{
+		V3R_NOANGLE = 1 << 1, //Do not rotate based on angle.
+		V3R_NOPITCH = 1 << 2, //Do not rotate based on pitch.
+		V3R_NOROLL	= 1 << 3, //Do not rotate based on roll.
+		
+		V3R_ANGLEONLY = V3R_NOPITCH|V3R_NOROLL
+	}
+	
+	//Like Vec3Offset, but also rotates the output vector based on the callers' angle.
+	//Other: The actor to offset from.
+	//Offs: The vector3 offsets to use.
+	//NoPortal: Should the function account for static portals or not ?
+	//Flags: See above for list of flags.
+	ClearScope Static Vector3 Vec3OffsetRelative (Actor Other, Vector3 Offs, Bool NoPortal = False, Int Flags = 0)
+	{
+		If (!Other) Return (Double.NaN,Double.NaN,Double.NaN);
+		Double Angle, Pitch, Roll;
+		If (!(Flags & V3R_NOANGLE)) Angle = Other.Angle;
+		If (!(Flags & V3R_NOPITCH)) Pitch = Other.Pitch;
+		If (!(Flags & V3R_NOROLL)) Roll = Other.Roll;
+		
+		Quat Dir = Quat.FromAngles (Angle,Pitch,Roll);
+		Return Level.Vec3Offset (Other.Pos,Dir * Offs,NoPortal);
 	}
 }
 

--- a/zscript/Weapons/Projectiles/BulletDef.SpecialProjectiles.zsc
+++ b/zscript/Weapons/Projectiles/BulletDef.SpecialProjectiles.zsc
@@ -1,3 +1,51 @@
+//[inkoalawetrust]: Make the ripping nailgun projectiles stick on the last actor they rip.
+//NOTE: This uses the tracer pointer because PB_Projectile has +HITTRACER on by default.
+//TODO: Somehow make them move relative to moving sectors like doors and lifts ? Also have them break or something if they end up moving into the floor.
+Mixin Class PB_NailgunGlue
+{
+	Override Void OnExplode (Int Type)
+	{
+		Super.OnExplode (Type);
+		
+		bNoGravity = True;
+		//IDEA: Maybe for bleeding actors have the nail spawn the actors' blood occasionally on the spot it landed at ? Especially for larger ones like javelins.
+		//BUG: Due to Brutal Spaghetti, this will often lead to nails sticking on those stupid headshot targets that immediately despawn. No way around it.
+		If ((Type == EType_Actor || Type == EType_BleedingActor))
+		{
+			StickOnVictim = True;
+			HitOffsets = Level.Vec3Diff (Tracer.Pos,Pos);
+			If (Type == EType_BleedingActor && GetClassName() != "PB_MGNailHot" && GetClassName() != "PB_JavelinProjectile_Hot")
+				BleedAmount = Random (16,32);
+		}
+	}
+	
+	Bool StickOnVictim;
+	Vector3 HitOffsets;
+	Int BleedAmount; //How many times the final victim of the nail should bleed. Only appears on standard nails and javelins.
+	
+	Override Void Tick()
+	{
+		Super.Tick();
+		
+		//If you are supposed to stick on victims, check if you hit (No longer a missile), and if you have a pointer to the victim.
+		If ((!IsFrozen() || Tracer && Tracer.bNoTimeFreeze) && StickOnVictim && !bMissile && Tracer && Tracer.bSolid)
+		{
+			SetOrigin (PB_Math.Vec3OffsetRelative (Tracer,HitOffsets),True); //https://www.youtube.com/watch?v=EXjfvx-k1Ms
+			If (BleedAmount && Random (0, 255) < 16)
+			{
+				BleedAmount--;
+				SpawnBlood (Pos,AngleTo (Tracer),20);
+			}
+		}
+		
+		If (bNoGravity && StickOnVictim && Tracer && !Tracer.bSolid) //Victim died and fell, fall down too now that you're unstuck.
+		{
+			bNoGravity = StickOnVictim = False;
+			Gravity = 1.0;
+		}
+	}
+}
+
 class PB_MGNail : PB_Projectile
 {
 	Default
@@ -7,11 +55,14 @@ class PB_MGNail : PB_Projectile
 		Damagetype "Nail";
 		DeathSound "Weapons/NailHit";
 		Scale 0.5;
+		Gravity 0.6;
 		Speed 100;
 		RenderStyle "Normal";
 		
 		Obituary "%o was filled with nails by %k.";
 	}
+	
+	Mixin PB_NailgunGlue;
 	
 	States
 	{
@@ -23,18 +74,22 @@ class PB_MGNail : PB_Projectile
 			TNT1 A 0;
 			NLPJ A 1;
 			Loop;
+			Loop;
 		Crash:
 		Death:
 			TNT1 A 0 A_StopSound(CHAN_BODY);
 			TNT1 A 0 A_SpawnItemEx("HitPuff");
 			TNT1 A 0 A_Stop();
-			NLPJ A 70 ;
+			NLPJ A 70;
 			NLPJ A 4200;
-			NLPJ AAAAA 1  A_FadeOut(0.2,FTF_REMOVE | FTF_CLAMP);
+			NLPJ AAAAA 1 A_FadeOut(0.2,FTF_REMOVE | FTF_CLAMP);
 			Stop;
 		XDeath:
 			TNT1 A 0 A_StopSound(CHAN_BODY);
 			NLPJ B 0 A_StartSound("Weapons/NailHitBleed");
+			NLPJ B 70;
+			NLPJ B 4200;
+			NLPJ BBBBB 1 A_FadeOut(0.2,FTF_REMOVE | FTF_CLAMP);
 			Stop;
 	}
 }
@@ -76,6 +131,9 @@ class PB_MGNailHot : PB_MGNail
 		XDeath:
 			TNT1 A 0 A_StopSound(CHAN_BODY);
 			NLPJ B 0 A_StartSound("Weapons/NailHitBleed");
+			NLPJ B 70;
+			NLPJ B 4200;
+			NLPJ BBBBB 1 A_FadeOut(0.2,FTF_REMOVE | FTF_CLAMP);
 			Stop;
 	}
 }
@@ -96,8 +154,10 @@ class PB_JavelinProjectile : PB_Projectile
 		RenderStyle "Normal";
 		Gravity 0.14;
 		
-		Obituary "%o was filled with bullets by %k.";
+		Obituary "%o was nailed by %k.";
 	}
+	
+	Mixin PB_NailgunGlue;
 	
 	States
 	{
@@ -131,6 +191,8 @@ class PB_JavelinProjectile : PB_Projectile
 		XDeath:
 			TNT1 A 0 A_StopSound(CHAN_BODY);
 			NAIL B 0 A_StartSound("Weapons/NailHitBleed");
+			NAIL B 70 ;
+			NAIL BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB 1 A_FadeOut(0.02);
 			Stop;
 	}
 }
@@ -139,7 +201,7 @@ class PB_JavelinProjectile_Hot : PB_Projectile
 {
 	Default
 	{
-		PB_Projectile.BaseDamage 420;
+		PB_Projectile.BaseDamage 420; //Extra devious blunt.
 		PB_Projectile.RipperCount 7;
 		
 		Damagetype "Blast";
@@ -151,8 +213,10 @@ class PB_JavelinProjectile_Hot : PB_Projectile
 		RenderStyle "Normal";
 		Gravity 0.14;
 		
-		Obituary "%o was filled with bullets by %k.";
+		Obituary "%o was crucified by %k.";
 	}
+	
+	Mixin PB_NailgunGlue;
 	
 	States
 	{
@@ -189,6 +253,8 @@ class PB_JavelinProjectile_Hot : PB_Projectile
 		XDeath:
 			TNT1 A 0 A_StopSound(CHAN_BODY);
 			NAIL A 0 A_StartSound("Weapons/NailHitBleed");
+			NAIL B 70 ;
+			NAIL BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB 1 A_FadeOut(0.02);
 			Stop;
 	}
 }
@@ -219,18 +285,15 @@ class PB_MicroMissileProjectile : PB_Projectile
 		Fly:
 			MICR AAAABBBBCCCCAAAABBBBCCCC 1 Bright Light("ROCKET")
 			{
-				if(waterlevel < 1) {
+				if(waterlevel < 1)
 					A_SpawnItemEx("RocketTrailSparks",-10,0,0,-5,0,0);
-				}
 			}
 		Fly2: //for makin it fly off in different directions
 			MICR AAABBBCCC 1 Bright Light("ROCKET")
 			{
 				A_Weave(3,3,frandom(-5,5),frandom(-5,5));
 				if(waterlevel < 1)
-				{
 					A_SpawnItemEx("RocketTrailSparks",-10,0,0,-5,0,0);
-				}
 			}
 			loop;
 		Crash:

--- a/zscript/Weapons/Projectiles/BulletProjectile.zsc
+++ b/zscript/Weapons/Projectiles/BulletProjectile.zsc
@@ -66,47 +66,77 @@ class PB_Projectile : FastProjectile abstract
 		
 		scaled_damage = victim.GetModifiedDamage(dmgType, scaled_damage, false, self, target);
 		
-		victim.DamageMobJ(self, target, ceil(scaled_damage), dmgType, 0, angle);
+		victim.DamageMobj(self, target, ceil(scaled_damage), dmgType, 0, angle);
 		
 		if( victim.bISMONSTER && !victim.bNOBLOOD ) 
 			victim.SpawnBlood( pos, angle, ceil(scaled_damage) );
 		
 		OnHitActor(target, dmgType);
-		if (bRIPPER && target.bBOSS && bNOBOSSRIP)
-		{
-			MustExplode = true;
-		}
+		if (bRIPPER && victim.bBOSS && bNOBOSSRIP)
+			MustExplode = true; //Billions must explode
 		
 		return -1;
 	}
 	
+	//[inkoalawetrust] The ripping code is just ripped (Lol) from my AI library.
+	Override Bool CanCollideWith (Actor Other, Bool Passive)
+	{
+		//Don't collide with actors you already ripped.
+		If (!Passive && bRipper && bRipOnce /*&& RippedAlready (Other)*/ && Other && (Other == LastRipped || Other == PreLastRipped))
+			Return False;
+		
+		Return Super.CanCollideWith (Other, Passive);
+	}
+	
 	override int SpecialMissileHit(Actor victim)
 	{
-		if (victim == Target)
+		if (victim == Target && !bHitOwner) return 1; //[inkoalawetrust] //This is default behavior though ?
+		
+		Handle_MissileHit(victim);
+		//Assume the actor will be hit and ripped. For overrides, this will need to be set manually, if some child class code says it shouldn't collide.
+		/*BUG: The RipDepth code is somewhat buggy, it doesn't necessarily rip through however many actors specified when they are tightly packed together.
+		And will sometimes do 2-3 rips on victims in despite the RipOnce flag. I've tried a few fixes, including using an array, but they made things worse.*/
+		IncrementRipDepth (Victim, False);
+		StoreLastRipped (Victim);
+		Return -1;
+	}
+	
+	Void StoreLastRipped (Actor Victim)
+	{
+		//If (bRipper && Victim && !RippedAlready(Victim))
+		//	Ripees.Push(Victim);
+		If (bRipper && LastRipped != Victim && PreLastRipped != Victim)
 		{
-			return 1;
+			PreLastRipped = LastRipped;
+			LastRipped = Victim;
+		}
+	}
+	
+	Void IncrementRipDepth (Actor Victim, Bool FromOverride)
+	{
+		If (!Default.RipAmount || !Victim || !bRipper) Return;
+		/*If (RippedAlready(Victim)) Return;
+		If (FromOverride) Ripees.Pop(); //Undo the rip from Super.SpecialMissileHit() if called from an override to that virtual.
+		If (Ripees.Size()-1 <= RipDepth+1)
+		{
+			Ripees.Clear();
+			a_log ("no more ripping");
+			bRipper = False;
+			Return;
+		}*/
+		
+		If (Victim == LastRipped || Victim == PreLastRipped) Return;
+		If (FromOverride) RipAmount++; //Undo the rip from Super.SpecialMissileHit() if called from an override to that virtual.
+		RipAmount--;
+		If (RipAmount <= 1)
+		{
+			RipAmount--; //Now the depth is 0.
+			//a_log ("no more ripping");
+			bRipper = False;
+			Return;
 		}
 		
-		if (bRIPPER)
-		{
-			if (ripAmount < 0)
-			{
-				return 0;
-			}
-
-			if (LastActor != victim && victim)
-			{
-				ripAmount = ripAmount - 1;
-				Handle_MissileHit(victim);
-				LastActor = victim;
-			}
-			else
-			{
-				return 1;
-			}
-		}
-
-		return -1;
+		//console.printf ("rip depth %d",RipAmount);
 	}
 	
 	virtual void ActivateLines()
@@ -120,27 +150,238 @@ class PB_Projectile : FastProjectile abstract
 		if(BlockingLine) BlockingLine.Activate(target, 0, SPAC_Impact);
 	}
 	
+	//[inkoalawetrust]: The stock FastProjectile code. We have to basically reimplement the whole think to make it support bouncing projectiles again.
+	Void FastProjectileTick()
+	{
+		ClearInterpolation();
+		double oldz = pos.Z;
+
+		if (isFrozen())
+			return;
+
+		// [RH] Ripping is a little different than it was in Hexen
+		FCheckPosition tm;
+		tm.DoRipping = bRipper;
+
+		int count = 8;
+		if (radius > 0)
+		{
+			while (abs(Vel.X) >= radius * count || abs(Vel.Y) >= radius * count)
+			{
+				// we need to take smaller steps.
+				count += count;
+			}
+		}
+
+		if (height > 0)
+		{
+			while (abs(Vel.Z) >= height * count)
+			{
+				count += count;
+			}
+		}
+
+		// Handle movement
+		bool ismoved = Vel != (0, 0, 0)
+			// Check Z position set during previous tick.
+			// It should be strictly equal to the argument of SetZ() function.
+			|| (   (pos.Z != floorz           ) /* Did it hit the floor?   */
+				&& (pos.Z != ceilingz - Height) /* Did it hit the ceiling? */ );
+
+		if (ismoved)
+		{
+			// force some lateral movement so that collision detection works as intended.
+			if (bMissile && Vel.X == 0 && Vel.Y == 0 && !IsZeroDamage())
+			{
+				VelFromAngle(MinVel);
+			}
+
+			Vector3 frac = Vel / count;
+			int changexy = frac.X != 0 || frac.Y != 0;
+			int ripcount = count / 8;
+			for (int i = 0; i < count; i++)
+			{
+				if (changexy)
+				{
+					if (--ripcount <= 0)
+					{
+						tm.ClearLastRipped();	// [RH] Do rip damage each step, like Hexen
+					}
+					
+					if (!TryMove (Pos.XY + frac.XY, true, false, tm))
+					{ // Blocked move
+						if (!bSkyExplode)
+						{
+							let l = tm.ceilingline;
+							if (l &&
+								l.backsector &&
+								l.backsector.GetTexture(sector.ceiling) == skyflatnum)
+							{
+								let posr = PosRelative(l.backsector);
+								if (pos.Z >= l.backsector.ceilingplane.ZatPoint(posr.XY))
+								{
+									// Hack to prevent missiles exploding against the sky.
+									// Does not handle sky floors.
+									Destroy ();
+									return;
+								}
+							}
+							// [RH] Don't explode on horizon lines.
+							if (BlockingLine != NULL && BlockingLine.special == Line_Horizon)
+							{
+								Destroy ();
+								return;
+							}
+							
+							// [inkoalawetrust] Bounce off of blocking lines and actors.
+							// https://sourcegraph.com/github.com/ZDoom/gzdoom/-/blob/src/playsim/p_mobj.cpp?L2105-2132
+							If (BlockingMobj) //Hit actor.
+							{
+								If (bBounceOnActors)
+								{
+									If (!BounceActor (BlockingMobj,False))
+									{
+										ExplodeMissile (Null, BlockingMobj);
+										OnExplode (FindExplosionType(BlockingMobj));
+									}
+									Return;
+								}
+							}
+							Else //Hit wall.
+							{
+								If (BounceWall())
+								{
+									PlayBounceSound (False);
+									Return;
+								}
+							}
+							
+							If (BlockingMobj && ReflectOffActor(BlockingMobj)) //Handle reflection too.
+								Return;
+						}
+						
+						ExplodeMissile (BlockingLine, BlockingMobj);
+						OnExplode (FindExplosionType(BlockingMobj));
+						return;
+					}
+				}
+				AddZ(frac.Z);
+				UpdateWaterLevel ();
+				oldz = pos.Z;
+				if (oldz <= floorz)
+				{ // Hit the floor
+
+					if (floorpic == skyflatnum && !bSkyExplode)
+					{
+						// [RH] Just remove the missile without exploding it
+						//		if this is a sky floor.
+						Destroy ();
+						return;
+					}
+					
+					SetZ(floorz);
+					
+					// [inkoalawetrust] Floor plane bounce handling.
+					// https://sourcegraph.com/github.com/ZDoom/gzdoom@cfe30c1d477e5cc8339226ebbb37f37b5bd2f019/-/blob/src/playsim/p_mobj.cpp?L2442-2463
+					CheckFor3DFloorHit(FloorZ,True);
+					
+					If (bBounceOnFloors)
+					{
+						BouncePlane (FloorSector.FloorPlane);
+						Return;
+					}
+					
+					HitFloor ();
+                    Destructible.ProjectileHitPlane(self, SECPART_Floor);
+					ExplodeMissile (NULL, NULL);
+					OnExplode (EType_Geometry);
+					return;
+				}
+				if (pos.Z + height > ceilingz)
+				{ // Hit the ceiling
+
+					if (ceilingpic == skyflatnum && !bSkyExplode)
+					{
+						Destroy ();
+						return;
+					}
+					
+					SetZ(ceilingz - Height);
+					
+					// [inkoalawetrust] Ceiling plane bounce handling.
+					// https://sourcegraph.com/github.com/ZDoom/gzdoom@cfe30c1d477e5cc8339226ebbb37f37b5bd2f019/-/blob/src/playsim/p_mobj.cpp?L2553-2572
+					CheckFor3DCeilingHit(CeilingZ,True);
+					
+					If (bBounceOnCeilings)
+					{
+						BouncePlane (CeilingSector.CeilingPlane);
+						Return;
+					}
+					
+                    Destructible.ProjectileHitPlane(self, SECPART_Ceiling);
+					ExplodeMissile (NULL, NULL);
+					OnExplode (EType_Geometry);
+					return;
+				}
+				CheckPortalTransition();
+				if (changexy && ripcount <= 0) 
+				{
+					ripcount = count >> 3;
+
+					// call the 'Effect' method.
+					Effect();
+				}
+			}
+		}
+		if (!CheckNoDelay())
+			return;		// freed itself
+		// Advance the state
+		if (tics != -1)
+		{
+			if (tics > 0) tics--;
+			while (!tics)
+			{
+				if (!SetState (CurState.NextState))
+				{ // mobj was removed
+					return;
+				}
+			}
+		}
+	}
+	
 	override void Tick()
 	{
 		if (IsFrozen())
-		{
 			return;
-		}
 
 		if (MustExplode)
 		{
+			OnExplode (FindExplosionType(BlockingMobj));
 			ExplodeMissile(BlockingLine, BlockingMobj);
 			return;
 		}
 		
 		activateLines();
 		
-		Super.Tick();
+		Double OldZ = Pos.Z;
+		FastProjectileTick(); //We just use our own copy of the Tick() method for bouncing.
+		FallAndSink(GetGravity(),OldZ); //[inkoalawetrust] It's as shrimple as that.
 	}
 
 	// [Ace] Override these if you want to do stuff when something happens.
 	protected virtual void OnHitActor(Actor target, Name dmgType) {}
 	protected virtual void OnExplode(int type) {}
+	
+	ExplosionType FindExplosionType (Actor Victim) //Determine what impact type to use.
+	{
+		If (!Victim) //No impact victim ? Probably level geometry.
+			Return EType_Geometry;
+		
+		If (((Victim.bShootable && Victim.bCorpse) || Victim.bKilled ) && Victim.bNoBlood) //https://www.youtube.com/watch?v=K63AVSCPcSI
+			Return EType_Actor;
+		
+		Return EType_BleedingActor; //https://www.youtube.com/watch?v=BlrjHLnNzAo
+	}
 	
 	// [Ace] In case you have attached anything to this item, calling OwnerDied allows you to do some effects on death.
 	protected void CallOwnerDied()
@@ -153,20 +394,21 @@ class PB_Projectile : FastProjectile abstract
 
 	bool MustExplode;
 	double ExtraDamageFactor;
-	protected Actor LastActor;
 	
-	Array<Actor> act_hits;
-	Actor hitactor;
+	//Array<Actor> act_hits;
+	//Actor hitactor;
+	Actor LastRipped, PreLastRipped; //The actor that a ripper last hit. Used for the RIPONCE flag.
 	int ripamount;
 	Property RipperCount : ripamount;
 	
 	double truedamage;
 	Property BaseDamage : truedamage;
 	
-	private int BehaviourFlags;
-	flagdef NoCriticals: BehaviourFlags, 0;
-	flagdef Omnidirectional: BehaviourFlags, 1;
-	flagdef InvisiblePuff: BehaviourFlags, 2;
+	private int BehaviorFlags;
+	flagdef NoCriticals: BehaviorFlags, 0;
+	flagdef Omnidirectional: BehaviorFlags, 1;
+	flagdef InvisiblePuff: BehaviorFlags, 2;
+	flagdef RipOnce: BehaviorFlags, 3;
 
 	Default
 	{
@@ -187,6 +429,7 @@ class PB_Projectile : FastProjectile abstract
 		+NOBOSSRIP
 		+RIPPER
 		-NOGRAVITY
+		+PB_Projectile.RipOnce;
 		ProjectileKickBack 20;
 		Renderstyle "Add";
 		Decal "BulletChip";


### PR DESCRIPTION
- The nailguns' nails and javelins are now able to get stuck on the last actor that they hit after running out of rips. They also make the victim bleed (Purely visual), unless it's one of the hot variants of the projectiles.
- Fixed the way PB_Projectile handles rippers and added a +RIPONCE flag. The only bug is that the last actor to be ripped sometimes takes several times the projectiles' damage.
- Added Vec3OffsetRelative().
- PB_Projectile is now affected by gravity and bouncing.
- Changed the actor editor number 23081 places to PB_Imp1.