### PR TITLE
Actorless monsters laser

### DIFF
--- a/ZSCRIPT.zc
+++ b/ZSCRIPT.zc
@@ -101,6 +101,8 @@ const MAXITERATIONS = 32676;
 #include "zscript/Effects/IceShards.txt"
 #include "zscript/Effects/BulletPuffs.txt"
 #include "zscript/Effects/Smoke.zs"
+#include "zscript/Effects/FxBase.zs"
+#include "zscript/Effects/MonsterBeam.zs"
 
 //Weapons
 #include "zscript/Weapons/BaseWeapon.zc"

--- a/actors/Monsters/T3-Revies/BeamRev.dec
+++ b/actors/Monsters/T3-Revies/BeamRev.dec
@@ -128,10 +128,10 @@ ACTOR PB_BeamRev : PB_Revenant //Replaces Revenant
 	TNT1 A 0 A_CustomMissile ("RedFlareSmall", 50, 15, 0, 0)
     R4SK J 2 Bright A_FaceTarget
 	TNT1 A 0 A_CustomMissile ("RedFlareSmall", 50, 15, 0, 0)
-	TNT1 A 0 A_CustomRailgun(0, 15, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,4000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 25)	
+	TNT1 A 0 A_giveinventory("BeamRevRailFx",1)//A_CustomRailgun(0, 15, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,4000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 25)	
 	R4SK J 2 A_FaceTarget
 	TNT1 A 0 A_CustomMissile ("RedFlareSmall", 50, 15, 0, 0)
-	TNT1 A 0 A_CustomRailgun(0, 15, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,4000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 25)	
+	TNT1 A 0 A_giveinventory("BeamRevRailFx",1)//A_CustomRailgun(0, 15, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,4000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 25)	
     R4SK J 2 Bright A_FaceTarget
 	TNT1 A 0 A_CustomMissile ("RedFlareSmall", 50, 15, 0, 0)
 	R4SK J 2 
@@ -694,7 +694,7 @@ DamageFactor "Blood", 0.0 DamageFactor "BlueBlood", 0.0 DamageFactor "GreenBlood
 	}
 }
 
-ACTOR RevanentBeam : FastProjectile
+ACTOR RevanentBeam : EnemyRailPj
 {
   Speed 120
   Radius 2

--- a/actors/Monsters/T3-Revies/Draugr.dec
+++ b/actors/Monsters/T3-Revies/Draugr.dec
@@ -182,10 +182,10 @@ ACTOR PB_Draugr : PB_Revenant //Replaces Revenant
 	//Aiming with laser pointer
 	TNT1 A 0 A_Playsound("REILAIM")	
 	TNT1 A 0 A_CustomMissile ("RedFlareSmall", 62, -15, 0, 0)
-	TNT1 A 0 A_CustomRailgun(0, -15, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,4000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 25)	
+	TNT1 A 0 A_giveinventory("DraugRailFx",1) //A_CustomRailgun(0, -15, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,4000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 25)	
 	SKE2 G 2 A_FaceTarget
 	TNT1 A 0 A_CustomMissile ("RedFlareSmall", 62, -15, 0, 0)
-	TNT1 A 0 A_CustomRailgun(0, -15, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,4000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 25)	
+	TNT1 A 0 A_giveinventory("DraugRailFx",1) //A_CustomRailgun(0, -15, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,4000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 25)	
     SKE2 G 2 Bright A_FaceTarget
 	TNT1 A 0 A_CustomMissile ("RedFlareSmall", 62, -15, 0, 0)
 	SKE2 G 2 

--- a/actors/Monsters/Tz-Bosses/CYBERDEMON.dec
+++ b/actors/Monsters/Tz-Bosses/CYBERDEMON.dec
@@ -183,57 +183,57 @@ ACTOR PB_Cyberdemon: Cyberdemon //Replaces Cyberdemon
 		CYMA F 2 A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
 		TNT1 A 0 A_PlaySound("Weapons/StachanovCharged3")
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)
 		CYMA F 2 A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 A_FaceTarget
 		TNT1 A 0 A_CustomMissile("RedFlare",66,-21,0,0)
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 //A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 //A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 //A_FaceTarget
 		TNT1 A 0 A_CustomMissile("RedFlare",66,-21,0,0)
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 //A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 //A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 2 //A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 3 //A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 3 //A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)	
 		CYMA F 3 BRIGHT //A_FaceTarget
 		TNT1 AA 0 A_CustomMissile("ObeliskTrailSpark",66,-21,0,0)
-		TNT1 A 0 A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)		
+		TNT1 A 0 A_giveinventory("CybRailFx",1)//A_CustomRailgun(0, -20, "None", "None", RGF_SILENT || RGF_NOPIERCING || RGF_FULLBRIGHT , 1, 0, "Laser_Red_CyberDemon",0,0,3000,0,1,1.0, "Tracer_Trail_Red_Cyberdemon", 18)		
 		TNT1 A 0 A_PlaySound("Weapons/StachanovFire")
 		CYMA G 8 A_CustomMissile("CyberDemonLaserCannon",60,-25,random(-1,1))
 		CYMA H 10
@@ -521,7 +521,7 @@ ACTOR CyberStomp
 	}
 }
 
-ACTOR CyberDemonLaserCannon : FastProjectile
+ACTOR CyberDemonLaserCannon : EnemyRailPj
 {
   Speed 100
   Radius 12
@@ -577,6 +577,7 @@ ACTOR Laser_Red_CyberDemon: FastProjectile
     Radius 1
     Height 2
     +NOBLOCKMAP
+	+NOINTERACTION //ig
     +NOGRAVITY
     +BLOODLESSIMPACT
     +ALWAYSPUFF

--- a/zscript/Effects/FxBase.zs
+++ b/zscript/Effects/FxBase.zs
@@ -1,0 +1,33 @@
+//base for effect actors that only needs to play an animation,
+//so it skips the tick()
+Class PB_LightActor : Actor
+{		
+	
+	override void Tick()
+	{
+		//from gzdoom.pk3
+		
+		if (isFrozen())
+			return;
+		
+		if (!CheckNoDelay())
+			return;
+		
+		if(alpha < 0)
+			destroy();
+			
+		// Advance the state
+		if (tics != -1)
+		{
+			if (tics > 0) tics--;
+			while (!tics)
+			{
+				if (!SetState (CurState.NextState))
+				{ // mobj was removed
+					return;
+				}
+			}
+		}
+	}
+	
+}

--- a/zscript/Effects/MonsterBeam.zs
+++ b/zscript/Effects/MonsterBeam.zs
@@ -1,0 +1,151 @@
+//Temporary inventory trick to draw a texpx beam from a monster
+//this can be removed when pb_beamrev & pb_cyberdemon are already in zscript, so this can be in the monster class itself
+
+Class MonsterBeamAim : Inventory
+{
+	int maxbeamduration;
+	property maxbeamduration:maxbeamduration;
+	bool TargetAim;
+	property TargetAim:TargetAim;
+	default
+	{
+		inventory.maxamount 1;
+		MonsterBeamAim.maxbeamduration 1;
+		MonsterBeamAim.TargetAim true;
+	}
+	int beamduration;
+	override void DoEffect()
+	{
+		super.doeffect();
+		
+		if(isfrozen())
+			return;
+		if(!owner || owner.health < 1)
+			destroy();
+			
+		if(beamduration >= maxbeamduration)
+			destroy();
+		else
+			beamduration++;
+		
+		PB_DoRailThings();
+		
+	}
+	
+	//this represents the distance between the particles
+	const distpx = 12;
+	
+	virtual void PB_DoRailThings()
+	{
+		PB_DoVisualRail();
+	}
+	
+	Void PB_DoVisualRail(int ofsfw = 0,int ofssd = 0,int ofsud = 0,int maxdist = 4000, bool AimAtTarget = true, string railpuff = "Laser_Red_CyberDemon")
+	{
+		if(!owner || owner.health < 1)
+			return;
+			
+		FLineTraceData t;
+		double ofsz = (owner.height * 0.5) + ofsud;
+		
+		double tempangle = owner.angle;
+		double temppitch = owner.pitch;
+		
+		//if its set to aim at the target, and there is a target, aim at it
+		//otherwise aim in the direction the monster is looking
+		if(AimAtTarget && owner && owner.target)
+		{
+			tempangle = owner.AngleTo(owner.target);
+			temppitch = owner.pitchTo(owner.target,owner.target.height * 0.5); //aim at the center of the victim
+		}
+		
+		bool hit = owner.linetrace(tempangle,maxdist,temppitch,0,ofsz,ofsfw,ofssd,data:t);
+		
+		vector3 fw = (cos(owner.angle),sin(owner.angle),0); //forward offset
+		vector3 sd = (cos(owner.angle - 90),sin(owner.angle - 90),0); //side offset
+		
+		//get a vector3 with the total offsets
+		vector3 offs = (fw * ofsfw) + (sd * ofssd);
+		
+		//add the offsets to the current position
+		vector3 spos = owner.vec3offset(offs.x,offs.y,ofsz);
+		vector3 fpos = t.HitLocation;
+		fpos -= t.hitdir;
+		
+		vector3 dif = levellocals.Vec3diff(spos,fpos);
+		vector3 dir = dif.unit();
+		double dis = dif.length();
+		
+		//limit the distance
+		if(dis > maxdist)
+			dis = maxdist;
+			
+		//if the linetrace hits a wall or another monster, stop at that place
+		if(dis > t.Distance)
+			dis = t.Distance;
+		
+		int steps = int(dis / distpx) + 1;
+		
+		for(int i = 0; i < steps; i++)
+		{
+			spos += (dir * distpx);
+			PB_DrawRailFx(spos);
+		}
+		
+		//if theres any puff type
+		if(railpuff != "")
+		{
+			//so the puff doesnt spawn inside the target (if any)
+			double sep = owner.target ? owner.target.radius : 1;
+			fpos -= (t.hitdir * sep);
+			owner.spawn(railpuff,fpos);
+		}
+	}
+	
+	//this function draws the particles
+	Void PB_DrawRailFx(vector3 where)
+	{
+		FSpawnParticleParams MonsterRail;
+		MonsterRail.Texture = TexMan.CheckForTexture("TTRRA0");
+		MonsterRail.Color1 = "FFFFFF";
+		MonsterRail.Style = STYLE_Add;
+		MonsterRail.Flags = SPF_ROLL|SPF_FULLBRIGHT;
+		MonsterRail.Vel = (0,0,0); 
+		MonsterRail.Startroll = randompick(0,360);
+		MonsterRail.RollVel = 0;
+		MonsterRail.StartAlpha = 0.28;
+		MonsterRail.FadeStep = 0;
+		MonsterRail.Size = 20;
+		MonsterRail.SizeStep = 0;
+		MonsterRail.Lifetime = 1;  
+		MonsterRail.Pos = where;
+		Level.SpawnParticle(MonsterRail);
+	}
+}
+
+//the beam handler for the beam revenant
+Class BeamRevRailFx : MonsterBeamAim
+{
+	override void PB_DoRailThings()
+	{
+		PB_DoVisualRail(0,15,25,4000,TargetAim);
+	}
+}
+
+//the beam handler for the draug revenant
+Class DraugRailFx : MonsterBeamAim
+{
+	override void PB_DoRailThings()
+	{
+		PB_DoVisualRail(0,-15,25,4000,TargetAim);
+	}
+}
+
+//the beam handler for the cyberdemon
+Class CybRailFx : MonsterBeamAim
+{
+	override void PB_DoRailThings()
+	{
+		PB_DoVisualRail(0,-20,18,3000,TargetAim);
+	}
+}

--- a/zscript/Player/ZSPlayer.zsc
+++ b/zscript/Player/ZSPlayer.zsc
@@ -148,7 +148,7 @@ class PB_PlayerPawn : PlayerPawnBase
 	{
 		if(name ~== "PB_ALL" || name ~== "PB_Upgrades")
 		{
-			for(int i = 0; i < self.PB_ActUpgrades.size() -1; i++)
+			for(int i = 0; i <= self.PB_ActUpgrades.size() -1; i++)
 				giveinventory(self.PB_ActUpgrades[i],2);
 			return;
 		}
@@ -162,7 +162,7 @@ class PB_PlayerPawn : PlayerPawnBase
 		"PB_LMG","RifleUpgrade", //slot 4
 		"PB_Minigun","MinigunUpgraded"," PB_MinigunUpgrade", //slot 5 
 		"PB_M2Upgrade", //slot 7
-		"PB_Flamethrower", "FlamerUpgraded" //slot 9?
+		"PB_Flamethrower", "PB_FlamethrowerUpgrade","FlamerUpgraded" //slot 9?
 	};
 
     States

--- a/zscript/Weapons/Projectiles/RailGunPj.zs
+++ b/zscript/Weapons/Projectiles/RailGunPj.zs
@@ -79,3 +79,37 @@ Class RailgunLaserBlast1 : FastProjectile
 		Level.SpawnParticle(LaserGun);
 	}
 }
+
+
+//this is basically the same as above, just made the effect a little smaller
+Class EnemyRailPj : FastProjectile
+{
+	override void Effect()
+	{
+		double hitz = pos.z - 8;
+		if (hitz < floorz)
+		{
+			hitz = floorz;
+		}
+		// Do not clip this offset to the floor.
+		hitz += MissileHeight;
+		
+		SpawnLaserTrail((pos.xy, hitz));
+	}
+	
+	void SpawnLaserTrail(vector3 where)
+	{
+		FSpawnParticleParams LaserGun;
+		LaserGun.Texture = TexMan.CheckForTexture("YAE4A0");
+		LaserGun.Style = STYLE_ADD;
+		LaserGun.Color1 = "FFFFFF";
+		LaserGun.Flags =SPF_FULLBRIGHT|SPF_NOTIMEFREEZE;
+		LaserGun.StartAlpha = 1.0;
+		LaserGun.FadeStep = -0.25;
+		LaserGun.Size = 125;
+		LaserGun.SizeStep = -10;
+		LaserGun.Lifetime = 10; 
+		LaserGun.Pos = where;
+		Level.SpawnParticle(LaserGun);
+	}
+}


### PR DESCRIPTION
- pb_cyberdemon, pb_beamrev and pb_draugr aim lasers now uses textured particles + linetrace to draw the beam instead of A_customrailgun  *they use an inventory item to handle the beam, since they arent in zscript yet
- added a tickless actor base fx class 
- fixed an oversight with CheatGive in zsplayer.zsx