### PR TITLE
Deagle Firing Rate Fix, Ammunition Management in KeepWeapManager Actor Fixed, Ammo Count System Fix, A_DoPBWeaponAction Reloading Update Fix

### DIFF
--- a/actors/Weapons/Slot2/MP40.dec
+++ b/actors/Weapons/Slot2/MP40.dec
@@ -64,7 +64,7 @@ ACTOR PB_MP40 : PB_Weapon
 	FloatBobStrength 0.5
 	PB_WeaponBase.OffsetRecoilX 2.5
 	PB_WeaponBase.OffsetRecoilY 2.5
-
+	PB_WeaponBase.DualWieldToken "DualWieldingMP40"
 	States
 	{
 		Steady:

--- a/actors/Weapons/Slot2/PBPISTOL.dec
+++ b/actors/Weapons/Slot2/PBPISTOL.dec
@@ -81,7 +81,7 @@ ACTOR PB_Pistol : PB_Weapon
 	PB_WeaponBase.UsesWheel 1
 	PB_WeaponBase.WheelInfo "PB_pistolWheel"
 	PB_WeaponBase.TailPitch 0.8
-
+	PB_WeaponBase.DualWieldToken "DualWieldingPistols"
 	States
 	{
 	

--- a/actors/Weapons/Slot2/UACSMG.dec
+++ b/actors/Weapons/Slot2/UACSMG.dec
@@ -142,7 +142,7 @@ ACTOR PB_SMG : PB_Weapon
 	PB_WeaponBase.TailPitch 1.2
 	// PB_WeaponBase.BarrelAttachmentPoint (6, 0, 0), (6, 0, 0)
 	+WEAPON.CHEATNOTWEAPON
-
+	PB_WeaponBase.DualWieldToken "DualWieldingSMGs"
 	States
 	{
 	Steady:

--- a/actors/Weapons/Slot3/AUTOSHOTGUN.dec
+++ b/actors/Weapons/Slot3/AUTOSHOTGUN.dec
@@ -137,7 +137,7 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 	PB_WeaponBase.OffsetRecoilX 2.5
 	PB_WeaponBase.OffsetRecoilY 2.5
 	PB_WeaponBase.TailPitch 0.75
-
+	PB_WeaponBase.DualWieldToken "DualWieldingAutoshotguns"
 	States
 	{
 		Steady:

--- a/actors/Weapons/Slot3/QUADBARREL.dec
+++ b/actors/Weapons/Slot3/QUADBARREL.dec
@@ -339,6 +339,7 @@ ACTOR PB_QuadSG : PB_Weapon
 	PB_WeaponBase.UnloaderToken "QuadShotgunHasUnloaded"
 	PB_WeaponBase.UsesWheel 1
 	PB_WeaponBase.WheelInfo "PB_QSGWheel"
+	PB_WeaponBase.DualWieldToken "QuadAkimboMode"
 	States
 	{
     Spawn:

--- a/actors/Weapons/Slot4/PBRIFLE.dec
+++ b/actors/Weapons/Slot4/PBRIFLE.dec
@@ -221,7 +221,7 @@ ACTOR Rifle : PB_Weapon
 	PB_WeaponBase.UsesWheel 0
 	PB_WeaponBase.WheelInfo "PB_RifleWheel"
 	PB_WeaponBase.TailPitch 0.5
-	
+	PB_WeaponBase.DualWieldToken "DualWieldingDMRs"
 	States
 	{
 		Steady:

--- a/actors/Weapons/Slot6/M2PLASMA.dec
+++ b/actors/Weapons/Slot6/M2PLASMA.dec
@@ -120,6 +120,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 	Scale 0.49
 	Inventory.AltHUDIcon "M2PRA0"
 	PB_WeaponBase.respectItem "RespectM2PlasmaGun"
+	PB_WeaponBase.DualWieldToken "DualWieldingM2Plasma"
 	//FloatBobStrength 0.5
 	States
 	{

--- a/actors/Weapons/Slot6/PLASMA.dec
+++ b/actors/Weapons/Slot6/PLASMA.dec
@@ -126,7 +126,7 @@ ACTOR PB_M1Plasma : PB_Weapon //Replaces PlasmaRifle
 	FloatBobStrength 0.5
 	PB_WeaponBase.OffsetRecoilX 2.5
 	PB_WeaponBase.OffsetRecoilY 2.0
-
+PB_WeaponBase.DualWieldToken "DualWieldingPlasma"
 	States
 	{
 	Steady:

--- a/zscript/Items/AmmoBase.zsc
+++ b/zscript/Items/AmmoBase.zsc
@@ -50,7 +50,12 @@ class PB_Ammo : Ammo
 		int aa = self.amount*factor;
 		if(toucher && toucher is "PlayerPawn")
 		{
-			cap = toucher.FindInventory("Backpack",true)?self.BackpackMaxAmount:self.MaxAmount;
+			if (!toucher.FindInventory(self.GetParentAmmo(),true)){
+				cap = toucher.FindInventory("Backpack",true)?self.BackpackMaxAmount:self.MaxAmount;
+			}
+			else{
+				cap = toucher.FindInventory(self.GetParentAmmo(),true).MaxAmount;
+			}
 			ca = toucher.CountInv(type);
 		}
 		res = cap-ca;

--- a/zscript/Weapons/BaseWeapon_Functions.zsc
+++ b/zscript/Weapons/BaseWeapon_Functions.zsc
@@ -1898,6 +1898,7 @@ extend class PB_WeaponBase
 		bool initialWRF_ALLOWRELOAD = false;
 		if (weapflags & WRF_ALLOWRELOAD) initialWRF_ALLOWRELOAD = true;
 		weapFlags &= ~(WRF_ALLOWRELOAD);
+		if(invoker is "Melee_Attacks"){weapFlags |= WRF_ALLOWRELOAD;}
 		if(invoker is "PB_BFG9000" && FindInventory("BFGBlackHoleMode")){weapFlags |= WRF_ALLOWRELOAD;}
 		if(invoker is "PB_MG42" && (CountInv("MG42HasOverheated") || CountInv("MG42BarrelOverheat") >= 1) ){weapFlags |= WRF_ALLOWRELOAD;}
 		bool ReloadCheck = !noReload && initialWRF_ALLOWRELOAD && (invoker.ammotype2 && countinv(invoker.ammotype1) > 0 && countinv(invoker.ammotype2) < GetAmmoCapacity(invoker.ammotype2));

--- a/zscript/Weapons/BaseWeapon_Functions.zsc
+++ b/zscript/Weapons/BaseWeapon_Functions.zsc
@@ -1895,6 +1895,11 @@ extend class PB_WeaponBase
 	
 	action state A_DoPBWeaponAction(int weapflags = WRF_ALLOWRELOAD, int pbFlags = 0, string unloadtoken = "HasUnloaded", bool noReload = false)
 	{
+		weapFlags &= ~(WRF_ALLOWRELOAD);
+		if(invoker is "PB_BFG9000" && FindInventory("BFGBlackHoleMode")){weapFlags |= WRF_ALLOWRELOAD;}
+		if(invoker is "PB_MG42" && (CountInv("MG42HasOverheated") || CountInv("MG42BarrelOverheat") >= 1) ){weapFlags |= WRF_ALLOWRELOAD;}
+		bool ReloadCheck = !noReload && (invoker.ammotype2 && countinv(invoker.ammotype1) > 0 && countinv(invoker.ammotype2) < GetAmmoCapacity(invoker.ammotype2));
+		if( !(invoker is "PB_Unmaker") && ReloadCheck ){weapFlags |= WRF_ALLOWRELOAD;}
 		static const string PBWeapEmptyToken[] = 
 		{
 			"PB_PistolWasEmpty","RifleWasEmpty","UACSMGWasEmpty"

--- a/zscript/Weapons/BaseWeapon_Functions.zsc
+++ b/zscript/Weapons/BaseWeapon_Functions.zsc
@@ -1901,7 +1901,9 @@ extend class PB_WeaponBase
 		if(invoker is "Melee_Attacks"){weapFlags |= WRF_ALLOWRELOAD;}
 		if(invoker is "PB_BFG9000" && FindInventory("BFGBlackHoleMode")){weapFlags |= WRF_ALLOWRELOAD;}
 		if(invoker is "PB_MG42" && (CountInv("MG42HasOverheated") || CountInv("MG42BarrelOverheat") >= 1) ){weapFlags |= WRF_ALLOWRELOAD;}
-		bool ReloadCheck = !noReload && initialWRF_ALLOWRELOAD && (invoker.ammotype2 && countinv(invoker.ammotype1) > 0 && countinv(invoker.ammotype2) < GetAmmoCapacity(invoker.ammotype2));
+		bool dualWieldCheck = invoker.DualWieldToken && FindInventory(invoker.DualWieldToken);
+		bool canLoadAmmo = invoker.ammotype2 && countinv(invoker.ammotype1) > 0 && countinv(invoker.ammotype2) < GetAmmoCapacity(invoker.ammotype2);
+		bool ReloadCheck = !noReload && initialWRF_ALLOWRELOAD && (canLoadAmmo || dualWieldCheck);
 		if( !(invoker is "PB_Unmaker") && ReloadCheck ){weapFlags |= WRF_ALLOWRELOAD;}
 		static const string PBWeapEmptyToken[] = 
 		{

--- a/zscript/Weapons/BaseWeapon_Functions.zsc
+++ b/zscript/Weapons/BaseWeapon_Functions.zsc
@@ -1895,10 +1895,12 @@ extend class PB_WeaponBase
 	
 	action state A_DoPBWeaponAction(int weapflags = WRF_ALLOWRELOAD, int pbFlags = 0, string unloadtoken = "HasUnloaded", bool noReload = false)
 	{
+		bool initialWRF_ALLOWRELOAD = false;
+		if (weapflags & WRF_ALLOWRELOAD) initialWRF_ALLOWRELOAD = true;
 		weapFlags &= ~(WRF_ALLOWRELOAD);
 		if(invoker is "PB_BFG9000" && FindInventory("BFGBlackHoleMode")){weapFlags |= WRF_ALLOWRELOAD;}
 		if(invoker is "PB_MG42" && (CountInv("MG42HasOverheated") || CountInv("MG42BarrelOverheat") >= 1) ){weapFlags |= WRF_ALLOWRELOAD;}
-		bool ReloadCheck = !noReload && (invoker.ammotype2 && countinv(invoker.ammotype1) > 0 && countinv(invoker.ammotype2) < GetAmmoCapacity(invoker.ammotype2));
+		bool ReloadCheck = !noReload && initialWRF_ALLOWRELOAD && (invoker.ammotype2 && countinv(invoker.ammotype1) > 0 && countinv(invoker.ammotype2) < GetAmmoCapacity(invoker.ammotype2));
 		if( !(invoker is "PB_Unmaker") && ReloadCheck ){weapFlags |= WRF_ALLOWRELOAD;}
 		static const string PBWeapEmptyToken[] = 
 		{

--- a/zscript/Weapons/Keepweapmanager.zsc
+++ b/zscript/Weapons/Keepweapmanager.zsc
@@ -41,7 +41,7 @@ class KeepWeapManager : inventory
 					if(wp.AmmoType1 != null && wp.AmmoGive1 > 0)
 					{
 						ammo amu1 = ammo(owner.findinventory(wp.ammotype1));
-						int left1 = (gotbackpack ? amu1.BackpackMaxAmount : amu1.maxamount) - amu1.amount;
+						int left1 = owner.GetAmmoCapacity(amu1.GetClass()) - amu1.amount;
 						
 						if(left1 > 0)
 						{
@@ -53,7 +53,7 @@ class KeepWeapManager : inventory
 					if(wp.AmmoType2 != null && wp.AmmoGive2 > 0)
 					{
 						ammo amu2 = ammo(owner.findinventory(wp.ammotype2));
-						int left2 = (gotbackpack ? amu2.BackpackMaxAmount : amu2.maxamount) - amu2.amount;
+						int left2 = owner.GetAmmoCapacity(amu2.GetClass()) - amu2.amount;
 						
 						if(left2 > 0)
 						{

--- a/zscript/Weapons/Slot2/Deagle.zs
+++ b/zscript/Weapons/Slot2/Deagle.zs
@@ -238,7 +238,7 @@ class PB_Deagle : PB_WeaponBase
 				A_SetInventory("Zoomed",0);
 				A_ZoomFactor(1.0);
 				A_WeaponOffset(0,32);
-				PB_HandleCrosshair(69);
+				PB_HandleCrosshair(42);
 			}
 			TNT1 A 0 PB_jumpIfHasBarrel("IdleBarrel","IdleFlameBarrel","IdleIceBarrel");
 			TNT1 A 0 A_JumpIf(A_CheckAkimbo(), "ReloadDualWield");
@@ -635,7 +635,7 @@ class PB_Deagle : PB_WeaponBase
 			TNT1 A 0 {
 				A_SetInventory("Zoomed",0);
 				A_ZoomFactor(1.0);
-				PB_HandleCrosshair(69);
+				PB_HandleCrosshair(42);
 			}
 			D3E1 EDCBA 1;
 			Goto Ready3;

--- a/zscript/Weapons/Slot2/Deagle.zs
+++ b/zscript/Weapons/Slot2/Deagle.zs
@@ -670,7 +670,7 @@ class PB_Deagle : PB_WeaponBase
 			}
 			Loop;
 		
-		Fire2:
+			Fire2:
 			TNT1 A 0 {
 					A_WeaponOffset(0,32);
 				}
@@ -692,8 +692,8 @@ class PB_Deagle : PB_WeaponBase
 				}
 			D3E0 C 1 BRIGHT PB_WeaponRecoil(-0.90,-0.25);
 			D3E0 DEF 1 A_ZoomFactor(1.2);
-			D3E0 GHA 1 A_ZoomFactor(1.18);
-			D3E0 AAAA 1 {
+			D3E0 GH 1 A_ZoomFactor(1.18);
+			D3E0 AAAAA 1 {
 				A_SetInventory("CantDoAction",0);
 				 
 				if(Cvar.GetCvar("pb_toggle_aim_hold",player).getint()) 


### PR DESCRIPTION
Corrected the ADS fire rate of the Deagle to match that of non-ADS.
Suggestion link:
https://discord.com/channels/498342220815007779/863756935484145674/1300547413722796093
Allows for a more dynamic and addon-friendly pickup system that functions when it does not rely on the BackpackAmount initially defined in the ammo definition, so it is more robust. For example, initially, when you get a heavy backpack addon that sets your ammo capacity to something higher than the initial backpack amount, the amount given shown in the pickup message is negative. This fixes it.
Suggestion link:
https://discord.com/channels/498342220815007779/863756935484145674/1300290498317254686
Ensures the idle animations do not get interrupted by hitting the 'reload' key if you can't even reload. While it is more of an aesthetic change, it does look janky and weird otherwise when holding the 'reload' key. This also accounts for the weapons that do use the reload key for functions other than reloading, but those are accounted for individually:
- PB_BFG9000
- PB_Unmaker
- PB_MG42

Suggestion link:
https://discord.com/channels/498342220815007779/863756935484145674/1300524374138421279