### PR TITLE
Updated decoration blocking bullets

### DIFF
--- a/zscript/Weapons/Projectiles/BulletProjectile.zsc
+++ b/zscript/Weapons/Projectiles/BulletProjectile.zsc
@@ -125,7 +125,7 @@ class PB_Projectile : FastProjectile abstract
 	
 	override int SpecialMissileHit(Actor victim)
 	{
-		if (victim == Target && !bHitOwner  || !victim.bSHOOTABLE)
+		if (victim == Target && !bHitOwner  || (!victim.bSHOOTABLE && (target.GetSpecies() == "Marines" || target is "PlayerPawn")))
 		{
 			return 1; //[inkoalawetrust] //This is default behavior though ?
 		}


### PR DESCRIPTION
Only Players or anything with the species 'Marines' can shoot through decorative actors now.