### PR TITLE
(heavy) BFG things optimizations,cheat added

### DIFF
--- a/actors/Weapons/Slot8/BFGMKIV.dec
+++ b/actors/Weapons/Slot8/BFGMKIV.dec
@@ -369,8 +369,9 @@ ACTOR PB_BFG9000: PB_Weapon Replaces BFG9000
 		BeamLoop:
 			016G FGHIJKL 1 BRIGHT {
 				PB_FireOffset;
-				A_FireCustomMissile ("BFG_BeamProjectile", 0, 0, 0, -8, 0,0);
-				A_RailAttack(0, 0, 0,"None", "Green", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT, 2.0, "NullPuff", 0, 0, 0, 0, 10.0, 1.0, "BFGLightningTrial_Small", -7,0,0);
+				//A_FireCustomMissile ("BFG_BeamProjectile", 0, 0, 0, -8, 0,0);
+				PB_FireAltBFGRail();  //function defined in BaseWeapon_Function.zsc to replace the rail and the projectilew
+				//A_RailAttack(0, 0, 0,"None", "Green", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT, 2.0, "NullPuff", 0, 0, 0, 0, 10.0, 1.0, "BFGLightningTrial_Small", -7,0,0);
 				A_TakeInventory("PB_Cell", 1);
 				
 				if(CountInv("PB_Cell") < 1) {
@@ -589,7 +590,7 @@ ACTOR BFG_BeamProjectile : MageWandMissile
   Speed 400
   Radius 13
   Height 8
-  Damage 20
+  //Damage 20
   Decal "none"
   damagetype Disintegrate
   RenderStyle Add
@@ -618,6 +619,45 @@ ACTOR BFG_BeamProjectile : MageWandMissile
     HSPL ABCDEFGHIJ 1 bright Light("BFGALT") A_SetScale(ScaleX -0.1, ScaleY -0.1)
     stop
   }
+}
+
+
+//this puff is to replace the projectile above
+Actor BFGBeamPuff : Actor 
+{
+	Radius 13
+	Height 8
+	Damage 20
+	Decal "none"
+	damagetype Disintegrate
+	RenderStyle Add
+	Alpha .85
+	Translation "0:255=%[0,0,0]:[0,1,0]"
+	-RIPPER
+	-NOBOSSRIP
+	-CANNOTPUSH
+	-NODAMAGETHRUST
+	+BLOODLESSIMPACT
+	+FORCERADIUSDMG
+	-BLOODSPLATTER
+	+DontHurtSpecies
+	Species "Marine"
+
+	states
+	{
+		Spawn:
+			TNT1 B 0 nodelay A_Explode(10,80,0, 1, 80)
+			TNT1 A 0 {
+				A_SpawnItem("GreenFlare",0,0);
+				A_SpawnItemEx("SmallGreenFlameTrails", 0, 0, 0, 0, 0, 0, 0, 128);
+				A_SpawnItem("BFGAltShockWave",0,0);
+				A_SpawnItemEx("BFGLightningTrial", 0, random(-1,1), random(4,6));
+				A_SpawnItemEx("NewBFGTrailGreen", 0, random(8,-8), random(8,-8), 0, 0, 0, 0, 128, 0);
+				A_SpawnItemEx("BFGFOG", 0, 0);
+			}
+			HSPL ABCDEFGHIJ 1 bright Light("BFGALT") A_SetScale(ScaleX - 0.1, ScaleY - 0.1)
+			stop
+	}
 }
 
 Actor Blackhole_Ball

--- a/actors/Weapons/Slot8/SuperBFGBall.zc
+++ b/actors/Weapons/Slot8/SuperBFGBall.zc
@@ -1,57 +1,38 @@
 class PB_SuperBFGBall : Actor
 {
 
-
 	Default
     {
-	Projectile;
-	Speed 24;
-	RenderStyle "Normal";
-// 	Alpha 0.99;
-	Scale 0.9;
-	Radius 4;
-	Height 8;
-	
-	
-	Damage 500;
-    Decal "BFGLightning";
-	DeathSound "BFGEXPLO";
-    DamageType "Disintegrate";
-// 	Scale 0.65;
-	Species "Marines";
-	+SEEKERMISSILE;
-	+Friendly;
-	+THRUSPECIES;
-	+MTHRUSPECIES;
-	+DONTHARMSPECIES;
-	+FORCEXYBILLBOARD;
+		Projectile;
+		Speed 24;
+		RenderStyle "Add";
+		Scale 0.9;
+		Radius 4;
+		Height 8;
+		Damage 500;
+		Decal "BFGLightning";
+		DeathSound "BFGEXPLO";
+		DamageType "Disintegrate";
+		Species "Marines";
+		+SEEKERMISSILE;
+		+Friendly;
+		+THRUSPECIES;
+		+MTHRUSPECIES;
+		+DONTHARMSPECIES;
+		+FORCEXYBILLBOARD;
 	}
-	  States
-	  {
-		  Spawn:
-				TNT1 A 0;
-				TNT1 A 0 A_StartSound("Bfgfly1", CHAN_BODY, CHANF_OVERLAP|CHANF_LOOPING );
-		  Flying:
-			098G ABCDEFGHIJKLMNOPQRSTUVWXYZ 1 BRIGHT Light("BFGBALL") {
-				
-			//	A_SpawnItemEx("BFGFOG",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION|SXF_TRANSFERPOINTERS);
-				A_SpawnItemEx("BFGTrailParticle", Random(-13, 13), Random(-13, 13), Random(7, 22), Random(-8, 8), Random(-3, 3), (0.1)*Random(-10, 10), Random(-20, 20), 128);
-				A_SpawnItemEx("BFGLightningTrial", 15, random(-1,1), random(-6,-4), 20);
-				
-				//A_SpawnItemEx("NewBFGTrailGreen", 15, random(8,-8), random(8,-8), 0, 0, 0, 0, 128, 0);
-			}
-			099G ABCD 1 BRIGHT Light("BFGBALL") {
-				
-			//	A_SpawnItemEx("BFGFOG",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION|SXF_TRANSFERPOINTERS);
-// 				A_SpawnItemEx("BFGTrailParticle", Random(-13, 13), Random(-13, 13), Random(0, 18), Random(1, 3), 0, (0.1)*Random(-10, 10), Random(-20, 20), 128);
-				A_SpawnItemEx("BFGTrailParticle", Random(-13, 13), Random(-13, 13), Random(7, 22), Random(-8, 8), Random(-3, 3), (0.1)*Random(-10, 10), Random(-20, 20), 128);
-				A_SpawnItemEx("BFGLightningTrial", 15, random(-1,1), random(-6,-4), 20);
-				//A_SpawnItemEx("NewBFGTrailGreen", 15, random(8,-8), random(8,-8), 0, 0, 0, 0, 128, 0);
-			}
+	States
+	 {
+		Spawn:
+			TNT1 A 0;
+			TNT1 A 0 A_StartSound("Bfgfly1", CHAN_BODY, CHANF_OVERLAP|CHANF_LOOPING );
+		Flying:
+			098G ABCDEFGHIJKLMNOPQRSTUVWXYZ 1 BRIGHT Light("BFGBALL") SpawnBFGBallTrail();
+			099G ABCD 1 BRIGHT Light("BFGBALL") SpawnBFGBallTrail();
 			Loop;
 	 
-		 Death:
-			TNT1 A 0;
+		Death:
+			TNT1 A 0 { DoTracers = false; }
 			TNT1 A 0 A_StopSound(6);
 			TNT1 A 0 Bright A_SpawnItem("GreenShockWave",0,0,0);
 			EXPL A 0 Radius_Quake (5, 16, 0, 20, 0);//(intensity, duration, damrad, tremrad, tid)
@@ -68,111 +49,122 @@ class PB_SuperBFGBall : Actor
 			TNT1 A 0 A_SPawnItem("SuperBFGExtraGiant");
 			BFE1 GGHHIIJJKK 1 Bright Light("BFGBALL") A_SpawnItem("GreenFlare",0,0);
 			Stop;
-	  }
+	 }
     
 
     override void PostBeginPlay()
     {
+		DoTracers = true;
         Super.PostBeginPlay();
-
     }
-	
-	int TickRate;
 
 	override void Tick()
 	{
 		Super.Tick();
-
-		TickRate++;
-		if (TickRate >= 3) 
-		{
-			A_AttackRailTargets(1024);
-			TickRate = 0; // Reset the counter
-		}
-	}
-
-    Actor FindTarget(double radius)
-    {
-        BlockThingsIterator it = BlockThingsIterator.Create(self, radius);
-		Actor thing;
-
-		while (it.Next())
-        {
-			thing = it.thing;
-         //   if (thing != self && thing.bShootable && !thing.bFriendly)
-            
-			if (!thing || thing is "PlayerPawn" || !thing.bSolid || Distance2D(thing) > radius)
-           		
-			{
-				continue;
-			}
-			
-			
-			if (self.CheckSight(thing))
-			{
-				return thing; // return the found actor
-			}
-			else
-			{
-				continue; // If no line of sight, continue checking the next potential target.
-			}
-        }
-        
-        return null;
-
-
-    }
-
-	void A_AttackRailTargets(double dist = 1024)
-	{
-		if (!target)
+		if(isfrozen())
 			return;
-
-		let itr = BlockThingsIterator.Create(self, dist);
-		while (itr.Next())
-		{        
-			let victim = itr.thing;
-			// check it's a valid victim (a shootable, hostile, alive monster):
-			if (victim == target || victim == self || !victim.bISMONSTER || !victim.bSHOOTABLE || !victim.isHostile(target) || victim.health <= 0)
-			{
-				continue;
-			}
-			
-			// check distance:
-			double victimDist = Distance3D(victim);
-			if (victimDist > dist)
-			{
-				continue;
-			}
-			
-			// face the victim:
-			A_Face(victim, flags: FAF_MIDDLE);
-
-			// check the victim can be reached:
-			FLineTraceData ltrace;
-			LineTrace(angle, victimDist, pitch, offsetz: height * 0.5, data: ltrace);
-			// abort the attack if LineTrace hit a different actor that is also shootable
-			// but is either the player or a player's friend:
-			if (ltrace.HitType == TRACE_HitActor)
-			{
-				let act = ltrace.hitActor;
-				if (act && act != victim && act.bSHOOTABLE && (act == target || act.IsFriend(target)))
-				{
-					continue;
-				}
-			}
-			
-			// proceed with attack:
-			A_CustomRailgun(15, 0, "", "Green", 
-				flags: RGF_SILENT|RGF_FULLBRIGHT|RGF_NOPIERCING, 
-				aim: 0, 
-				pufftype: "None", 
-				range: victimdist, 
-				duration: 1, 
-				sparsity: 60, 
-				spawnclass: "BFGLightningTrial_Small"
-			);
-		}
+		if (DoTracers && level.time % 3 == 0) 
+			DoBFGBeams();
 	}
+	
+	bool DoTracers;
+	
+	const Dist_BT_Fx = 25; //the space between particles, used to determine how many particles are going to spawn to create the "rail"
+	
+	Void DoBFGBeams(int dist = 1024,int dmg = 15)
+	{
+		if(!target) return;
+		BlockThingsIterator bti = BlockThingsIterator.Create(self,dist);
+		actor current;
+		
+		//was not fired by a player?
+		bool bad = (target && !target.player);
+		
+		while(bti.next())
+		{
+			current = bti.thing;
+			//if there no monster, the monster is dead, isnt shootable, the monster is a player (and its not fired from a player)
+			//the monster is not on sight
+			if(!current || current == target || current.health < 1 ||!current.bshootable || !current.bsolid || 
+			!self.checksight(current) || (!bad && current.player) || (!bad && !current.bismonster) || current.isfriend(target))
+				continue;
+			
+			//check if the thing is not too far away
+			int distance = self.distance3D(current);
+			if(distance > dist)
+				continue;
+				
+			//get the difference between the bfgball pos and the enemy pos
+			vector3 dif = levellocals.vec3diff((self.pos.x,self.pos.y,self.pos.z + self.height*0.5),(current.pos.x,current.pos.y,current.pos.z + current.height*0.5));
+			//get the direction
+			vector3 direction = dif.unit();
+			//the total distance as a magnitude instead of a vector
+			double magnitude = dif.length();
+			//get the amount of steps based on the space between the particles
+			int steps = int(magnitude/Dist_BT_Fx);
+			//save the actual pos of the ball
+			vector3 actpos = self.pos;
+			
+			for(int i = 1; i <= steps; i++)
+			{
+				actpos += (direction * Dist_BT_Fx);
+				SpawnBFGLightng(actpos);
+			}
+			
+			//apply the damage directly to the mobj instead of firing a railgun
+			//anyways the "rail" is spawned in the for loop
+			current.damagemobj(self,self.target,dmg,"Disintegrate");
+	
+		}
+		
+	}
+	
+	
+	//visuals
+	
+	//this function spawns a textured particle of a little bfg spark in the desired pos
+	Void SpawnBFGLightng(vector3 where)
+	{
+		FSpawnParticleParams BFGLGT;
+		BFGLGT.Texture = TexMan.CheckForTexture ("SRKGM0"); //DB46Q0 DB08C0 YAE6A0
+		BFGLGT.Color1 = "FFFFFF";
+		BFGLGT.Style = STYLE_Add;
+		BFGLGT.Flags = SPF_ROLL|SPF_FULLBRIGHT;
+		BFGLGT.Vel = (frandom(-3,3),frandom (-3,3),frandom (-3,3)); 
+		BFGLGT.Startroll = random(0,360);
+		BFGLGT.RollVel = frandom(-5,5);
+		BFGLGT.StartAlpha = 1.0;
+		BFGLGT.FadeStep = -0.25;
+		BFGLGT.Size = random(8,13);
+		BFGLGT.SizeStep = random(7,25);
+		BFGLGT.Lifetime = random (2,4); 
+		BFGLGT.Pos = where;
+		
+		Level.SpawnParticle(BFGLGT);
+	}
+	
+	//the lightning trail fx
+	void SpawnBFGBallTrail()
+	{
+		FSpawnParticleParams BFGTrail;
+		int fm = random(1,5);
+		BFGTrail.Texture = TexMan.CheckForTexture ("DLI"..fm.."G0R0");
+		BFGTrail.Color1 = "FFFFFF";
+		BFGTrail.Style = STYLE_Add;
+		BFGTrail.Flags = SPF_ROLL|SPF_FULLBRIGHT;
+		BFGTrail.Vel = (frandom(-6,6),frandom (-3,3),frandom (-0.3,0.3)); 
+		BFGTrail.Startroll = random(0,360);
+		//BFGTrail.RollVel = frandom(-5,5);
+		BFGTrail.StartAlpha = 1.0;
+		BFGTrail.FadeStep = -0.1;
+		BFGTrail.Size = random(12,24);
+		BFGTrail.SizeStep = random(10,25);
+		BFGTrail.Lifetime = random (10,15);
+		vector3 randvar = (random(-13,13),random(-13,13),random(-10,22));
+		BFGTrail.Pos = self.vec3offset(randvar.x,randvar.y,randvar.z);
+		
+		Level.SpawnParticle(BFGTrail);
+	}
+	
 
 }

--- a/zscript/Player/ZSPlayer.zsc
+++ b/zscript/Player/ZSPlayer.zsc
@@ -44,7 +44,7 @@ class PB_PlayerPawn : PlayerPawnBase
         DamageFactor "Flames",0.875;
         DamageFactor "Fire",0.875;
         DamageFactor "Burn",0.875;
-        DamageFactor "Disintegrate",0;
+        DamageFactor "Disintegrate",1.0;
 		DamageFactor "Avoid",0;
 		
         Player.ViewHeight 44;
@@ -143,6 +143,27 @@ class PB_PlayerPawn : PlayerPawnBase
         }
         return Super.DamageMobj(inflictor,source,damage,mod,flags,angle);
     }
+	
+	override void CheatGive (String name, int amount)
+	{
+		if(name ~== "PB_ALL" || name ~== "PB_Upgrades")
+		{
+			for(int i = 0; i < self.PB_ActUpgrades.size() -1; i++)
+				giveinventory(self.PB_ActUpgrades[i],2);
+			return;
+		}
+		super.cheatgive(name,amount);
+	}
+	
+	//array to save all the upgrades
+	static const string PB_ActUpgrades[] = {
+		"PB_Deagle", //slot 2
+		"PB_AutoshotgunUpgrade","PB_QuadSGUpgrade","PB_SGMagazine", //slot3
+		"PB_LMG","RifleUpgrade", //slot 4
+		"PB_Minigun","MinigunUpgraded"," PB_MinigunUpgrade", //slot 5 
+		"PB_M2Upgrade", //slot 7
+		"PB_Flamethrower", "FlamerUpgraded" //slot 9?
+	};
 
     States
     {

--- a/zscript/Weapons/BaseWeapon_Functions.zsc
+++ b/zscript/Weapons/BaseWeapon_Functions.zsc
@@ -1157,4 +1157,62 @@ extend class PB_WeaponBase
 			return invoker.A_Jump(256,"SelectAnimation");
 		}
 	}
+	
+	
+	
+	//temporal thing for the bfg alt fire, move this to the bfg when/if it gets rewritten in zscript
+	const bfgpartstep = 30;
+	action void PB_FireAltBFGRail()
+	{
+		//the first option is a lineattack cuz linetrace acts weird in some tipes of geometry (try one with the kinsie test map, in the elevator or the pool)
+		Actor p = LineAttack(angle,8000,pitch,20,'Disintegrate',"BFGBeamPuff",LAF_NOIMPACTDECAL|LAF_NORANDOMPUFFZ);
+		vector3 destpos;
+		
+		if(p) 
+			destpos = (p.pos.XY,p.pos.z + p.height);
+		else //no puff spawned, probably fired at the sky, so fire a linetrace to draw the rail anyway
+		{
+			FLineTraceData t;
+			bool hit = linetrace(angle,8000,pitch,0,height * 0.5 - floorclip + player.mo.AttackZOffset*player.crouchFactor,data:t);
+			if(hit)
+				destpos = t.hitlocation;
+				
+		}
+		
+		vector3 dif = levellocals.vec3diff((pos.XY,pos.z + height * 0.5),destpos);
+		vector3 dir = dif.unit();
+		double dis = dif.length();
+		
+		int q = int(dis / bfgpartstep) + 1; //bfgpartstep is an arbitrary value representing the distance between particles, basically get the divide the total distance / steps between particles to get the number of particles
+			
+		vector3 actpos = (pos.XY,pos.z + height * 0.5);
+		for(int i = 1; i <= q; i++)
+		{
+			actpos += (dir * bfgpartstep);
+			PB_Drawrailparticle(actpos);
+		}
+
+	}
+	
+	action void PB_Drawrailparticle(vector3 where)
+	{
+		FSpawnParticleParams bfgrail;
+		int fm = random(1,5);
+		bfgrail.Texture = TexMan.CheckForTexture ("DLI"..fm.."G0R0");
+		bfgrail.Color1 = "FFFFFF";
+		bfgrail.Style = STYLE_Add;
+		bfgrail.Flags = SPF_ROLL|SPF_FULLBRIGHT|SPF_NOTIMEFREEZE;
+		bfgrail.Vel = (random(-1,1),random(-1,1),random(-1,1)); 
+		bfgrail.Startroll = random(0,360);
+		bfgrail.RollVel = 0;
+		bfgrail.StartAlpha = 1.0;
+		bfgrail.FadeStep = -0.05;
+		bfgrail.Size = random(32,42);
+		bfgrail.SizeStep = -12;
+		bfgrail.Lifetime = random (2,3); 
+		bfgrail.Pos = where;
+		Level.SpawnParticle(bfgrail);
+	}
+	
+	
 }

--- a/zscript/Weapons/BaseWeapon_Functions.zsc
+++ b/zscript/Weapons/BaseWeapon_Functions.zsc
@@ -1169,7 +1169,10 @@ extend class PB_WeaponBase
 		vector3 destpos;
 		
 		if(p) 
+		{
+			p.target = self;
 			destpos = (p.pos.XY,p.pos.z + p.height);
+		}
 		else //no puff spawned, probably fired at the sky, so fire a linetrace to draw the rail anyway
 		{
 			FLineTraceData t;


### PR DESCRIPTION
-Optimized BFG ball tracer attack (now uses textured particles and damagemobj() instead of railattack).

-Optimized bfg beam altfire (anti slideshow optimizations).

-Restored "disintegrate" damage factor on the player ~and therefore, bfg altfire damages the player~ (nevermind, it was an oversight).

-Added "**pb_all**" to the give cheats (use "**give pb_all**" to get all the weapon upgrades, akin to EOA, just made for faster testing purposes )

*Note: two functions added to baseweapon, due to bfg being defined in decorate, move them when the bfg gets rewritten in zscript.

*Note2: BFG ball tracer beams may need a little more work to look a little more fancier, as they are kinda simple in this implementation, should be easy to work it