### PR TITLE
spawner things

### DIFF
--- a/CVARINFO
+++ b/CVARINFO
@@ -218,6 +218,8 @@ server bool DisablePB_MinigunUpgrade = false;
 server bool DisablePB_M2Upgrade = false;
 server bool DisablePB_Unmaker = false; //Why would you want this disabled???
 server bool DisablePB_FlamerUpgrade = false;	//not actually sure wich tier is this
+server bool DisablePB_Flamer = false;
+server int  DisablePB_MG42 = 0;	//0 can replace bfg, 1 only on wolfenstein maps, 2 or anything else is disabled
 server int pb_NoUpgrades = 0;
 server int pb_NoPulseCannonUpgrade = 0;
 

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -218,6 +218,7 @@ OptionMenu "WeaponSpawns"
 	Option "Carbine", "DisablePB_Carbine", "OffOn"
 	Option "Grenade Launcher", "DisablePB_SuperGL", "OffOn"
 	Option "M2 Plasma Rifle", "DisablePB_M2Plasma", "OffOn"
+	Option "Flamethrower","DisablePB_Flamer","OffOn"
 	StaticText " "
 	StaticText "--------Tier 3 Weapons-------", gold
 	Option "Sub Machine Gun", "DisablePB_SMG", "OffOn"
@@ -225,9 +226,11 @@ OptionMenu "WeaponSpawns"
 	Option "Quad-Barreled Shotgun",				"DisablePB_QuadSG", "OffOn"
 	Option "Heavy DMR",				"DisableRifleUpgrade", "OffOn"
 	Option "Nailgun", "DisablePB_Nailgun", "OffOn"
+	Option "MG42","DisablePB_MG42","MG42Spawns"
 	Option "Anti-Matter Pulse Cannon",				"DisablePulseCannonUpgrade", "OffOn"
 	Option "Cryo Rifle", "DisablePB_CryoRifle", "OffOn"
 	Option "Rail Gun", "DisablePB_Railgun", "OffOn"
+	option "Flamethrower Upgrade","DisablePB_FlamerUpgrade","OffOn"
 	StaticText " "
 	StaticText "--------Tier 4 Weapons--------", gold
 	Option "'Martian Raptor' Automag pistol",				"DisablePB_Deagle", "OffOn"
@@ -246,6 +249,13 @@ OptionValue "ReticleCode"
 {
 	0, "DECORATE"
 	1, "ACS with floating"
+}
+
+optionvalue "MG42Spawns"
+{
+	0,"On"
+	1,"On (only in Wolfenstein maps)"
+	2,"Off"
 }
 
 OptionMenu "GameplaySettings"

--- a/zscript/PBHandler.zc
+++ b/zscript/PBHandler.zc
@@ -13,6 +13,8 @@ class PB_EventHandler : EventHandler
 	int taunttimer;
 	const tauntcooldown = 40;
 	
+	bool WSuSinMap;	//check for WolfensteinSS	
+	
 	bool gz413detected;
 	
 	transient int pickuptic[MAXPLAYERS];
@@ -466,7 +468,7 @@ class PB_EventHandler : EventHandler
 			case 'Fatso':					e.replacement = 'PBMancubusSpawner';			break;
 			case 'Cyberdemon':				e.replacement = 'PBCyberDemonSpawner';			break;
 			case 'SpiderMastermind':		e.replacement = 'PBSpiderMasterMindSpawner';	break;
-			case 'WolfensteinSS':			e.replacement = 'EvilNaziSpawner';				break;
+			case 'WolfensteinSS':			e.replacement = 'EvilNaziSpawner';	WSuSinMap = true;	break;
 			
 		}
 	}

--- a/zscript/Spawner/Ammo/PB_PackSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_PackSpawner.zc
@@ -103,7 +103,7 @@ Class UpgradeSpawner : Actor
 		Spawn:
 			TNT1 A 0;
 			TNT1 A 0 A_jumpif(pb_NoUpgrades,"Null");
-			TNT1 A 0 A_Jump(256, "SpawnFlamerUpgrade", "SpawnLMG", "SpawnQuadSSG", "SpawnPB_AutoshotgunUpgrade", "SpawnPB_MinigunUpgrade", "SpawnDragonBreathUpgrade", "SpawnPB_UnmakerUpgrade", "SpawnM2Upgrade", "SpawnDeagle", "SpawnRifleUpgrade");
+			TNT1 A 0 A_Jump(256, "SpawnFlamerUpgrade", "SpawnLMG", "SpawnQuadSSG", "SpawnPB_AutoshotgunUpgrade", "SpawnPB_MinigunUpgrade", "SpawnDragonBreathUpgrade", "SpawnPB_UnmakerUpgrade", "SpawnM2Upgrade", "SpawnDeagle", "SpawnRifleUpgrade","SpawnSMG");
 			
 		SpawnFlamerUpgrade:
 			TNT1 A 0 A_jumpif(DisablePB_FlamerUpgrade,"SpawnLMG");
@@ -141,8 +141,13 @@ Class UpgradeSpawner : Actor
 			Stop;
 			
 		SpawnM2Upgrade:
-			TNT1 A 0 A_jumpif(DisablePB_M2Upgrade,"SpawnDeagle");
+			TNT1 A 0 A_jumpif(DisablePB_M2Upgrade,"SpawnSMG");
 			TNT1 A 0 A_SpawnItemEx("PB_M2Upgrade",0,0,0,0,0,0,0,288);
+			Stop;
+		
+		SpawnSMG:
+			TNT1 A 0 A_jumpif(DisablePB_SMG,"SpawnDeagle");
+			TNT1 A 0 A_SpawnItemEx("PB_SMG",0,0,0,0,0,0,0,288);
 			Stop;
 			
 		SpawnDeagle:

--- a/zscript/Spawner/Weapons/PB_BFGSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_BFGSpawner.zc
@@ -64,6 +64,11 @@ class PB_BFGSpawnerT3 : PB_WeaponSpawner
 	{
 		DropItem 'PB_MG42', 255, 1;
 	}
+	override void HandleSpawnExeptions(in out name toSpawn)
+	{	
+		if(toSpawn == "PB_MG42" && (DisablePB_MG42 > 1 || (DisablePB_MG42 == 1 && !Handler.WSuSinMap)))	//if the weapon is disabled or only allowed when wolfss in map (and there are none)
+			toSpawn = "PB_BFG9000";
+	}
 }
 
 class PB_BFGSpawnerT4 : PB_WeaponSpawner

--- a/zscript/Spawner/Weapons/PB_ChainsawSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_ChainsawSpawner.zc
@@ -56,7 +56,11 @@ class PB_SawSpawnerT2 : PB_WeaponSpawner
 		DropItem 'PB_Chainsaw', 255, 1;
 		DropItem 'PB_Flamethrower', 255, 1;
 	}
-	
+	override void HandleSpawnExeptions(in out name toSpawn)
+	{
+		if(DisablePB_Flamer && toSpawn == "PB_Flamethrower")
+			toSpawn = "PB_Chainsaw";
+	}
 }
 
 class PB_SawSpawnerT3 : PB_WeaponSpawner
@@ -66,6 +70,13 @@ class PB_SawSpawnerT3 : PB_WeaponSpawner
 		DropItem 'PB_Flamethrower', 255, 1;
 		DropItem 'PB_FlamethrowerUpgrade', 255, 1;
 	}
+	override void HandleSpawnExeptions(in out name toSpawn)
+	{
+		if(DisablePB_FlamerUpgrade && toSpawn == "PB_FlamethrowerUpgrade")
+			toSpawn = "PB_Flamethrower";
+		if(DisablePB_Flamer && toSpawn == "PB_Flamethrower")
+			toSpawn = "PB_Chainsaw";
+	}
 }
 
 class PB_SawSpawnerT4 : PB_WeaponSpawner
@@ -73,5 +84,12 @@ class PB_SawSpawnerT4 : PB_WeaponSpawner
 	Default
 	{
 		DropItem 'PB_FlamethrowerUpgrade', 255, 1;
+	}
+	override void HandleSpawnExeptions(in out name toSpawn)
+	{
+		if(DisablePB_FlamerUpgrade && toSpawn == "PB_FlamethrowerUpgrade")
+			toSpawn = "PB_Flamethrower";
+		if(DisablePB_Flamer && toSpawn == "PB_Flamethrower")
+			toSpawn = "PB_Chainsaw";
 	}
 }

--- a/zscript/Weapons/Slot2/Deagle.zs
+++ b/zscript/Weapons/Slot2/Deagle.zs
@@ -87,6 +87,7 @@ class PB_Deagle : PB_WeaponBase
 		
 		Ready:
 			TNT1 A 0 A_WeaponOffset(0,32);
+			TNT1 A 0 A_SetCrosshair(42);
 		Ready3:
 			TNT1 A 0 A_JumpIf(A_CheckAkimbo(), "ReadyDualWield");
 			TNT1 A 0 A_jumpif(invoker.ammo2.amount < 1,"ReadyUnloaded");

--- a/zscript/Weapons/Slot2/Deagle.zs
+++ b/zscript/Weapons/Slot2/Deagle.zs
@@ -62,6 +62,7 @@ class PB_Deagle : PB_WeaponBase
 			D4E2 B 1 { A_DoPBWeaponAction(); A_weaponoffset(0,32,WOF_interpolate);}
 			TNT1 A 0 A_Startsound("weapons/deagle/swapfol",18,CHANF_OVERLAP);
 			D4E2 CDEFG 1 A_DoPBWeaponAction();
+			TNT1 A 0 A_SetCrosshair(42);
 			goto ready3;
 			
 		Select:

--- a/zscript/Weapons/Slot2/Deagle.zs
+++ b/zscript/Weapons/Slot2/Deagle.zs
@@ -241,7 +241,7 @@ class PB_Deagle : PB_WeaponBase
 				A_SetInventory("Zoomed",0);
 				A_ZoomFactor(1.0);
 				A_WeaponOffset(0,32);
-				PB_HandleCrosshair(42);
+				PB_HandleCrosshair(5);
 			}
 			TNT1 A 0 PB_jumpIfHasBarrel("IdleBarrel","IdleFlameBarrel","IdleIceBarrel");
 			TNT1 A 0 A_JumpIf(A_CheckAkimbo(), "ReloadDualWield");

--- a/zscript/Weapons/Slot2/Revolver.zs
+++ b/zscript/Weapons/Slot2/Revolver.zs
@@ -362,7 +362,7 @@ Class PB_Revolver : PB_WeaponBase
 			TNT1 A 0 {
 				A_WeaponOffset(0,32);
 				A_SetRoll(0);
-				PB_HandleCrosshair(69);
+				PB_HandleCrosshair(5);
 				A_SetInventory("PB_LockScreenTilt",0);
 			}
 			TNT1 A 0 A_jumpif(countinv("zoomed") > 0,"zoomout");
@@ -379,7 +379,7 @@ Class PB_Revolver : PB_WeaponBase
 			TNT1 A 0 {
 				A_SetInventory("Zoomed",0);
 				A_ZoomFactor(1.0);
-				PB_HandleCrosshair(69);
+				PB_HandleCrosshair(42);
 			}
 			R4V2 EDCBA 1;
 			Goto Ready3;


### PR DESCRIPTION
- mg42 and flamethrower can be disabled from their spawners (also the mg42 can be set to only spawn in wolfenstein maps)
- added smg to the upgradespawner
- fixed deagle crosshair dissapearing after reloading
