### PR TITLE
Some keep weapons adjustments

### DIFF
--- a/actors/Weapons/Slot2/Deagle.dec
+++ b/actors/Weapons/Slot2/Deagle.dec
@@ -113,7 +113,6 @@ ACTOR PB_Deagle : PB_Weapon
 			}
 		TNT1 A 0 A_JumpIfInventory("DualWieldingDeagles", 1, "ReadyDualWield")
 	ReadyToFire:
-		D4E0 E 0 PB_TakeIfUpgrade("PB_Revolver") //A_TakeInventory("PB_Revolver", 2)
 		D4E0 E 1 {
 			if (PressingFire() && PressingAltfire() && CountInv("DeagleAmmo") > 0){
 					return state("Fire");
@@ -155,7 +154,7 @@ ACTOR PB_Deagle : PB_Weapon
 	
 	SelectAnimationDualWield:
 		TNT1 A 0 A_PlaySoundEx("weapons/deagle/equip", "Auto")
-		D7E0 GFEDCBA 1
+		D7E0 GFDBA 1
 		TNT1 A 0 A_PlaySoundEx("weapons/deagle/equip", "Auto")
 	ReadyDualWield:
 		TNT1 A 0 {
@@ -447,9 +446,9 @@ ACTOR PB_Deagle : PB_Weapon
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		Wait
 	DeselectDualWield:
-		D7E0 ABCDE 1 A_Setroll(roll+0.5, SPF_INTERPOLATE)
-		D7E0 FGH 1 A_Setroll(roll-1.0, SPF_INTERPOLATE)
-		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
+		D7E0 ABD 1 A_Setroll(roll+0.5, SPF_INTERPOLATE)
+		D7E0 FG 1 A_Setroll(roll-1.0, SPF_INTERPOLATE)
+		TNT1 A 0 A_Lower(120)
 		Wait
 
 	Select:
@@ -467,6 +466,7 @@ ACTOR PB_Deagle : PB_Weapon
 		TNT1 A 0 A_TakeInventory("GrabbedBarrel",1)
 		TNT1 A 0 A_TakeInventory("GrabbedIceBarrel",1)
 		TNT1 A 0 A_TakeInventory("GrabbedFlameBarrel",1)
+		D4E0 E 0 PB_TakeIfUpgrade("PB_Revolver")
 		
 		Goto SelectFirstPersonLegs
 		SelectContinue:

--- a/actors/Weapons/Slot2/REVOLVER.dec
+++ b/actors/Weapons/Slot2/REVOLVER.dec
@@ -61,6 +61,7 @@ ACTOR PB_Revolver : PB_Weapon
 	Inventory.AltHUDIcon "RVICA0"
 	PB_WeaponBase.respectItem "RespectRevolver"
 	FloatBobStrength 0.5
+	PB_WeaponBase.DualWieldToken "DualWieldingRevolver"
 	States
 	{  
 	
@@ -453,10 +454,9 @@ ACTOR PB_Revolver : PB_Weapon
 		TNT1 A 0 A_TakeInventory("GrabbedBarrel",1)
 		TNT1 A 0 A_TakeInventory("GrabbedIceBarrel",1)
 		TNT1 A 0 A_TakeInventory("GrabbedFlameBarrel",1)
-		
+		TNT1 A 0 PB_SelectifUpgade("PB_Deagle") //A_SelectWeapon("PB_Deagle")
 		Goto SelectFirstPersonLegs
 	SelectContinue:
-		TNT1 A 0 PB_SelectifUpgade("PB_Deagle") //A_SelectWeapon("PB_Deagle")
 		TNT1 A 0 PB_WeapTokenSwitch("RevolverSelected")
 		TNT1 A 0
 		TNT1 A 0 A_JumpIfInventory("SwitchingFromDualWieldRevolver", 1, "FastSwitchFromDualWield1")

--- a/actors/Weapons/Slot3/SSG.dec
+++ b/actors/Weapons/Slot3/SSG.dec
@@ -87,6 +87,7 @@ ACTOR PB_SSG : PB_weapon //Replaces SuperShotgun
 	Inventory.AltHUDIcon "SGN2A0"
 	PB_WeaponBase.respectItem "RespectSSG"
 	FloatBobStrength 0.5
+	PB_WeaponBase.DualWieldToken "DualWieldingSSG"
 	States
 	{
 		
@@ -145,7 +146,7 @@ ACTOR PB_SSG : PB_weapon //Replaces SuperShotgun
 		TNT1 A 0 A_TakeInventory("GrabbedFlameBarrel",1)
 		
 		Goto SelectFirstPersonLegs
-		SelectContinue:
+	SelectContinue:
 		TNT1 A 0 PB_SelectifUpgade("PB_QuadSG") //A_SelectWeapon("PB_QuadSG")
 		TNT1 A 0 PB_WeapTokenSwitch("SSGSelected")
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Raise

--- a/actors/Weapons/Slot4/Carbine.dec
+++ b/actors/Weapons/Slot4/Carbine.dec
@@ -82,7 +82,7 @@ ACTOR PB_Carbine : PB_Weapon
 	FloatBobStrength 0.5
 	PB_WeaponBase.OffsetRecoilX 3
 	PB_WeaponBase.OffsetRecoilY 1.5
-
+	PB_WeaponBase.DualWieldToken "DualWieldingCarbines"
 	States
 	{
 		Steady:

--- a/zscript/Weapons/BaseWeapon.zc
+++ b/zscript/Weapons/BaseWeapon.zc
@@ -61,6 +61,9 @@ class PB_WeaponBase : DoomWeapon
 	bool chainsawMode;
 	property chainsawMode: chainsawMode;
 	
+	string dualwieldToken;
+	property DualWieldToken:dualwieldToken;
+	
 	//Cemtex's PB_AmmoIntoMag function variables
 	string AmmoMag;
 	string AmmoPool;

--- a/zscript/Weapons/BaseWeapon_Functions.zsc
+++ b/zscript/Weapons/BaseWeapon_Functions.zsc
@@ -66,8 +66,15 @@ extend class PB_WeaponBase
 		//console.printf("cvar val: \ca"..pb_keepweapons.."\c-, weapon is: \cd"..invoker.getclassname().."\c-, oldweapon is: \ca"..oldweap.."\c-");
 		if(!pb_keepweapons)
 		{
+			let pbw = PB_WeaponBase(findinventory(oldweap));
+			if(pbw && pbw.DualWieldToken)
+			{
+				A_takeinventory(pbw.DualWieldToken,1);	//this function takes weapons that may be in akimbo mode, so you also need to take this token
+				pbw.A_SetAkimbo(false);
+			}
+			
 			//console.printf("taking: \cg"..oldweap.."\c-");
-			A_takeinventory(oldweap,2);
+			A_takeinventory(oldweap,3);
 		}
 	}
 	
@@ -77,6 +84,10 @@ extend class PB_WeaponBase
 		if(!pb_keepweapons)
 		{
 			//console.printf("switching to: \cg"..upgrade.."\c-");
+			A_SetAkimbo(false);
+			if(invoker.DualWieldToken)
+				A_takeinventory(invoker.DualWieldToken,1);
+			
 			A_selectweapon(upgrade);
 		}
 	}

--- a/zscript/Weapons/Projectiles/DragonsBreath.zs
+++ b/zscript/Weapons/Projectiles/DragonsBreath.zs
@@ -216,8 +216,8 @@ Class PB_DragonBreath : Actor
 				TNT1 A 0 A_Spawnprojectile ("FireworkSFXType2", 0, 0, random (0, 360), 2, random (-60, -30));
 				TNT1 A 0 A_SpawnItemEx("DragonsBreathPiece2", random (-35, 35), random (-35, 35));
 				TNT1 A 0 A_SpawnItemEx("DragonsBreathPiece3", random (-45, 45), random (-45, 35));
-				TNT1 AAAAAAAAAAAAAA 0 A_Spawnprojectile("SparkX", 2, 0, random (0, 360), 2, random (0, 360));
-				TNT1 A 0 A_SpawnItemEx ("RicoChet",0,0,-5,0,0,0,0,SXF_NOCHECKPOSITION,0);
+				TNT1 AAAAAAAAAAA 0 A_Spawnprojectile("SparkX", 2, 0, random (0, 360), 2, random (0, 360));
+				TNT1 A 0 A_SpawnItemEx ("PB_BulletPuff",0,0,-5,0,0,0,0,SXF_NOCHECKPOSITION,0);
 				Stop;
 			Death:
 				Stop;


### PR DESCRIPTION
-i forgot akimbo (shouldnt just take the weapons without making sure the akimbo related tokens/vars are too), fixed now 
-deagle dual wield (de)select animation isnt slower for no reason anymore 
-dragon breaths dont leave old flat decals anymore