### PR TITLE
Upgrade Item Fixes + Minor nailgun tweak + Chaingunguy ZScript Death States + Map Compatibility patches

### DIFF
--- a/ZSCRIPT.zc
+++ b/ZSCRIPT.zc
@@ -261,6 +261,7 @@ const MAXITERATIONS = 32676;
 #include "zscript/Spawner/Monsters/PBMastermindSpawner.zc"
 #include "zscript/Spawner/Monsters/PBCyberDemonSpawner.zc"
 #include "zscript/Spawner/Monsters/PBNaziSpawner.zc"
+#include "zscript/Spawner/Monsters/PBStealthMonsterSpawner.zc"
 
 #include "zscript/Spawner/Ammo/PB_PackSpawner.zc"
 #include "zscript/Spawner/Ammo/PB_MagSpawner.zc"

--- a/actors/Monsters/T1-Grunts/Commando.dec
+++ b/actors/Monsters/T1-Grunts/Commando.dec
@@ -39,16 +39,16 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 	MaxStepHeight 24
 	MaxDropOffHeight 32
 	+FLOORCLIP
-    +MISSILEMORE
-    +MISSILEEVENMORE
+	+MISSILEMORE
+	+MISSILEEVENMORE
 	damagefactor "Blood", 0.0 damagefactor "BlueBlood", 0.0 damagefactor "GreenBlood", 0.0
 	SeeSound "commando/sight"
 	PainSound "commando/pain"
 	DeathSound "commando/death"
 	ActiveSound "commando/active"
 	AttackSound "weapons/minigun/chaingunmode/fire"
-    damagefactor "Kick", 0.4
-    damagefactor "Shrapnel", 0.4
+	damagefactor "Kick", 0.4
+	damagefactor "Shrapnel", 0.4
 	damagefactor "explosiveimpact", 2.0
 	DropItem "None" 3
 	Obituary "%o has been mowed down by a Zombie Commando."
@@ -73,9 +73,9 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		Goto Death.SSG
 	
 	Pain.Siphon:
-        TNT1 A 0 
+		TNT1 A 0 
 		
-		TNT1 AAA 0 A_SpawnItemEx ("RedLightning_Small", random (-12, 12), random (-12, 12), random (16, 52), 0, 0)
+		TNT1 AAA 0 A_SpawnItemEx("RedLightning_Small", random (-12, 12), random (-12, 12), random (16, 52), 0, 0)
 		MPOS G 1 
 		{
 			A_FaceTarget;
@@ -87,19 +87,19 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		
 	Death.Shrink:
 		TNT1 A 1 A_PlaySound("Shrink", 3)
-		TNT1 A 0 A_SpawnItemEx ("ChaingunGuy1ShrinkFX1", 0, 0,  5, 0, 0)
-		TNT1 A 1 A_SpawnItemEx ("ChaingunGuy1ShrinkFX2", 0, 0, 5, 0, 0)
-		TNT1 A 1 A_SpawnItemEx ("ChaingunGuy1ShrinkFX3", 0, 0, 5, 0, 0)
-		TNT1 A 1 A_SpawnItemEx ("ChaingunGuy1ShrinkFX4", 0, 0, 5, 0, 0)
-		TNT1 A 1 A_SpawnItemEx ("ChaingunGuy1ShrinkFX5", 0, 0, 5, 0, 0)
-		TNT1 A 1 A_SpawnItemEx ("ChaingunGuy1ShrinkFX6", 0, 0, 5, 0, 0)
-		TNT1 A 1 A_SpawnItemEx ("ChaingunGuy1ShrinkFX7", 0, 0, 5, 0, 0)
-		TNT1 A 1 A_SpawnItemEx ("LilChaingunGuy1", 1)
+		TNT1 A 0 A_SpawnItemEx("ChaingunGuy1ShrinkFX1", 0, 0,  5, 0, 0)
+		TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX2", 0, 0, 5, 0, 0)
+		TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX3", 0, 0, 5, 0, 0)
+		TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX4", 0, 0, 5, 0, 0)
+		TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX5", 0, 0, 5, 0, 0)
+		TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX6", 0, 0, 5, 0, 0)
+		TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX7", 0, 0, 5, 0, 0)
+		TNT1 A 1 A_SpawnItemEx("LilChaingunGuy1", 1)
 		stop
 		
 	Death.Blackhole:
-        TNT1 A 0 A_NoBlocking
-        TNT1 A 0 A_SpawnItem("BlackHoledHuman")
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_SpawnItem("BlackHoledHuman")
 		Stop
 		
 	
@@ -114,7 +114,7 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 	STAND:
 		TNT1 A 0
 		TNT1 A 0 A_CheckSight("Stand2")
-        TNT1 A 0
+		TNT1 A 0
 		MPOS BB 10 A_Look
 		Loop
 		
@@ -125,7 +125,7 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 	Idle:	
 	SearchForPlayer:
 		TNT1 A 0 A_ClearTarget
-	    TNT1 A 0 A_TakeInventory("EnemyMemory", 30)
+		TNT1 A 0 A_TakeInventory("EnemyMemory", 30)
 		TNT1 A 0 A_GiveInventory("SKChaingunguy", 1)
 		
 		MPOS A 0 
@@ -193,8 +193,8 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 	Goto SeeContinue
 	
 	SeeContinue:
-	    //TNT1 A 0 A_CheckSight("SeeNeverSeen")
-        
+		//TNT1 A 0 A_CheckSight("SeeNeverSeen")
+		
 		TNT1 A 0 A_JumpIfInventory("EnemyMemory", 12, "SearchForPlayer")
 		TNT1 A 0 A_GiveInventory("EnemyMemory", 1)
 		MPOS A 0 
@@ -240,7 +240,7 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		Loop
 		
 	SeeNeverSeen:
-        
+		
 		TNT1 A 0 A_TakeInventory("SKChaingunGuy", 1)
 		MPOS A 0 
 		MPOS AA 2 A_Chase
@@ -263,7 +263,7 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		MPOS DD 2 A_Chase
 		MPOS A 0 
 		MPOS DD 2 A_Chase
-        TNT1 A 0 A_CheckSight("SeeNeverSeen")
+		TNT1 A 0 A_CheckSight("SeeNeverSeen")
 		Goto SeeContinue
 
 	Missile:
@@ -283,55 +283,55 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		TNT1 A 0 A_GiveInventory("IsFiring", 1)
 		TNT1 A 0
 
-    MissileContinue:
+	MissileContinue:
 		MPOS E 1 A_FaceTarget
 		TNT1 A 0 
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-9, 9), 1, random(-2, 2))
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-9, 9), 1, random(-2, 2))
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
 		
 		MPOS E 2 A_FaceTarget 
 		TNT1 A 0 
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-7, 7), 1, random(-2, 2))
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-7, 7), 1, random(-2, 2))
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
 		
 		MPOS E 2 A_FaceTarget 
 		TNT1 A 0 
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
-        MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-9, 9), 1, random(-2, 2))
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
+		MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-9, 9), 1, random(-2, 2))
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
 		
 		MPOS E 2 A_FaceTarget 
 		TNT1 A 0 
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-7, 7), 1, random(-2, 2))
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-7, 7), 1, random(-2, 2))
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
 		
 		MPOS E 2 A_FaceTarget 
 		TNT1 A 0 
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-9, 9), 1, random(-2, 2))
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-9, 9), 1, random(-2, 2))
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
 		
 		TNT1 A 0 A_JumpIfInTargetInventory("ChainguyguyContinue", 1, "MissileContinue")
 		MPOS E 2 A_FaceTarget 
 		TNT1 A 0 
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 34, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-9, 9), 1, random(-2, 2))
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		MPOS F 1 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 38, 0, random(-9, 9), 1, random(-2, 2))
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
 		
 		TNT1 A 0 A_CheckSight("SeeContinue")
 		TNT1 A 0 A_JumpIfInTargetInventory("ChainguyguyContinue", 1, "MissileContinue")
@@ -349,97 +349,97 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		MP1S A 12 A_FaceTarget
 		TNT1 A 0
 		TNT1 A 0
-    MissileCrouchedContinue:
+	MissileCrouchedContinue:
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
 		MP1S A 2 A_FaceTarget 
 		TNT1 A 0
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire", 2)
-        MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
+		MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
 		TNT1 A 0
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
 		
 		MP1S A 2 A_FaceTarget 
 		TNT1 A 0
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 20,0)
+		MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 20,0)
 		
 		TNT1 A 0
 		MP1S A 2 A_FaceTarget 
 		TNT1 A 0
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 20,0)
+		MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 20,0)
 		
 		TNT1 A 0
 		MP1S A 2 A_FaceTarget
 		TNT1 A 0
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 20,0)
+		MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 20,0)
 		
 		TNT1 A 0
 		MP1S A 2 A_FaceTarget
 		TNT1 A 0
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 20,0)
+		MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 20,0)
 		
 		TNT1 A 0
 		TNT1 A 0 A_JumpIfInTargetInventory("ChainguyguyContinue", 1, "MissileContinue")
 		MP1S A 2 A_FaceTarget 
 		TNT1 A 0
-        TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
+		TNT1 AA 0 A_CustomMissile("OrangeLensFlareAltFast", 24, 10, 15, 0)
 		TNT1 A 0 A_PlaySound("weapons/minigun/chaingunmode/fire")
 		TNT1 A 0 PB_DynamicTailMonster("lmg", "br")
-        MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 20,0)
+		MP1S B 2 BRIGHT A_CustomMissile("PB_MonsterMinigunTracer", 28, 0, random(-8, 8), 0)
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 20,0)
 		
 		TNT1 A 0 A_CPosRefire
 		TNT1 A 0 A_JumpIfInTargetInventory("ChainguyguyContinue", 1, "MissileContinue")
 		Goto MissileCrouchedContinue
 
-     SpecialAttack:
+	SpecialAttack:
 		TNT1 A 0 
 		MPOS E 10 A_FaceTarget 
 		TNT1 A 0 
-        TNT1 A 0 A_CustomMissile("FireFightFlare", 34, 10, 15, 25)
+		TNT1 A 0 A_CustomMissile("FireFightFlare", 34, 10, 15, 25)
 		MPOS F 10 //A_CustomMissile("CommandoGrenade",10,0,0,0)
-        TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
 		TNT1 A 0 
 		MPOS E 10
-        Goto SeeContinue
+		Goto SeeContinue
 		
-   
+	
 		
-	   Pain.Melee:
+		Pain.Melee:
 		MPOS G 3
  		TNT1 A 0 
-        MPOS G 3 A_Pain
+		MPOS G 3 A_Pain
 		TNT1 A 0 A_TakeInventory("IsFiring", 1)
-        Goto See
-     Pain:
-	    TNT1 A 0
+		Goto See
+	Pain:
+		TNT1 A 0
 		TNT1 A 0 A_JumpIfInventory("IsFiring", 1, "Pain.IsFiring")
 		TNT1 A 0 
 		TNT1 A 0 A_TakeInventory("SKChaingunGuy", 1)
 		MPOS G 3
  		TNT1 A 0 
-        MPOS G 3 A_Pain
+		MPOS G 3 A_Pain
 		TNT1 A 0 A_TakeInventory("IsFiring", 1)
-        Goto SeeContinue
+		Goto SeeContinue
 		
-	 Possession:
+	Possession:
 		TNT1 A 0 A_StopAllSounds
 		TNT1 A 0 A_SetInvulnerable
 		MPOS G 3
@@ -452,65 +452,65 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 	
 	Pain.Stun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItemEx ("StunElectrocute", random (-4, 4), random (-4, 4),  random (16, 32), 0, 0)
-        TNT1 A 0 
+		TNT1 A 0 A_SpawnItemEx("StunElectrocute", random (-4, 4), random (-4, 4),  random (16, 32), 0, 0)
+		TNT1 A 0 
 		MPOS G 1 A_Pain
-		MPOS GGGGGGGGGG 3 A_SpawnItemEx ("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
-        TNT1 A 0 
+		MPOS GGGGGGGGGG 3 A_SpawnItemEx("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
+		TNT1 A 0 
 		MPOS G 1 A_Pain
-		MPOS GGGGGGGGGG 3 A_SpawnItemEx ("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
-        TNT1 A 0 
+		MPOS GGGGGGGGGG 3 A_SpawnItemEx("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
+		TNT1 A 0 
 		MPOS G 1 A_Pain
-		MPOS GGGGGGGGGG 3 A_SpawnItemEx ("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
-        TNT1 A 0 
+		MPOS GGGGGGGGGG 3 A_SpawnItemEx("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
+		TNT1 A 0 
 		MPOS G 1 A_Pain
-		MPOS GGGGGGGGGG 3 A_SpawnItemEx ("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
-        TNT1 A 0 
+		MPOS GGGGGGGGGG 3 A_SpawnItemEx("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
+		TNT1 A 0 
 		MPOS G 1 A_Pain
-		MPOS GGGGGGGGGG 3 A_SpawnItemEx ("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
-        TNT1 A 0 
+		MPOS GGGGGGGGGG 3 A_SpawnItemEx("StunElectrocute", random (-12, 12), random (-12, 12),  random (16, 52), 0, 0)
+		TNT1 A 0 
 		MPOS G 1 A_Pain
 		Goto See
 		
 	Pain.IsFiring:	
 	CPDR A 3 
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 32, 15, 0, 2, -20)
+	TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+	TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 32, 15, 0, 2, -20)
 	CPDR B 3 BRIGHT //A_NoBlocking
 	Goto MissileContinue
 	
 	Pain.ExtremePunches:
-        TNT1 A 0 A_FaceTarget
+		TNT1 A 0 A_FaceTarget
 		TNT1 A 0 A_JumpIfInTargetInventory("Kicking",1, 1)
 		Goto Pain.IsFiring
 	Pain.Kick:
-		 TNT1 A 0 
-         TNT1 A 0 A_Pain
-		 TNT1 A 0 A_TakeInventory("IsFiring", 1)
-		 TNT1 A 0 A_TakeInventory("SKChaingunGuy", 1)
-         TNT1 A 0
-        TNT1 A 0 //ThrustThingZ(0,15,0,1)
-        TNT1 A 0 A_FaceTarget
-        TNT1 A 0 A_Recoil (3)
-         MPOS G 2
-		 CPBK ABC 2
-		 MPOS A 0 
-		 CPBK C 8 A_Pain
-		 MPOS A 0 
-		 CPBK D 8 
-		 MPOS A 0 
-		 CPBK C 8 A_Pain
-		 CPBK D 8 
-		 MPOS A 0 
-		 CPBK C 8 A_Pain
-		 CPBK D 8 
-		 MPOS A 0 
-		 CPBK C 8 A_Pain
-		 CPBK D 8 
-		 MPOS A 0 
-		 CPBK BA 4
-		 MPOS G 4
-         Goto See
+		TNT1 A 0 
+		TNT1 A 0 A_Pain
+		TNT1 A 0 A_TakeInventory("IsFiring", 1)
+		TNT1 A 0 A_TakeInventory("SKChaingunGuy", 1)
+		TNT1 A 0
+		TNT1 A 0 //ThrustThingZ(0,15,0,1)
+		TNT1 A 0 A_FaceTarget
+		TNT1 A 0 A_Recoil (3)
+		MPOS G 2
+		CPBK ABC 2
+		MPOS A 0 
+		CPBK C 8 A_Pain
+		MPOS A 0 
+		CPBK D 8 
+		MPOS A 0 
+		CPBK C 8 A_Pain
+		CPBK D 8 
+		MPOS A 0 
+		CPBK C 8 A_Pain
+		CPBK D 8 
+		MPOS A 0 
+		CPBK C 8 A_Pain
+		CPBK D 8 
+		MPOS A 0 
+		CPBK BA 4
+		MPOS G 4
+		Goto See
 		
 		
 	Death.Cutless:
@@ -519,12 +519,12 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		TNT1 A 0 A_Jump(22, "Death.Saw", "Death.Tear")
 		TNT1 A 0 A_JumpIfInventory("IsFiring", 1, "Death.Rare")
 	Death.Minigun:
-        TNT1 A 0
+		TNT1 A 0
 		TNT1 A 0 A_FaceTarget
 		TNT1 A 0 A_Scream
 		TNT1 O 0 A_NoBlocking
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        TNT1 A 0 A_SpawnItem ("BrutalizedChaingunCommando1", 1)
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_SpawnItem("BrutalizedChaingunCommando1", 1)
 		Stop
 	
 	Death.Shotgun:
@@ -543,177 +543,177 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		CPHM CD 4 A_JumpIf((MomY == 0), "TakeASit")
 		CPHM EF 4
 		TNT1 A 0 A_PlaySound("BODYF",6)
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-		TNT1 A 0 A_SpawnItem ("DeadChaingunGuy_KilledByMinorHead", 3)
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem("DeadChaingunGuy_KilledByMinorHead", 3)
 		Stop
 		
 	Death:
-	    TNT1 A 0
+		TNT1 A 0
 		TNT1 A 0 A_JumpIfInventory("IsFiring", 1, "Death.Rare")
 		TNT1 A 0 A_Jump(30,"Death.Arm")
 		TNT1 A 0 A_Jump(80,"Death3")
 		TNT1 A 0 A_Jump(132,"Death2")
 		TNT1 A 0 A_Jump(64,"Death.Rare")
-        CPOD A 8 A_Scream
-        CPOD B 6 A_NoBlocking
-        CPOD CDEF 6
+		CPOD A 8 A_Scream
+		CPOD B 6 A_NoBlocking
+		CPOD CDEF 6
 		TNT1 A 0 A_PlaySound("BODYF",6)
 		TNT1 A 0 A_Jump(62, "SufferBitch")
 		CPOD G 6
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-        TNT1 A 0 A_SpawnItem ("DeadChaingunGuy1", 3)
-        Stop
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem("DeadChaingunGuy1", 3)
+		Stop
 		
 	Death2:	
-        CPSC I 7 A_Scream
-        CPSC J 6 A_NoBlocking
-        CPSC KLM 6
+		CPSC I 7 A_Scream
+		CPSC J 6 A_NoBlocking
+		CPSC KLM 6
 		TNT1 A 0 A_PlaySound("BODYF",6)
 		CPSC N 6
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-        TNT1 A 0 A_SpawnItem ("DeadChaingunGuyCPSCN", 3)
-        Stop
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem("DeadChaingunGuyCPSCN", 3)
+		Stop
 		
 	Death3:
-	     TNT1 A 0 A_CustomMissile ("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
-        CP04 A 8 A_Scream
-        CP04 B 6 A_NoBlocking
-        CP04 CD 6
+		TNT1 A 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
+		CP04 A 8 A_Scream
+		CP04 B 6 A_NoBlocking
+		CP04 CD 6
 		TNT1 A 0 A_PlaySound("BODYF",6)
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        CP04 EF 6
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-		TNT1 A 0 A_SpawnItemEx ("DeadChaingunGuyCP04F",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
-        Stop
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		CP04 EF 6
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItemEx("DeadChaingunGuyCP04F",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		Stop
 	
 	SufferBitch:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem ("SufferingCommandoGuts")
+		TNT1 A 0 A_SpawnItem("SufferingCommandoGuts")
 		Stop
 		
 	Death.Rare:
-	TNT1 A 0
-	TNT1 A 0 A_FaceTarget
-	TNT1 A 0 A_Recoil(2)
-	CPDR A 3 A_Scream
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 32, 15, 0, 2, -20)
-	CPDR B 3 BRIGHT A_NoBlocking
-	
-	CPDR A 3
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 32, 15, 0, 2, -20)
-	CPDR B 3 BRIGHT A_NoBlocking
-	
+		TNT1 A 0
+		TNT1 A 0 A_FaceTarget
+		TNT1 A 0 A_Recoil(2)
+		CPDR A 3 A_Scream
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 32, 15, 0, 2, -20)
+		CPDR B 3 BRIGHT A_NoBlocking
+		
+		CPDR A 3
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 32, 15, 0, 2, -20)
+		CPDR B 3 BRIGHT A_NoBlocking
+		
 
-	CPDR C 2
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 24, 15, -20, 2, -20)
-	CPDR D 2 BRIGHT
-	
-	CPDR C 2
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 24, 15, -20, 2, -20)
-	CPDR D 2 BRIGHT
-	
-	CPDR E 2
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 24, 15, -20, 2, 20)
-	CPDR F 2 BRIGHT
-	
-	CPDR G 2
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 24, 15, -10, 2, 40)
-	CPDR H 2 BRIGHT
-	
-	TNT1 A 0 A_Recoil(1)
-	CPDR I 2
-	TNT1 A 0 A_JumpIf((MomY == 0), "TakeASit")
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 24, 15, -10, 2, 40)
-	CPDR J 2 BRIGHT
-	TNT1 A 0 A_JumpIf((MomY == 0), "TakeASit")
-	
-	CPDR K 2
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 12, 15, -20, 2, 40)
-	CPDR L 2 BRIGHT
-	TNT1 A 0 A_PlaySound("BODYF",6)
-	TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-	CPDR M 2
-	TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 12, 15, -20, 2, 20)
-	CPDR N 2 BRIGHT
-	
-	CPDR M 2
-	TNT1 A 0 A_CustomMissile ("PB_MonsterMinigunTracer", 12, 15, -20, 2, 20)
-	CPDR N 2 BRIGHT
-	
-	
-	TNT1 A 0 A_SpawnItemEx ("DropedMinigun", 0, 30)
-    TNT1 A 0 A_SpawnItem ("DeadChaingunguyCPDRO", 3)
-	Stop
+		CPDR C 2
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -20, 2, -20)
+		CPDR D 2 BRIGHT
+		
+		CPDR C 2
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -20, 2, -20)
+		CPDR D 2 BRIGHT
+		
+		CPDR E 2
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -20, 2, 20)
+		CPDR F 2 BRIGHT
+		
+		CPDR G 2
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -10, 2, 40)
+		CPDR H 2 BRIGHT
+		
+		TNT1 A 0 A_Recoil(1)
+		CPDR I 2
+		TNT1 A 0 A_JumpIf((MomY == 0), "TakeASit")
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -10, 2, 40)
+		CPDR J 2 BRIGHT
+		TNT1 A 0 A_JumpIf((MomY == 0), "TakeASit")
+		
+		CPDR K 2
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 12, 15, -20, 2, 40)
+		CPDR L 2 BRIGHT
+		TNT1 A 0 A_PlaySound("BODYF",6)
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		CPDR M 2
+		TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 12, 15, -20, 2, 20)
+		CPDR N 2 BRIGHT
+		
+		CPDR M 2
+		TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 12, 15, -20, 2, 20)
+		CPDR N 2 BRIGHT
+		
+		
+		TNT1 A 0 A_SpawnItemEx("DropedMinigun", 0, 30)
+		TNT1 A 0 A_SpawnItem("DeadChaingunguyCPDRO", 3)
+		Stop
 	
 	TakeASit:
 		TNT1 A 0 A_PlaySound("BODYF",6)
-	    TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 6, 0, random (170, 190), 2, random (0, 40))
-	    TNT1 A 0
-	    TNT1 A 0 A_SpawnItem("GrowingBloodPool")
-		TNT1 A 0 A_SpawnItemEx ("DropedMinigun", 0, 30)
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 6, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItemEx("DropedMinigun", 0, 30)
 		TNT1 A 0 A_SpawnItemEx("DeadChaingunguy_Slumped", 10)
 		Stop
 	
 		
 	Death.OriginalGibz:
-	    TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        TNT1 AAA 0 A_CustomMissile ("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainArm", 35, 0, random (0, 360), 2, random (60, 120))
-		TNT1 A 0 A_CustomMissile ("XDeath1", 35, 0, random (0, 360), 2, random (60, 120))
-		TNT1 AA 0 A_CustomMissile ("XDeath2", 35, 0, random (0, 360), 2, random (60, 120))
-		TNT1 AA 0 A_CustomMissile ("XDeath3", 35, 0, random (0, 360), 2, random (60, 120))
-		TNT1 AAA 0 A_CustomMissile ("SmallBrainPiece", 35, 0, random (0, 360), 2, random (60, 120))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		TNT1 AAA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainArm", 35, 0, random (0, 360), 2, random (60, 120))
+		TNT1 A 0 A_CustomMissile("XDeath1", 35, 0, random (0, 360), 2, random (60, 120))
+		TNT1 AA 0 A_CustomMissile("XDeath2", 35, 0, random (0, 360), 2, random (60, 120))
+		TNT1 AA 0 A_CustomMissile("XDeath3", 35, 0, random (0, 360), 2, random (60, 120))
+		TNT1 AAA 0 A_CustomMissile("SmallBrainPiece", 35, 0, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_XScream
 		TNT1 O 0 A_NoBlocking
-	    CPSC ABCDEFGH 4
-        CPSC H 1
+		CPSC ABCDEFGH 4
+		CPSC H 1
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-         TNT1 A 1 A_SpawnItem ("DeadChaingunGuy_Half", 3)
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 1 A_SpawnItem("DeadChaingunGuy_Half", 3)
 		Stop
 	
 		
 	Death.Arm:
-	     TNT1 A 0 A_Jump(140, "DeathArm2")
-	     TNT1 A 0 A_CustomMissile ("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_Scream
-	     CPOD H 10 A_NoBlocking
-		 TNT1 A 0 A_PlaySound("BODYF",6)
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-		 CPOD I 5
-		 CPOD I 1 A_NoBlocking
-		 TNT1 A 1 A_SpawnItem ("BrutalizedCommando1")
+		TNT1 A 0 A_Jump(140, "DeathArm2")
+		TNT1 A 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_Scream
+		CPOD H 10 A_NoBlocking
+		TNT1 A 0 A_PlaySound("BODYF",6)
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		CPOD I 5
+		CPOD I 1 A_NoBlocking
+		TNT1 A 1 A_SpawnItem("BrutalizedCommando1")
 		Stop
 		
 	DeathArm2:
-	     TNT1 AA 0 A_CustomMissile ("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_Scream
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-		 CP05 A 10 A_NoBlocking
-		 TNT1 A 0 A_SpawnItemEx ("DyingChaingunGuyNoArm1",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
-		 Stop
+		TNT1 AA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_Scream
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		CP05 A 10 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("DyingChaingunGuyNoArm1",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		Stop
 		
-    XDeath:
+	XDeath:
 		TNT1 A 0 A_JumpIfInTargetInventory("HasCutingWeapon",1,"Death.Saw")
-        TNT1 A 1 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		TNT1 A 1 A_SpawnItem("DropedMinigun", 0, 5,0)
 		TNT1 A 1 A_JumpIfInTargetInventory("SSGSelected", 1, "Death.SSG")
 		TNT1 A 1 A_XScream
 		TNT1 A 1 A_NoBlocking
@@ -725,8 +725,8 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		TNT1 A 0 A_Jump(72, "Death.HeadExplode")
 		Goto Death.HeadMinor
 		
-    Death.Head:
-	    TNT1 A 0
+	Death.Head:
+		TNT1 A 0
 		TNT1 A 0 A_JumpIfInTargetInventory("HasPlasmaWeapon", 1, "Death.Plasma")
 		TNT1 A 0 A_JumpIfInTargetInventory("HasIncendiaryWeapon",1,"Death.Incinerate")
 		TNT1 A 0 A_JumpIfInTargetInventory("HasCutingWeapon", 1, "Death.Decaptate")
@@ -735,103 +735,103 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 	Death.HeadMinor:
 		TNT1 A 0
 		TNT1 A 0 A_Playsound("MinorHeadshot", 0)
-		TNT1 AA 0 A_CustomMissile ("BloodMistBig", 60, 0, random (0, 360), 2, random (30, 90))
-        TNT1 AAAAA 0 A_CustomMissile ("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AA 0 A_CustomMissile ("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40))
-		TNT1 A 0 A_CustomMissile ("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AA 0 A_CustomMissile("BloodMistBig", 60, 0, random (0, 360), 2, random (30, 90))
+		TNT1 AAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
 		CPHM I 6
 		CPHM C 6 A_NoBlocking
 		CPHM DEF 6 
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-         TNT1 A 0 A_SpawnItem ("DeadChaingunGuy_KilledByMinorHead", 3)
-        Stop
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem("DeadChaingunGuy_KilledByMinorHead", 3)
+		Stop
 		
-		 Death.Melee:
-		 TNT1 A 0
+		Death.Melee:
+		TNT1 A 0
 		CPHM A 9
 		CPHM B 9 A_Scream
 		CPHM C 8 A_NoBlocking
 		CPHM DEF 8 
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 		TNT1 A 0 A_PlaySound("BODYF",6)
-         TNT1 A 0 A_SpawnItem ("DeadChaingunGuy_KilledByMinorHead", 3)
-        Stop
+		TNT1 A 0 A_SpawnItem("DeadChaingunGuy_KilledByMinorHead", 3)
+		Stop
 		
 	Death.headExplode:
-	    
-        TNT1 A 0
+		
+		TNT1 A 0
 		TNT1 A 0 A_SpawnItem("ChaingunguyHeadExplode", 0, 50)
 		TNT1 A 0 A_Jump(132, "HeadExplode2", "HeadExplode3")
-		CPHS AAA 2 A_CustomMissile ("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
-		CPHS BBB 2 A_CustomMissile ("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
-		CPHS CCC 2 A_CustomMissile ("Brutal_LiquidBlood2", 40, 0, random (0, 360), 2, random (60, 120))
+		CPHS AAA 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
+		CPHS BBB 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
+		CPHS CCC 2 A_CustomMissile("Brutal_LiquidBlood2", 40, 0, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_NoBlocking
-		CPHS DDDDDDDDDDDDEEE 2 A_CustomMissile ("Brutal_LiquidBlood2", 30, 0, random (0, 360), 2, random (60, 120))
-        
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-		CPHS FFFFFFFFFFFFFFF 2 A_CustomMissile ("Brutal_LiquidBlood2", 5, 0, random (0, 360), 2, random (10, 40))
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		CPHS DDDDDDDDDDDDEEE 2 A_CustomMissile("Brutal_LiquidBlood2", 30, 0, random (0, 360), 2, random (60, 120))
+		
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		CPHS FFFFFFFFFFFFFFF 2 A_CustomMissile("Brutal_LiquidBlood2", 5, 0, random (0, 360), 2, random (10, 40))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		TNT1 A 1 A_SpawnItem ("DeadChaingunGuy_NoHead", 3)
-        Stop
+		TNT1 A 1 A_SpawnItem("DeadChaingunGuy_NoHead", 3)
+		Stop
 		
 	HeadExplode2:
-        TNT1 A 0 A_PlaySound("misc/xdeath4")
-		CP04 GGGG 2 A_CustomMissile ("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
-		CP04 HHHH 2 A_CustomMissile ("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
-		CP04 III 2 A_CustomMissile ("Brutal_LiquidBlood2", 40, 0, random (0, 360), 2, random (60, 120))
+		TNT1 A 0 A_PlaySound("misc/xdeath4")
+		CP04 GGGG 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
+		CP04 HHHH 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
+		CP04 III 2 A_CustomMissile("Brutal_LiquidBlood2", 40, 0, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_NoBlocking
-		CP04 JJJKKK 2 A_CustomMissile ("Brutal_LiquidBlood2", 30, 0, random (0, 360), 2, random (60, 120))
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		CP04 JJJKKK 2 A_CustomMissile("Brutal_LiquidBlood2", 30, 0, random (0, 360), 2, random (60, 120))
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		CP04 LLLLLLLLLLLLLLLLLL 2 A_CustomMissile ("Brutal_LiquidBlood2", 5, 0, random (0, 360), 2, random (10, 40))
-		TNT1 A 1 A_SpawnItem ("DeadChaingunGuyCP04L", 3)
-        Stop
+		CP04 LLLLLLLLLLLLLLLLLL 2 A_CustomMissile("Brutal_LiquidBlood2", 5, 0, random (0, 360), 2, random (10, 40))
+		TNT1 A 1 A_SpawnItem("DeadChaingunGuyCP04L", 3)
+		Stop
 		
 	HeadExplode3:
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_SpawnItem("ChaingunguyHeadExplode", 0, 50)
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-		CPHS GGG 2 A_CustomMissile ("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		CPHS GGG 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_SpawnItem("BrutalizedCommandoLostHead")
 		Stop
 		
 	Death.decaptate:
-        TNT1 AAAAA 0 A_CustomMissile ("BloodMistLarge", 50, 0, random (0, 360), 2, random (0, 160))
-        TNT1 A 0 A_PlaySound("misc/xdeath4")
-        TNT1 A 0 A_SpawnItemEx ("XDeathChaingunguyHeadBeheaded", 50, 0, random (0, 360), 2, random (40, 90))
-		CP04 GGGGGGG 2 A_CustomMissile ("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
-		CP04 HHHH 2 A_CustomMissile ("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
+		TNT1 AAAAA 0 A_CustomMissile("BloodMistLarge", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_PlaySound("misc/xdeath4")
+		TNT1 A 0 A_SpawnItemEx("XDeathChaingunguyHeadBeheaded", 50, 0, random (0, 360), 2, random (40, 90))
+		CP04 GGGGGGG 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
+		CP04 HHHH 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_XScream
-		CP04 IIII 2 A_CustomMissile ("Brutal_LiquidBlood2", 40, 0, random (0, 360), 2, random (60, 120))
+		CP04 IIII 2 A_CustomMissile("Brutal_LiquidBlood2", 40, 0, random (0, 360), 2, random (60, 120))
 		TNT1 A 0 A_NoBlocking
-		CP04 JJJJKKKK 2 A_CustomMissile ("Brutal_LiquidBlood2", 30, 0, random (0, 360), 2, random (60, 120))
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		CP04 JJJJKKKK 2 A_CustomMissile("Brutal_LiquidBlood2", 30, 0, random (0, 360), 2, random (60, 120))
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		CP04 LLLLLLLLLLLLLLLLLL 2 A_CustomMissile ("Brutal_LiquidBlood2", 5, 0, random (0, 360), 2, random (10, 40))
-		TNT1 A 1 A_SpawnItem ("DeadChaingunGuyCP04L", 3)
-        Stop
+		CP04 LLLLLLLLLLLLLLLLLL 2 A_CustomMissile("Brutal_LiquidBlood2", 5, 0, random (0, 360), 2, random (10, 40))
+		TNT1 A 1 A_SpawnItem("DeadChaingunGuyCP04L", 3)
+		Stop
 		
 		
 	
 	Death.cut:
-        TNT1 A 0
-        TNT1 AA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0
+		TNT1 AA 0 A_CustomMissile("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_XScream
-  	    TNT1 O 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("RipChaingunGuy1", 0, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
-	    TNT1 AAAA 0 A_CustomMissile ("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
-		CP06 AABC 9 A_CustomMissile ("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
+		TNT1 O 0 A_NoBlocking
+		TNT1 A 0 A_CustomMissile("RipChaingunGuy1", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
+		CP06 AABC 9 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
 		TNT1 A 0 A_PlaySound("BODYF",6)
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-		CP06 DDDDDDDDDDDDDDDDDDDDDDDDD 1 A_CustomMissile ("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		CP06 DDDDDDDDDDDDDDDDDDDDDDDDD 1 A_CustomMissile("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90))
 		TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP06D")
 		Stop
 		
@@ -839,18 +839,18 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		TNT1 A 0 A_Jump(64, "Death.cut")
 		TNT1 A 0 A_Jump(12, "Death.arm")
 	Death.Tear:
-        TNT1 A 0
-        TNT1 AA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
-  	    TNT1 O 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("RipChaingunGuy2", 0, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
-	    TNT1 AAAA 0 A_CustomMissile ("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
-		CP06 EE 9 A_CustomMissile ("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
+		TNT1 A 0
+		TNT1 AA 0 A_CustomMissile("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
+		TNT1 O 0 A_NoBlocking
+		TNT1 A 0 A_CustomMissile("RipChaingunGuy2", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
+		CP06 EE 9 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
 		CP06 FGHI 6
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
 		TNT1 A 0 A_PlaySound("BODYF",6)
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-		CP06 JJJJJJJJJJJJJJJJJJJJJJJJ 1 A_CustomMissile ("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		CP06 JJJJJJJJJJJJJJJJJJJJJJJJ 1 A_CustomMissile("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90))
 		TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP06J")
 		Stop
 		
@@ -872,52 +872,52 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 		
 	BlownAwayLeft:	
 		TNT1 A 0 A_NoBlocking
-	    TNT1 AA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
-		TNT1 A 0 A_CustomMissile ("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
-		TNT1 AAAAAAAAAAA 0 A_CustomMissile ("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 ThrustThingZ(0,30,0,1)
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-	    CPDE A 1 A_Scream
-	    CPDE A 1
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		CPDE A 1 A_Scream
+		CPDE A 1
 		CPDE A 2 A_CheckFloor ("Dead.Landmine")
 		CPDE BCDEFGH 2 A_CheckFloor ("Dead.Landmine")
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		CPDE A 0 A_SpawnItem ("GrowingBloodPool")
-		CPDE A 0 A_SpawnItem ("DeadChaingunguyCPDEI")
+		CPDE A 0 A_SpawnItem("GrowingBloodPool")
+		CPDE A 0 A_SpawnItem("DeadChaingunguyCPDEI")
 		Stop
 		
 	BlownAwayRight:
 		TNT1 A 0 A_Jump(96, "Death.ExtremePunches")
 		TNT1 A 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeath2", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath1", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_ChangeFlag("NOBLOCKMONST", 1)
-        TNT1 A 0 A_SpawnItemEx ("XDeathChaingunguyHeadBeheaded", 50, 0, random (0, 360), 2, random (40, 90))
-		TNT1 AAAA 0 A_CustomMissile ("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
-		TNT1 AAAA 0 A_CustomMissile ("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
-        TNT1 AAAAAAAAAAA 0 A_CustomMissile ("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AA 0 A_CustomMissile ("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeath3", 40, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		TNT1 A 0 A_SpawnItemEx("XDeathChaingunguyHeadBeheaded", 50, 0, random (0, 360), 2, random (40, 90))
+		TNT1 AAAA 0 A_CustomMissile("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10))
+		TNT1 AAAA 0 A_CustomMissile("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath3", 40, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
 		TNT1 A 0 ThrustThingZ(0,30,0,1)
 		TNT1 A 0 A_XScream
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-	    4N02 ABCDCBA 3 A_CustomMissile ("Brutal_FlyingBlood", 0, 0, 0, 2, 90)
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		4N02 ABCDCBA 3 A_CustomMissile("Brutal_FlyingBlood", 0, 0, 0, 2, 90)
 		TNT1 A 0 A_CheckFloor("Land8472")
 		4N02 ABCDCBABCDCBA 5 A_CheckFloor("Land8472")
 		Land8472:
 		SXS2 N 0
 		TNT1 A 0 A_Stop
 		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
-		CPDE A 0 A_SpawnItem ("DeadChaingunguy4N02E") 
+		CPDE A 0 A_SpawnItem("DeadChaingunguy4N02E")
 		Stop
 	
 	
@@ -926,245 +926,245 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 	Death.LandMine2:
 	TNT1 A 0 A_NoBlocking
 	TNT1 A 0 ThrustThingZ(0,40,0,1)
-	TNT1 AA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
-	TNT1 AA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
-	TNT1 AAAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
-	TNT1 A 0 A_CustomMissile ("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
-	TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160))
-	TNT1 AA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
-	TNT1 AAAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
-	TNT1 AAAAAAAAAAA 0 A_CustomMissile ("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+	TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
+	TNT1 AA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+	TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+	TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
+	TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160))
+	TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
+	TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+	TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 	
-	    CPDE A 1 A_Scream
-	    CPDE A 1
+		CPDE A 1 A_Scream
+		CPDE A 1
 		CPDE A 2 A_CheckFloor ("Dead.Landmine")
 		CPDE BCDEFGH 2 A_CheckFloor ("Dead.Landmine")
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		CPDE A 0 A_SpawnItem ("GrowingBloodPool")
-		CPDE A 0 A_SpawnItem ("DeadChaingunguyCPDEI")
+		CPDE A 0 A_SpawnItem("GrowingBloodPool")
+		CPDE A 0 A_SpawnItem("DeadChaingunguyCPDEI")
 		Stop
 	
 	Dead.Landmine:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem ("Ploft")
-		TNT1 AAAA 0 A_SpawnItem ("Blood")
+		TNT1 A 0 A_SpawnItem("Ploft")
+		TNT1 AAAA 0 A_SpawnItem("Blood")
 		TNT1 A 0 A_PlaySound("BODYF",6)
 		CPDE I 1
-		CPDE A 0 A_SpawnItem ("DeadChaingunguyCPDEI")
+		CPDE A 0 A_SpawnItem("DeadChaingunguyCPDEI")
 		Stop
 	
-    Death.Plasma: Death.Plasma2:
+	Death.Plasma: Death.Plasma2:
 		TNT1 A 0
 		TNT1 A 0 A_Stop
 		TNT1 A 0 A_PlaySound("plasmaflesh")
-		TNT1 AAAAAAAAA 0 A_CustomMissile ("Ashes1", 32, 0, random (0, 360), 2, random (0, 180))
-		TNT1 AAAAAAAAA 0 A_CustomMissile ("Ashes2", 32, 0, random (0, 360), 2, random (0, 180))
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1Blue",random(-2,2),random(-2,2),18,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		TNT1 AAAA 0 A_CustomMissile ("BluePlasmaFireNonStatic", 42, 0, random (0, 360), 2, random (0, 180))
-		TNT1 AAAA 0 A_CustomMissile ("BloodMistBig", 32, 0, random (0, 360), 2, random (0, 180))
-		TNT1 AAAAAA 0 A_CustomMissile ("SuperGoreMistSmall", 32, 0, random (0, 360), 2, random (10, 90))
-		TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAAAAAAAA 0 A_CustomMissile("Ashes1", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAAAAAAAA 0 A_CustomMissile("Ashes2", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1Blue",random(-2,2),random(-2,2),18,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		TNT1 AAAA 0 A_CustomMissile("BluePlasmaFireNonStatic", 42, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAAA 0 A_CustomMissile("BloodMistBig", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAAAAA 0 A_CustomMissile("SuperGoreMistSmall", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (0, 360), 2, random (0, 180))
 		PBR1 B 6 A_NoBlocking
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1Blue",random(-2,2),random(-2,2),10,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		TNT1 A 0 A_SpawnItemEx ("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1Blue",random(-2,2),random(-2,2),10,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		TNT1 A 0 A_SpawnItemEx("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		TNT1 A 0 A_SpawnItem("BarrelExplosionSmokeColumn")
 		TNT1 A 0 A_SpawnItemEx("TinyBurningPiece", random (-15, 15), random (-15, 15))
 		TNT1 A 0 A_SpawnItemEx("TinyBurningPiece2", random (-35, 35), random (-35, 35))
 		TNT1 A 0 A_SpawnItemEx("TinyBurningPiece3", random (-45, 45), random (-45, 35))
-		PBR1 CCDD 3 A_CustomMissile ("BluePlasmaFireNonStatic", 32, 0, random (0, 360), 2, random (0, 180))
+		PBR1 CCDD 3 A_CustomMissile("BluePlasmaFireNonStatic", 32, 0, random (0, 360), 2, random (0, 180))
 		PBR1 EEFF 3
 		PBR1 GG 3
 		PBR1 H -1
 		Stop
 	
 	Death.SuperPlasma:
-        TNT1 A 0
-        TNT1 A 0 A_XScream
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        TNT1 A 0 A_NoBlocking
+		TNT1 A 0
+		TNT1 A 0 A_XScream
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_NoBlocking
 		XBRN AA 2 BRIGHT A_SpawnItem("BlueFlare",0,43)
-        TNT1 AAAA 0 A_CustomMissile ("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160))
 		
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
 
 		XBRN BB 2 BRIGHT A_SpawnItem("BlueFlare",0,43)
-        TNT1 A 0 A_CustomMissile ("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160))
 		XBRN CC 2 BRIGHT A_SpawnItem("BlueFlare",0,43)
-		TNT1 AAAAA 0 A_CustomMissile ("PlasmaParticleX", 48, 0, random (0, 360), 2, random (0, 360))
-		TNT1 AAA 0 A_CustomMissile ("BigPlasmaParticleX", 42, 0, random (0, 360), 2, random (0, 360))
-        TNT1 A 0
-        Stop
+		TNT1 AAAAA 0 A_CustomMissile("PlasmaParticleX", 48, 0, random (0, 360), 2, random (0, 360))
+		TNT1 AAA 0 A_CustomMissile("BigPlasmaParticleX", 42, 0, random (0, 360), 2, random (0, 360))
+		TNT1 A 0
+		Stop
 		
 			Death.GreenFire:
-        TNT1 A 0
-        TNT1 A 0 A_XScream
-        TNT1 A 0 A_NoBlocking
-        TNT1 AAAA 0 A_CustomMissile ("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0
+		TNT1 A 0 A_XScream
+		TNT1 A 0 A_NoBlocking
+		TNT1 AAAA 0 A_CustomMissile("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160))
 		
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
 		
-		EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("GreenFlameTrails", 50, 0, random (0, 360), 2, random (0, 360))
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile("GreenFlameTrails", 50, 0, random (0, 360), 2, random (0, 360))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 		XBRN AAAA 2 BRIGHT A_SpawnItem("GreenFlare",0,43)
-        Stop
+		Stop
 	
 		Death.Incinerate:
 		TNT1 A 0
 		TNT1 A 0 A_Stop
-        TNT1 A 0 A_Playsound("MELT")
-        TNT1 A 0 A_NoBlocking
-        TNT1 AAAAAA 0 A_CustomMissile ("ExplosionParticleHeavy", 32, 0, random (0, 360), 2, random (0, 360))
-		TNT1 AAAAAA 0 A_CustomMissile ("ExplosionParticleVeryFast", 32, 0, random (0, 360), 2, random (0, 360))
-        TNT1 A 0 A_SpawnItemEx ("ExplosionFlareSpawner",0,0,32,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_Playsound("MELT")
+		TNT1 A 0 A_NoBlocking
+		TNT1 AAAAAA 0 A_CustomMissile("ExplosionParticleHeavy", 32, 0, random (0, 360), 2, random (0, 360))
+		TNT1 AAAAAA 0 A_CustomMissile("ExplosionParticleVeryFast", 32, 0, random (0, 360), 2, random (0, 360))
+		TNT1 A 0 A_SpawnItemEx("ExplosionFlareSpawner",0,0,32,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		TNT1 A 0 A_SpawnItemEx("TinyBurningPiece", random (-15, 15), random (-15, 15))
 		TNT1 A 0 A_SpawnItemEx("TinyBurningPiece2", random (-35, 35), random (-35, 35))
 		TNT1 A 0 A_SpawnItemEx("TinyBurningPiece3", random (-45, 45), random (-45, 35))
-		TNT1 AAAAAAAAAAAA 0 A_CustomMissile ("Ashes1", 28, 0, random (0, 360), 2, random (0, 180))
-		TNT1 AAAAAAAAAAAA 0 A_CustomMissile ("Ashes2", 40, 0, random (0, 360), 2, random (0, 180))
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),32,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		CB06 AAAAA 1 BRIGHT Light("IncinerationGlow") A_CustomMissile ("BurningEmberParticlesFloating_Bigger", 36, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),28,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		CB06 BBBBB 1 BRIGHT Light("IncinerationGlow") A_CustomMissile ("BurningEmberParticlesFloating_Bigger", 32, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),24,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		CB06 CCCCCC 1 BRIGHT Light("IncinerationGlow") A_CustomMissile ("BurningEmberParticlesFloating_Bigger", 28, 0, random (0, 360), 2, random (0, 160))
-        TNT1 A 0 A_Playsound("SZZLL", 3)
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),20,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		CB06 DDDDDD 1 BRIGHT Light("IncinerationGlow") A_CustomMissile ("BurningEmberParticlesFloating_Bigger", 20, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),16,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		CB06 EEEEEE 1 BRIGHT Light("IncinerationGlow") A_CustomMissile ("BurningEmberParticlesFloating_Bigger", 12, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),12,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		CB06 FFFFF 1 BRIGHT Light("IncinerationGlow") A_CustomMissile ("BurningEmberParticlesFloating_Bigger", 10, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		TNT1 AAAAAAAAAAAA 0 A_CustomMissile("Ashes1", 28, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAAAAAAAAAAA 0 A_CustomMissile("Ashes2", 40, 0, random (0, 360), 2, random (0, 180))
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),32,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		CB06 AAAAA 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 36, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),28,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		CB06 BBBBB 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),24,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		CB06 CCCCCC 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 28, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_Playsound("SZZLL", 3)
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),20,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		CB06 DDDDDD 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 20, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),16,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		CB06 EEEEEE 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 12, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),12,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		CB06 FFFFF 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 10, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
 		TNT1 A 0 A_SpawnItem("BarrelExplosionSmokeColumn")
 		CB06 GGGG 2 BRIGHT Light("IncinerationGlow")
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		CB06 FFGGFFGGFFGGFFGG 2 BRIGHT Light("IncinerationGlow") A_CustomMissile ("PlasmaSmoke", 14, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
-		CB06 FFGGFFGGFFGGFFGG 2 Light("IncinerationGlow") A_CustomMissile ("PlasmaSmoke", 14, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_SpawnItemEx ("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		CB06 FFGGFFGGFFGGFFGG 2 BRIGHT Light("IncinerationGlow") A_CustomMissile("PlasmaSmoke", 14, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
+		CB06 FFGGFFGGFFGGFFGG 2 Light("IncinerationGlow") A_CustomMissile("PlasmaSmoke", 14, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0)
 		CB06 FFGGFFGGFFHHHHHH 2
-		CB06 IIIIIII 12 A_CustomMissile ("PlasmaSmoke", 14, 0, random (0, 360), 2, random (0, 160))
+		CB06 IIIIIII 12 A_CustomMissile("PlasmaSmoke", 14, 0, random (0, 360), 2, random (0, 160))
 		CB06 I -1
 		Stop
 		
-    Death.fire:
+	Death.fire:
 	Death.FireExplosion:
-    Death.burn:
-    Death.flames:
+	Death.burn:
+	Death.flames:
 		TNT1 A 0 A_JumpIfInTargetInventory("HasIncendiaryWeapon",1,"Death.Incinerate")
-        TNT1 A 0 A_Scream
-        TNT1 A 0 A_NoBlocking
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_Scream
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 		TNT1 A 1 A_SpawnItemEx("BurningcHAINGUNGUY",0,0,0,0,0,0,0,288)
-      Stop
+		Stop
 
 
 	Death.Throwable:
 		Goto Death
 		
 	Death.Disintegrate:
-        TNT1 A 0 A_Scream
-        TNT1 A 0 A_NoBlocking
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        TNT1 A 1 A_SpawnItemEx("DisintegratedHuman",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
-      Stop
+		TNT1 A 0 A_Scream
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		TNT1 A 1 A_SpawnItemEx("DisintegratedHuman",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
+		Stop
 		
-    Death.Fatality:
-	    TNT1 A 0 A_Pain
-        TNT1 A 0 A_NoBlocking
+	Death.Fatality:
+		TNT1 A 0 A_Pain
+		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_JumpIfIntargetInventory("FistsSelected", 1, 1)
 		Goto Death.ExplosiveImpact
 		TNT1 A 0 A_GiveToTarget("GoFatality", 1)
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        TNT1 A 0 A_Jump(130,5)
-        TNT1 A 0 A_GiveToTarget("ComandoFatality", 1)
-        Stop
-        TNT1 AAAAAAA 0
-        TNT1 A 0 A_GiveToTarget("ComandoFatality2", 1)
-        TNT1 A 1
-        TNT1 A 0
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_Jump(130,5)
+		TNT1 A 0 A_GiveToTarget("ComandoFatality", 1)
+		Stop
+		TNT1 AAAAAAA 0
+		TNT1 A 0 A_GiveToTarget("ComandoFatality2", 1)
+		TNT1 A 1
+		TNT1 A 0
 		Stop
 		
-	    Death.Eat:
-	    TNT1 A 0
+		Death.Eat:
+		TNT1 A 0
 		TNT1 A 0 A_NoBlocking
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        TNT1 A 0 A_GiveToTarget("ComandoFatality",1)
-        Stop
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_GiveToTarget("ComandoFatality",1)
+		Stop
 	
 	Raise:
 		CPOS N 5
 		CPOS MLKJIH 5
 		Goto See
-     Crush:
-	 Death.Stomp:
-	    TNT1 AAAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail8", 0, 0, random (0, 360), 2, random (0, 360))
-		TNT1 AAAAAA 0 bright A_CustomMissile ("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180))
-		TNT1 AAAAAA 0 bright A_CustomMissile ("XDeath1", 5, 0, random (0, 360), 2, random (30, 180))
-		TNT1 AA 0 bright A_CustomMissile ("XDeath2", 55, 0, random (0, 360), 2, random (30, 180))
-		TNT1 AA 0 bright A_CustomMissile ("XDeath3", 55, 0, random (0, 360), 2, random (30, 180))
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-		TNT1 A 0 A_SpawnItem ("CrushedRemains")
+	Crush:
+	Death.Stomp:
+		TNT1 AAAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile("Brutal_FlyingBloodTrail8", 0, 0, random (0, 360), 2, random (0, 360))
+		TNT1 AAAAAA 0 bright A_CustomMissile("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AAAAAA 0 bright A_CustomMissile("XDeath1", 5, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AA 0 bright A_CustomMissile("XDeath2", 55, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AA 0 bright A_CustomMissile("XDeath3", 55, 0, random (0, 360), 2, random (30, 180))
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem("CrushedRemains")
 		TNT1 A 1
 		TNT1 A 1 A_XScream
 		TNT1 A 1 A_NoBlocking
-        TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 		Stop
 
-    Pain.KillMe:
-    Pain.Taunt:
-        TNT1 A 0
-        Goto Missile
-    Death.KillMe:
-    Death.Taunt:
-	    TNT1 A 0 A_ChangeFlag("SOLID", 0)
-        TNT1 A 0 A_SpawnItem("Pb_Commando")
-        Stop
+	Pain.KillMe:
+	Pain.Taunt:
+		TNT1 A 0
+		Goto Missile
+	Death.KillMe:
+	Death.Taunt:
+		TNT1 A 0 A_ChangeFlag("SOLID", 0)
+		TNT1 A 0 A_SpawnItem("Pb_Commando")
+		Stop
 	
 	
 	Death.SSG:
-		TNT1 AAA 0 bright A_CustomMissile ("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAAA 0 A_CustomMissile ("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 A 0 A_CustomMissile ("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 A 0 A_CustomMissile ("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AA 0 A_CustomMissile ("XDeath4", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("Instestin", 32, 0, random (0, 360), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAAAAAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
-		TNT1 AA 0 A_CustomMissile ("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160))
-		CP06 AAAAAAA 2 A_CustomMissile ("Brutal_LiquidBlood2", 44, 0, random (0, 60), 2, random (30, 60))
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AA 0 A_CustomMissile("XDeath4", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAAAAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 AA 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160))
+		CP06 AAAAAAA 2 A_CustomMissile("Brutal_LiquidBlood2", 44, 0, random (0, 60), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
 		TNT1 A 0 A_Jump(129, "SSGDeathFallForward")
 		
-		CP06 BC 9 A_CustomMissile ("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
+		CP06 BC 9 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		CP06 DDDDDDDDDDDDDDDDDDDDDDDDD 1 A_CustomMissile ("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90))
+		CP06 DDDDDDDDDDDDDDDDDDDDDDDDD 1 A_CustomMissile("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90))
 		TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP06D")
 		Stop
 		
 	SSGDeathFallForward:
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-		CP04 SSSSSSS 2 A_CustomMissile ("Brutal_LiquidBlood2", 44, 0, random (0, 60), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		CP04 SSSSSSS 2 A_CustomMissile("Brutal_LiquidBlood2", 44, 0, random (0, 60), 2, random (30, 60))
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		CP04 UV 9 A_CustomMissile ("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
-		CP04 VVVVVVVVVVVVVVVVVVVVVV 1 A_CustomMissile ("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90))
+		CP04 UV 9 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40))
+		CP04 VVVVVVVVVVVVVVVVVVVVVV 1 A_CustomMissile("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90))
 		TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP04V")
 		Stop
 		
@@ -1173,92 +1173,92 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 	Death.Blast:
 		TNT1 A 0 A_Jump(138, "DeathBlast2", "DeathBlast3")
 	DeathBlast1:
-	    MPSD A 1 
+		MPSD A 1 
 		MPSD A 1 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("BloodSplasher2")
-	    TNT1 AAA 0 bright A_CustomMissile ("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40))
-        //TNT1 A 0 A_CustomMissile ("MeatDeath", 0, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAAA 0 A_CustomMissile ("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 A 0 A_CustomMissile ("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 A 0 A_CustomMissile ("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("Instestin", 32, 0, random (0, 360), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
-		TNT1 A 0 A_CustomMissile ("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
-        TNT1 A 0 A_XScream
+		TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40))
+		//TNT1 A 0 A_CustomMissile("MeatDeath", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 A 0 A_XScream
 		TNT1 A 0 A_NoBlocking
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        MPSD AAAA 6 A_CustomMissile ("Brutal_LiquidBlood2", 64, 0, random (0, 360), 2, random (30, 60))
-		MPSD BBBBCCCC 2 A_CustomMissile ("Brutal_LiquidBlood2", 34, 0, random (0, 60), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		MPSD AAAA 6 A_CustomMissile("Brutal_LiquidBlood2", 64, 0, random (0, 360), 2, random (30, 60))
+		MPSD BBBBCCCC 2 A_CustomMissile("Brutal_LiquidBlood2", 34, 0, random (0, 60), 2, random (30, 60))
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-		MPSD DDDDDDDDDDDDDDDDDDDDD 6 A_CustomMissile ("Brutal_LiquidBlood2", 16, 0, random (0, 60), 2, random (30, 60))
-        TNT1 A 0 A_SpawnItem("DeadChaingunguyMPSDD")
-        Stop
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		MPSD DDDDDDDDDDDDDDDDDDDDD 6 A_CustomMissile("Brutal_LiquidBlood2", 16, 0, random (0, 60), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("DeadChaingunguyMPSDD")
+		Stop
 		
 	DeathBlast2:
-	    CPOD T 1 
+		CPOD T 1 
 		CPOD T 1 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("BloodSplasher2")
-	    TNT1 AAA 0 bright A_CustomMissile ("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 A 0 A_CustomMissile ("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 A 0 A_CustomMissile ("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAAA 0 A_CustomMissile ("Instestin", 32, 0, random (0, 360), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAAA 0 A_CustomMissile ("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90))
-		TNT1 A 0 A_CustomMissile ("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
-        TNT1 A 0 A_XScream
+		TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAA 0 A_CustomMissile("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90))
+		TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 A 0 A_XScream
 		TNT1 A 0 A_NoBlocking
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        CPOD TTTT 2 A_CustomMissile ("Brutal_LiquidBlood2", 64, 0, random (0, 360), 2, random (30, 60))
-		CPOD UUUVVV 2 A_CustomMissile ("Brutal_LiquidBlood2", 34, 0, random (0, 60), 2, random (30, 60))
-        CPOD WWW 2 A_CustomMissile ("Brutal_LiquidBlood2", 14, 0, random (0, 360), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		CPOD TTTT 2 A_CustomMissile("Brutal_LiquidBlood2", 64, 0, random (0, 360), 2, random (30, 60))
+		CPOD UUUVVV 2 A_CustomMissile("Brutal_LiquidBlood2", 34, 0, random (0, 60), 2, random (30, 60))
+		CPOD WWW 2 A_CustomMissile("Brutal_LiquidBlood2", 14, 0, random (0, 360), 2, random (30, 60))
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-		CPOD XXXXXXXXXXXXXXXX 4 A_CustomMissile ("Brutal_LiquidBlood2", 16, 0, random (0, 60), 2, random (30, 60))
-        TNT1 A 0 A_SpawnItem("DeadChaingunguyCPODX")
-        Stop
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		CPOD XXXXXXXXXXXXXXXX 4 A_CustomMissile("Brutal_LiquidBlood2", 16, 0, random (0, 60), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("DeadChaingunguyCPODX")
+		Stop
 		
 	DeathBlast3:
-	    CP04 M 1 
+		CP04 M 1 
 		CP04 M 1 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("BloodSplasher2")
-	    TNT1 AAA 0 bright A_CustomMissile ("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 A 0 A_CustomMissile ("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 A 0 A_CustomMissile ("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAAA 0 A_CustomMissile ("Instestin", 32, 0, random (0, 360), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAAA 0 A_CustomMissile ("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90))
-		TNT1 A 0 A_CustomMissile ("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
-        TNT1 A 0 A_XScream
+		TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAA 0 A_CustomMissile("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90))
+		TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 A 0 A_XScream
 		TNT1 A 0 A_NoBlocking
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
-        CP04 NNNN 2 A_CustomMissile ("Brutal_LiquidBlood2", 64, 0, random (0, 360), 2, random (30, 60))
-		CP04 OOOOOPPP 2 A_CustomMissile ("Brutal_LiquidBlood2", 34, 0, random (0, 60), 2, random (30, 60))
-        CP04 QQQ 2 A_CustomMissile ("Brutal_LiquidBlood2", 14, 0, random (0, 360), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0)
+		CP04 NNNN 2 A_CustomMissile("Brutal_LiquidBlood2", 64, 0, random (0, 360), 2, random (30, 60))
+		CP04 OOOOOPPP 2 A_CustomMissile("Brutal_LiquidBlood2", 34, 0, random (0, 60), 2, random (30, 60))
+		CP04 QQQ 2 A_CustomMissile("Brutal_LiquidBlood2", 14, 0, random (0, 360), 2, random (30, 60))
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-		CP04 RRRRRRRRRRRRRRRRR 3 A_CustomMissile ("Brutal_LiquidBlood2", 16, 0, random (0, 60), 2, random (30, 60))
-        TNT1 A 0 A_SpawnItem("DeadChaingunguyCP04R")
-        Stop
+		TNT1 A 0 A_SpawnItem("GrowingBloodPool")
+		CP04 RRRRRRRRRRRRRRRRR 3 A_CustomMissile("Brutal_LiquidBlood2", 16, 0, random (0, 60), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("DeadChaingunguyCP04R")
+		Stop
 		
 
 	
@@ -1281,346 +1281,346 @@ ACTOR PB_Commando: PB_Monster //Replaces ChaingunGuy
 
 Actor DeadChaingunGuy1: CurbstompedMarine
 {
-    Radius 12
-    Height 12
-    +SHOOTABLE
-    +NOTELEPORT
-    +MOVEWITHSECTOR
-    +CORPSE
+	Radius 12
+	Height 12
+	+SHOOTABLE
+	+NOTELEPORT
+	+MOVEWITHSECTOR
+	+CORPSE
 	+FLOORCLIP
 	-SOLID
 	+THRUACTORS
 	damagefactor "Crush", 50.0
-    Mass 1000
-    Health 100
-    damagefactor "Blood", 0.0
-    damagefactor "Trample", 0.0
+	Mass 1000
+	Health 100
+	damagefactor "Blood", 0.0
+	damagefactor "Trample", 0.0
 States
-    {
-    Spawn:
-        CPOD G -1
-        Stop
+	{
+	Spawn:
+		CPOD G -1
+		Stop
 	Raise:
-		TNT1 A 2 A_CustomMissile ("RealFlameTrailsSmall", 6, 0, random (0, 360), 2, random (70, 110))
+		TNT1 A 2 A_CustomMissile("RealFlameTrailsSmall", 6, 0, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 A_SpawnItem("PentagramSpawner", 0, 60)
-		TNT1 A 2 A_CustomMissile ("RealFlameTrailsSmall", 6, 0, random (0, 360), 2, random (70, 110))
+		TNT1 A 2 A_CustomMissile("RealFlameTrailsSmall", 6, 0, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 A_SpawnItem("PentagramSpawner", 0, 60)
 		TNT1 A 0 A_SpawnItem("TeleportFog")
 		TNT1 A 0 A_NoBlocking
-        TNT1 A 0 A_SpawnItem ("PB_Commando", 3)
+		TNT1 A 0 A_SpawnItem("PB_Commando", 3)
 		Stop
-    Death:
+	Death:
 		TNT1 A 0 A_SpawnItem("GibsZ")
 		TNT1 A 0 A_SpawnItem("DeadChaingunguyMPSDD")
-         TNT1 A 0 A_CustomMissile ("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 AAA 0 A_CustomMissile ("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
-        Stop
-    Death.CutLess:
-    Death.Cut:
-        TNT1 AA 0 A_CustomMissile ("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainArm", 0, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
+		Stop
+	Death.CutLess:
+	Death.Cut:
+		TNT1 AA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainArm", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
 		TNT1 O 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
-         TNT1 A 1 A_SpawnItem ("DeadChaingunGuy_Half", 5)
-     Stop
-    Death.Plasma: Death.Plasma2:
-        TNT1 A 0
-        TNT1 A 0 A_XScream
-        TNT1 A 0 A_NoBlocking
-        TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
-		EXPL AAA 0 A_CustomMissile ("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
-        TNT1 A 0
-        Stop}}
+		TNT1 A 0 A_CustomMissile("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 1 A_SpawnItem("DeadChaingunGuy_Half", 5)
+	Stop
+	Death.Plasma: Death.Plasma2:
+		TNT1 A 0
+		TNT1 A 0 A_XScream
+		TNT1 A 0 A_NoBlocking
+		TNT1 AAA 0 A_CustomMissile("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
+		EXPL AAA 0 A_CustomMissile("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
+		TNT1 A 0
+		Stop}}
 
 Actor DeadChaingunGuy_NoHead: DeadChaingunGuy1
 {Health 200 States{Spawn:
 		CPHS F -1
-        Stop    
-       Death.Cut:
-  	     TNT1 A 0 A_CustomMissile ("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 AAA 0 A_CustomMissile ("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
+		Stop	
+		Death.Cut:
+		TNT1 A 0 A_CustomMissile("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
 		Stop}}
 		
 		
 Actor DeadChaingunGuy_NoHeadExploded: DeadChaingunGuy1
 {Health 200 States{Spawn:
 		CPHS L -1
-        Stop    
-       Death.Cut:
+		Stop	
+		Death.Cut:
 		TNT1 A 0 A_SpawnItem("GibsZ")
-  	     TNT1 A 0 A_CustomMissile ("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 AAA 0 A_CustomMissile ("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
 		Stop}}
 
 Actor DeadChaingunGuy_Half: DeadChaingunGuy1
 {Health 200 States{Spawn:
-        CPSC H -1
-        Stop
-    Death.CutLess:
-    Death.Cut:
+		CPSC H -1
+		Stop
+	Death.CutLess:
+	Death.Cut:
 	Death.Saw:
 	Death.Tear:
 		TNT1 A 0 A_SpawnItem("GibsZ")
-  	     TNT1 A 0 A_CustomMissile ("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 AAA 0 A_CustomMissile ("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
 		Stop
 		}}
 
 
 Actor BrutalizedDeadChaingunGuy: DeadChaingunGuy1
 {Health 200 States{Spawn:
-        CFTB C -1
-        Stop
+		CFTB C -1
+		Stop
 	Death.CutLess:
-    Death.Cut:
-        TNT1 AA 0 A_CustomMissile ("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
+	Death.Cut:
+		TNT1 AA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
 		TNT1 O 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
-         TNT1 A 1 A_SpawnItem ("DeadChaingunGuy_Half", 5)
+		TNT1 A 0 A_CustomMissile("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 1 A_SpawnItem("DeadChaingunGuy_Half", 5)
 		}}
 
 Actor SuperBrutalizedDeadChaingunGuy: DeadChaingunGuy1
 {Health 200 States{Spawn:
-        CFTB D -1
-        Stop
+		CFTB D -1
+		Stop
 	Death.CutLess:
-    Death.Cut:
-        TNT1 AA 0 A_CustomMissile ("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
+	Death.Cut:
+		TNT1 AA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
 		TNT1 O 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
-         TNT1 A 1 A_SpawnItem ("DeadChaingunGuy_Half", 5)
+		TNT1 A 0 A_CustomMissile("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 1 A_SpawnItem("DeadChaingunGuy_Half", 5)
 		}}
 
 Actor DeadChaingunGuy_KilledByMinorHead: DeadChaingunGuy1
 {Health 200 States{Spawn:
-        CPHM F -1
-        Stop
-       }}
+		CPHM F -1
+		Stop
+		}}
 
 
 actor DeadChaingunguyMPSDD: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 MPSD D -1
-       Stop    }}
-	   
+		Stop	}}
+		
 actor DeadChaingunguyCP04F: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		CP04 F -1
-       Stop    }}
-	   
+		Stop	}}
+		
 
 actor DeadChaingunguyCPDEI: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CPDE I -1
-       Stop    }}
+		Stop	}}
 
 actor DeadChaingunguy4N02E: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 4N02 E -1
-       Stop    }}
-	   
+		Stop	}}
+		
 actor DeadChaingunguyCPDRO: DeadChaingunguy1
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CPDR O -1
-       Stop    }}
+		Stop	}}
 	
 actor DeadChaingunGuyCPSCN: DeadChaingunguy1
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CPSC N -1
-       Stop    }}
-	   
+		Stop	}}
+		
 actor DeadChaingunGuyCP04L: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CP04 L -1
-       Stop    }}
-	   
+		Stop	}}
+		
 actor DeadChaingunguyCP04R: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CP04 R -1
-       Stop    }}
-	   
+		Stop	}}
+		
 actor DeadChaingunGuyCP05L: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		CP05 L -1
-        Stop    }}
+		Stop	}}
 
 actor DeadChaingunGuyCP05X: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		CP05 X -1
-        Stop    }}
+		Stop	}}
 		
 actor DeadChaingunGuyCP05H: DeadChaingunguy1
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		CP05 H -1
-        Stop
+		Stop
 	Death:
 		TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP05L")
-		TNT1 A 0 A_CustomMissile ("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 AAA 0 A_CustomMissile ("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
-		Stop    }}
+		TNT1 A 0 A_CustomMissile("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
+		Stop	}}
 		
 actor DeadChaingunGuyC405H: DeadChaingunguy1
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		C405 H -1
-        Stop
+		Stop
 	Death:
 		TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP05L")
-		TNT1 A 0 A_CustomMissile ("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 AAA 0 A_CustomMissile ("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
-		Stop    }}		
+		TNT1 A 0 A_CustomMissile("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
+		Stop	}}		
 
 actor DeadChaingunGuyCP05S: DeadChaingunguy1
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		CP05 S -1
-        Stop    
-    Death.CutLess:
-    Death.Cut:
-        TNT1 AA 0 A_CustomMissile ("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
+		Stop	
+	Death.CutLess:
+	Death.Cut:
+		TNT1 AA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
 		TNT1 O 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
-         TNT1 A 1 A_SpawnItem ("DeadChaingunGuy_Half", 5)
-     Stop	
+		TNT1 A 0 A_CustomMissile("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 1 A_SpawnItem("DeadChaingunGuy_Half", 5)
+	Stop	
 		}}
 		
 actor DeadChaingunGuyC405S: DeadChaingunguy1
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		C405 S -1
-        Stop    }}
+		Stop	}}
 
 actor BrutalizedDeadCommando1: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CPOD L -1
-       Stop    }}
-	   
+		Stop	}}
+		
 
 
 actor DeadChaingunGuyCP06D: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CP06 D -1
 Stop
 Death:
 		TNT1 A 0 A_SpawnItem("GibsZ")
-TNT1 AA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
-	TNT1 A 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
-	TNT1 A 0 A_CustomMissile ("XDeath3", 45, 0, random (0, 360), 2, random (0, 160))
-TNT1 AA 0 A_CustomMissile ("XDeathChainLeg", 5, 0, random (0, 360), 2, random (0, 160))
-       Stop    }}
-	   
+TNT1 AA 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
+	TNT1 A 0 A_CustomMissile("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
+	TNT1 A 0 A_CustomMissile("XDeath3", 45, 0, random (0, 360), 2, random (0, 160))
+TNT1 AA 0 A_CustomMissile("XDeathChainLeg", 5, 0, random (0, 360), 2, random (0, 160))
+		Stop	}}
+		
 actor DeadChaingunGuyCP06J: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CP06 J -1
 Stop
 Death:
 		TNT1 A 0 A_SpawnItem("GibsZ")
-TNT1 AA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
-	TNT1 A 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
-	TNT1 A 0 A_CustomMissile ("XDeath3", 45, 0, random (0, 360), 2, random (0, 160))
-TNT1 AA 0 A_CustomMissile ("XDeathChainLeg", 5, 0, random (0, 360), 2, random (0, 160))
-       Stop    }}
+TNT1 AA 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
+	TNT1 A 0 A_CustomMissile("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
+	TNT1 A 0 A_CustomMissile("XDeath3", 45, 0, random (0, 360), 2, random (0, 160))
+TNT1 AA 0 A_CustomMissile("XDeathChainLeg", 5, 0, random (0, 360), 2, random (0, 160))
+		Stop	}}
 
 
   
 actor BrutalizedCommandoLegs: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CPOD S -1
 Stop
 Death:
 		TNT1 A 0 A_SpawnItem("GibsZ")
-TNT1 AA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
-	TNT1 A 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
-	TNT1 A 0 A_CustomMissile ("XDeath3", 45, 0, random (0, 360), 2, random (0, 160))
-TNT1 AA 0 A_CustomMissile ("XDeathChainLeg", 5, 0, random (0, 360), 2, random (0, 160))
-       Stop    }}
-	   
+TNT1 AA 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
+	TNT1 A 0 A_CustomMissile("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
+	TNT1 A 0 A_CustomMissile("XDeath3", 45, 0, random (0, 360), 2, random (0, 160))
+TNT1 AA 0 A_CustomMissile("XDeathChainLeg", 5, 0, random (0, 360), 2, random (0, 160))
+		Stop	}}
+		
 actor DeadChaingunGuyCP04V: BrutalizedCommandoLegs
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		CP04 V -1
-        Stop    }}
+		Stop	}}
 		
 
-	   
+		
 
 actor DeadChaingunguyCPODX: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 CPOD X -1
-       Stop    }}	   
-	   
-	   
-	   
-	   
+		Stop	}}		
+		
+		
+		
+		
 Actor DeadChaingunguy_Slumped: ZombiemanTorso
 {
 +NOPAIN
@@ -1636,7 +1636,7 @@ States{Spawn:
 		TNT1 A 0 A_JumpIf(momx != 0 || momy != 0, "LayDown")
 		TNT1 A 0 
 		BR95 A 16
-        Loop  
+		Loop  
 	LayDown:
 	TNT1 A 0 A_NoBlocking
 	TNT1 A 0 A_SpawnItem("DeadChaingunguy1")
@@ -1655,16 +1655,16 @@ States{Spawn:
 		Stop
 		
 	Death:
-	    TNT1 A 0 A_NoBlocking
-		TNT1 AAA 0 A_CustomMissile ("Instestin", 32, 0, random (150, 210), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("XDeath1", 32, 0, random (150, 210), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("Xdeath3", 16, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
-		TNT1 AA 0 A_CustomMissile ("XDeathChainArm", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 A 0 A_NoBlocking
+		TNT1 AAA 0 A_CustomMissile("Instestin", 32, 0, random (150, 210), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("XDeath1", 32, 0, random (150, 210), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("Xdeath3", 16, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 AA 0 A_CustomMissile("XDeathChainArm", 40, 0, random (0, 360), 2, random (30, 90))
 		TNT1 A 0 A_SpawnItemEx("ChaingunguyHeadExplode", 0, 0, 22)
 		TNT1 A 0 A_SpawnItem("DeadChaingunguyMPSDD")
 		Stop
@@ -1679,88 +1679,88 @@ Scale 0.9
 States{Spawn:
 		TNT1 A 0
 		BR95 B 100
-        Loop  
+		Loop  
 	XDeath:
 	Death.Explosives:
 	Death.ExplosiveImpact:
 		TNT1 A 0 A_NoBlocking
-		TNT1 AAA 0 A_CustomMissile ("Instestin", 32, 0, random (150, 210), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("XDeath1", 32, 0, random (150, 210), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("Xdeath3", 16, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
-		TNT1 AA 0 A_CustomMissile ("XDeathChainArm", 40, 0, random (0, 360), 2, random (30, 90))
-		TNT1 AA 0 A_CustomMissile ("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("Instestin", 32, 0, random (150, 210), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("XDeath1", 32, 0, random (150, 210), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("Xdeath3", 16, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 AA 0 A_CustomMissile("XDeathChainArm", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 AA 0 A_CustomMissile("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
 		Stop	
 	Death:
-	    TNT1 A 0 A_NoBlocking
-		TNT1 AAA 0 A_CustomMissile ("Instestin", 32, 0, random (150, 210), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("XDeath1", 32, 0, random (150, 210), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("Xdeath3", 16, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
-		TNT1 AAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
-		TNT1 AA 0 A_CustomMissile ("XDeathChainArm", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 A 0 A_NoBlocking
+		TNT1 AAA 0 A_CustomMissile("Instestin", 32, 0, random (150, 210), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("XDeath1", 32, 0, random (150, 210), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("Xdeath3", 16, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90))
+		TNT1 AA 0 A_CustomMissile("XDeathChainArm", 40, 0, random (0, 360), 2, random (30, 90))
 		TNT1 A 0 A_SpawnItem("DeadChaingunguyMPSDD")
 		Stop	
-		}}	   
+		}}		
 		
 
 Actor DeadChaingunGuy_Melee
 {
-    Radius 20
-    Height 16
-    +SHOOTABLE
-    -SOLID
-    +NOTELEPORT
-    +MOVEWITHSECTOR
-    -CORPSE
+	Radius 20
+	Height 16
+	+SHOOTABLE
+	-SOLID
+	+NOTELEPORT
+	+MOVEWITHSECTOR
+	-CORPSE
 	-DONTGIB
 	-TELESTOMP
 	DamageFactor "Crush", 50.0 
 	Mass 220
-    Health 35
-    DamageFactor "Blood", 0.0
-    DamageFactor "Trample", 0.0
+	Health 35
+	DamageFactor "Blood", 0.0
+	DamageFactor "Trample", 0.0
 States
-    {
-    Spawn:
-        FID4 F -1
-        Stop
+	{
+	Spawn:
+		FID4 F -1
+		Stop
 	Raise:
 		CPOD GFEDCBA 5
-        TNT1 A 0 A_SpawnItem ("PB_Commando", 3)
+		TNT1 A 0 A_SpawnItem("PB_Commando", 3)
 		Stop
-    Death:
-         TNT1 A 0 A_CustomMissile ("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 A 0 A_CustomMissile ("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
-		 TNT1 AAA 0 A_CustomMissile ("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
-        Stop
-    Death.CutLess:
-    Death.Saw:
-        TNT1 AA 0 A_CustomMissile ("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainArm", 0, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
+	Death:
+		TNT1 A 0 A_CustomMissile("XDeath2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeath3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile("XDeath4", 5, 0, random (0, 360), 2, random (0, 160))
+		Stop
+	Death.CutLess:
+	Death.Saw:
+		TNT1 AA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainArm", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathChainLeg", 0, 0, random (0, 360), 2, random (0, 160))
 		TNT1 O 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
-         TNT1 A 1 A_SpawnItem ("DeadChaingunGuy_Half", 5)
-     Stop
-    Death.Plasma: Death.Plasma2:
-        TNT1 A 0
-        TNT1 A 0 A_XScream
-        TNT1 A 0 A_NoBlocking
-        TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
-	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
-		EXPL AAA 0 A_CustomMissile ("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
-        TNT1 A 0
-        Stop}}
+		TNT1 A 0 A_CustomMissile("RipGuts", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 1 A_SpawnItem("DeadChaingunGuy_Half", 5)
+	Stop
+	Death.Plasma: Death.Plasma2:
+		TNT1 A 0
+		TNT1 A 0 A_XScream
+		TNT1 A 0 A_NoBlocking
+		TNT1 AAA 0 A_CustomMissile("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
+		EXPL AAA 0 A_CustomMissile("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
+		TNT1 A 0
+		Stop}}
 		
 
 ACTOR SufferingCommandoGuts
@@ -1770,13 +1770,13 @@ ACTOR SufferingCommandoGuts
 	Height 20
 	Health 56
 	DamageFactor "Blood", 0.0 DamageFactor "BlueBlood", 0.0 DamageFactor "GreenBlood", 0.0
-    DamageFactor "Avoid", 0.0
+	DamageFactor "Avoid", 0.0
 	DamageFactor "Shrapnel", 0.0
 	DamageFactor "KillMe", 0.0
 	DamageFactor "BlueBloodSplasher", 0.0
-    DamageFactor "BlueSuperBloodSplasher", 0.0
+	DamageFactor "BlueSuperBloodSplasher", 0.0
 	PainSound "commando/pain"
-	DamageFactor "bloodsplasher", 0.0    DamageFactor "tinybloodsplasher", 0.0    DamageFactor "superbloodsplasher", 0.0    DamageFactor "smallbloodsplasher", 0.0
+	DamageFactor "bloodsplasher", 0.0	DamageFactor "tinybloodsplasher", 0.0	DamageFactor "superbloodsplasher", 0.0	DamageFactor "smallbloodsplasher", 0.0
 	Mass 0x7FFFFFFF
 	-SOLID
 	+SHOOTABLE
@@ -1786,37 +1786,37 @@ ACTOR SufferingCommandoGuts
 	{
 	Spawn:
 	CPOS A 0 
-	ACB0 ABCB 5 A_SpawnItem ("DripingBlood", 0, 23)
+	ACB0 ABCB 5 A_SpawnItem("DripingBlood", 0, 23)
 	TNT1 A 0 A_PlaySound("commando/pain")
 	TNT1 A 0 A_PlaySound("misc/xdeath2c", 3)
 	CPOS A 0 
 	TNT1 AA 0 A_SpawnItem("Xdeath1", 0, 20)
 	TNT1 A 0 A_SpawnItem("BloodMistSmall", 0, 23)
-	ACB0 ABCB 5 A_SpawnItem ("DripingBlood", 0, 23)
+	ACB0 ABCB 5 A_SpawnItem("DripingBlood", 0, 23)
 	CPOS A 0 
 	TNT1 A 0 A_PlaySound("commando/pain")
 	TNT1 A 0 A_PlaySound("misc/xdeath2c", 3)
 	TNT1 A 0 A_SpawnItem("BloodMistSmall", 0, 23)
 	TNT1 AA 0 A_SpawnItem("Instestin", 0, 20)
-	ACB0 ABCB 5 A_SpawnItem ("DripingBlood", 0, 23)
+	ACB0 ABCB 5 A_SpawnItem("DripingBlood", 0, 23)
 	CPOS A 0 
 	TNT1 A 0 A_PlaySound("commando/pain")
 	TNT1 A 0 A_PlaySound("misc/xdeath2c", 3)
 	TNT1 A 0 A_SpawnItem("BloodMistSmall", 0, 23)
 	TNT1 AA 0 A_SpawnItem("Xdeath1", 0, 20)
-	ACB0 ABCB 5 A_SpawnItem ("DripingBlood", 0, 23)
+	ACB0 ABCB 5 A_SpawnItem("DripingBlood", 0, 23)
 	CPOS A 0 
 	TNT1 A 0 A_PlaySound("commando/pain")
 	TNT1 A 0 A_PlaySound("misc/xdeath2c", 3)
 	TNT1 A 0 A_SpawnItem("BloodMistSmall", 0, 23)
 	TNT1 AA 0 A_SpawnItem("Xdeath1", 0, 20)
-	ACB0 ABCB 5 A_SpawnItem ("DripingBlood", 0, 23)
+	ACB0 ABCB 5 A_SpawnItem("DripingBlood", 0, 23)
 	CPOS A 0 
 	TNT1 A 0 A_PlaySound("commando/pain")
 	TNT1 A 0 A_PlaySound("misc/xdeath2c", 3)
 	TNT1 A 0 A_SpawnItem("BloodMistSmall", 0, 23)
 	TNT1 AA 0 A_SpawnItem("Xdeath1", 0, 20)
-	ACB0 ABCB 5 A_SpawnItem ("DripingBlood", 0, 23)
+	ACB0 ABCB 5 A_SpawnItem("DripingBlood", 0, 23)
 	CPOS A 0 
 	TNT1 A 0 A_PlaySound("commando/pain")
 	TNT1 A 0 A_PlaySound("misc/xdeath2c", 3)
@@ -1824,52 +1824,52 @@ ACTOR SufferingCommandoGuts
 	TNT1 AA 0 A_SpawnItem("Instestin", 0, 20)
 	ACPS LM 5
 	TNT1 A 0 A_PlaySound("BODYF",6)
-	TNT1 A 0 A_SpawnItem ("DeadAssCommandoGuts")
+	TNT1 A 0 A_SpawnItem("DeadAssCommandoGuts")
 	Stop
 
 	Death:
-	TNT1 A 0 A_SpawnItem ("CrueltyBonus5Health")
-	TNT1 AAAAAA 0 A_CustomMissile ("BloodMistBig", 1, 0, random (0, 360), 2, random (0, 160))
-	TNT1 AA 0 A_CustomMissile ("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160))
-	TNT1 AAAA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
-	TNT1 AA 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
-    TNT1 A 0 A_PlaySound("chainguy/death")
-	TNT1 A 0 A_SpawnItem ("BrutalizedCommandoLegs")
+	TNT1 A 0 A_SpawnItem("CrueltyBonus5Health")
+	TNT1 AAAAAA 0 A_CustomMissile("BloodMistBig", 1, 0, random (0, 360), 2, random (0, 160))
+	TNT1 AA 0 A_CustomMissile("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160))
+	TNT1 AAAA 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
+	TNT1 AA 0 A_CustomMissile("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
+	TNT1 A 0 A_PlaySound("chainguy/death")
+	TNT1 A 0 A_SpawnItem("BrutalizedCommandoLegs")
 	Stop
 	
 	Death.Head:
 	Death.MinorHead:
 	TNT1 A 0 A_PlaySound("misc/xdeath4")
-		TNT1 A 0 A_SpawnItem ("CrueltyBonus5Health")
- 		TNT1 AAAA 0 A_CustomMissile ("Brains1", 25, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("Brains3", 25, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("Brains6", 25, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("Brains7", 25, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAAAAAAAAAA 0 A_CustomMissile ("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
-		TNT1 AAAA 0 A_CustomMissile ("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40))
-		TNT1 AAAA 0 A_CustomMissile ("SmallBrainPiece", 25, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem("CrueltyBonus5Health")
+ 		TNT1 AAAA 0 A_CustomMissile("Brains1", 25, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("Brains3", 25, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("Brains6", 25, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile("Brains7", 25, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile("SmallBrainPiece", 25, 0, random (0, 360), 2, random (0, 160))
 		ACHS DDDDDDDE 3
 		TNT1 A 0 A_PlaySound("BODYF",6)
-		TNT1 A 0 A_SpawnItem ("HeadlessCommandoGuts")
+		TNT1 A 0 A_SpawnItem("HeadlessCommandoGuts")
 		Stop
 }}
 
 actor HeadlessCommandoGuts: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
-       ACHS E -1 
-       Stop    
-	   }
+	States
+	{
+	Spawn:
+		ACHS E -1 
+		Stop	
+		}
 }
 
 actor DeadAssCommandoGuts: CurbstompedMarine
 {
-    States
-    {
-    Spawn:
-       ACPS N -1 
-       Stop    
-	   }
+	States
+	{
+	Spawn:
+		ACPS N -1 
+		Stop	
+		}
 }

--- a/actors/Weapons/Slot1/MELEE.dec
+++ b/actors/Weapons/Slot1/MELEE.dec
@@ -105,7 +105,7 @@ ACTOR ArachnoGun_Plasma
 	Height 10
 	Speed 60
 	Damage 10
-    DamageType Plasma
+	DamageType Plasma
 	Decal "Scorch"
 	alpha 0.87
 	Scale 0.30
@@ -113,12 +113,12 @@ ACTOR ArachnoGun_Plasma
 	+RANDOMIZE
 	renderstyle ADD
 	DeathSound "weapons/plasmax"
-    SeeSound "None"
+	SeeSound "None"
 	Obituary "%o was melted by %k's Plasma Gun"
 	States
 	{
 	Spawn:
-        PBAL C 1 BRIGHT A_SpawnItem("PlasmaFlare",0,0)
+		PBAL C 1 BRIGHT A_SpawnItem("PlasmaFlare",0,0)
 		TNT1 A 0 A_PlaySound("weapons/plasmaloop",6,1,1)
 		Loop
 	
@@ -134,7 +134,7 @@ ACTOR ArachnoGun_Plasma
 	Death:
 		TNT1 A 0 A_StopSound(6)
 		TNT1 A 0 A_SpawnItemEx ("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
-	    TNT1 A 0 A_SpawnItemEx ("DetectCeilCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SpawnItemEx ("DetectCeilCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		TNT1 B 1 A_Explode(8,50,1)
 		TNT1 A 0 A_CustomMissile ("BluePlasmaFire", 0, 0, random (0, 360), 2, random (0, 360))
 		TNT1 AAAAA 0 A_CustomMissile ("BluePlasmaParticle", 0, 0, random (0, 360), 2, random (0, 360))
@@ -160,10 +160,12 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 	Obituary "%o was Ripped and Torn by %k"
 	+WEAPON.WIMPY_WEAPON
 	+WEAPON.MELEEWEAPON
-    +WEAPON.NOALERT
-    +WEAPON.NOAUTOAIM
+	+WEAPON.NOALERT
+	+WEAPON.NOAUTOAIM
 	//+WEAPON.NOAUTOFIRE
 	+WEAPON.CHEATNOTWEAPON
+	+INVENTORY.UNDROPPABLE
+	+INVENTORY.UNTOSSABLE
 	Tag "Bare Hands"
 	inventory.AltHUDIcon "KUKRA0"
 	States
@@ -190,9 +192,9 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_JumpIfInventory ("GrabbedFlameBarrel", 1, "IdleFlameBarrel")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedIceBarrel", 1, "IdleIceBarrel")
 		TNT1 A 0 A_TakeInventory("Punching", 1)
-        TNT1 A 0 A_JumpIfInventory("LostSoulFatality",1,"KillLS")
+		TNT1 A 0 A_JumpIfInventory("LostSoulFatality",1,"KillLS")
 		TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
-	    TNT1 A 0 A_JumpIfInventory("PB_PowerStrength",1,"SelectFatalityModes")
+		TNT1 A 0 A_JumpIfInventory("PB_PowerStrength",1,"SelectFatalityModes")
 		PUNS E 2
 		PUNS F 2 A_PlaySoundEx("KNUCKLED", "Auto")
 		PUNS GFEK 2
@@ -207,7 +209,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		Goto FatalityOff
 	FatalityOn:
 		TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
-	    TNT1 A 0 A_Print("Auto Execute: On")
+		TNT1 A 0 A_Print("Auto Execute: On")
 		PUNS E 2
 		TNT1 A 0 A_PlaySoundEx("KNUCKLED", "Auto")
 		PUNS FGF 2 A_FireCustomMissile("ShakeYourAss", 0, 0, 0, 0) 
@@ -226,7 +228,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		P2NR ABCDEFFGGHIJKKLMMNOPQRSTUVWX 0
 		P3NR ABCDEFFGGHIJKKLMMNOPQRSTUVWX 0
 		
-	    P9NS ABCDEFF 1 {
+		P9NS ABCDEFF 1 {
 			if (CountInv("PowerBloodOnVisor") >= 1 ) { A_SetWeaponSprite("P1NR"); }
 			if (CountInv("PowerBlueBloodOnVisor") >= 1 ) { A_SetWeaponSprite("P2NR");}
 			if (CountInv("PowerGreenBloodOnVisor") >= 1 ) { A_SetWeaponSprite("P3NR");}
@@ -254,10 +256,10 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		Goto ReadyFists
 	
 	Ready:
-        ////////////////// Check if player is performing a fatality
-        TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
+		////////////////// Check if player is performing a fatality
+		TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
  		TNT1 A 0 A_JumpIfInventory("ShotgunguyHead",1,"ReadyShotgunguyHead")
-        TNT1 A 0 A_JumpIfInventory("LostSoulFatality",1,"ReadySoul")
+		TNT1 A 0 A_JumpIfInventory("LostSoulFatality",1,"ReadySoul")
 		TNT1 A 0 A_JumpIfInventory("PhantasmFatality",1, "ReadyPhantasm")
 		
 		//Play raising animation
@@ -293,9 +295,9 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_SetInventory("PSeq3", 0)
 		TNT1 A 0 A_SetInventory("PSeq4", 0)
 	ReadyFistsLoop:
-        TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
+		TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
  		TNT1 A 0 A_JumpIfInventory("ShotgunguyHead",1,"ReadyShotgunguyHead")
-        TNT1 A 0 A_JumpIfInventory("LostSoulFatality",1,"ReadySoul")
+		TNT1 A 0 A_JumpIfInventory("LostSoulFatality",1,"ReadySoul")
 		TNT1 A 0 A_JumpIfInventory("PhantasmFatality",1, "ReadyPhantasm")
 		P0NG ABCDEFGHIJKLMNOPQRSRQPONMLKJIHGFEDCBA 1 {
 			if (CountInv("PowerBloodOnVisor") >= 1 ) { A_SetWeaponSprite("P1NG"); }
@@ -306,7 +308,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		loop
 		
 	ReadyShotgunguyHEad:
-        PTG1 B 1 A_DoPBWeaponAction
+		PTG1 B 1 A_DoPBWeaponAction
 		loop
 	
 	LostSoulHandFireOverlay:
@@ -322,7 +324,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 			
 	ReadySoul:
 		TNT1 A 0 A_Overlay(-3, "LostSoulHandFireOverlay")
-        THEA AAAABBBBAAAABBBBCCCCDDDDCCCCDDDD 1 BRIGHT A_DoPBWeaponAction
+		THEA AAAABBBBAAAABBBBCCCCDDDDCCCCDDDD 1 BRIGHT A_DoPBWeaponAction
 		loop
 	
 	PhantasmHandFireOverlay:
@@ -337,10 +339,10 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 			Stop
 	ReadyPhantasm:
 		TNT1 A 0 A_Overlay(-3, "PhantasmHandFireOverlay")
-        TH3A AAAABBBBAAAABBBBCCCCDDDDCCCCDDDD 1 BRIGHT A_DoPBWeaponAction
+		TH3A AAAABBBBAAAABBBBCCCCDDDDCCCCDDDD 1 BRIGHT A_DoPBWeaponAction
 		loop
 		
-    Deselect:
+	Deselect:
 		TNT1 A 0 A_JumpIfInventory ("GrabbedBarrel", 1, "PlaceBarrel")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedFlameBarrel", 1, "PlaceFlameBarrel")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedIceBarrel", 1, "PlaceIceBarrel")
@@ -360,13 +362,13 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		Wait
 	GrabObject:
 		TNT1 A 0
-	    TNT1 A 0 A_PlaySound("weapons/fistwhoosh2")
-        PKUP ABCDEF 1
+		TNT1 A 0 A_PlaySound("weapons/fistwhoosh2")
+		PKUP ABCDEF 1
 		Goto Ready		
-    KillLS:
+	KillLS:
 		THEA E 1 A_PlaySound("gore/headshot")
-        THEA E 3 
-        THEA F 4 
+		THEA E 3 
+		THEA F 4 
 		{
 			A_FireCustomMissile("ShakeYourAss", 0, 0, 0, 0);
 			A_FireCustomMissile("ShakeYourAss", 0, 0, 0, 0);
@@ -394,9 +396,9 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
 		TNT1 A 0 A_SetInventory("Reloading", 0) //Prevent accidentally switching to smash/fatality mode
 		TNT1 A 0 PB_WeapTokenSwitch("FistsSelected")
-        ////////////////// Check if player is performing a fatality\\\\
+		////////////////// Check if player is performing a fatality\\\\
 		TNT1 A 0
-        ////////////////////
+		////////////////////
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Raise
 		TNT1 AAAAAAAA 1 A_Raise
 		Wait
@@ -431,7 +433,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_SetInventory("Punching",1)
 		TNT1 A 0 A_GiveInventory("PSeq1",1)
 //Added to prevent an issue with the PSPF_PLAYERTRANSLATED flag overwriting the
-//green blood  when doing punch and kick combos at the same time.		
+//green blood when doing punch and kick combos at the same time.		
 		TNT1 A 0 A_OverlayFlags(1,PSPF_PLAYERTRANSLATED, false)
 		//Initialize Bloodied Sprites in GZDoom's virtual memory
 		P1NJ ABCDEFGH 0
@@ -452,7 +454,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 			if (CountInv("PB_PowerStrength") >= 1 & CountInv("PowerGreenBloodOnVisor") >= 1) { A_SetWeaponSprite("P4NJ");}
 			A_SetRoll(roll+0.5);
 			}
-        TNT1 A 0 A_PlaySound("weapons/fistwhoosh2")
+		TNT1 A 0 A_PlaySound("weapons/fistwhoosh2")
 		//Determine berserk strike or not
 		TNT1 A 0 {
 			if (CountInv("PB_PowerStrength") >= 1 ) 
@@ -492,7 +494,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_GiveInventory("PSeq2",1)
 		TNT1 A 0 A_TakeInventory("PSeq1",3)
 //Added to prevent an issue with the PSPF_PLAYERTRANSLATED flag overwriting the
-//green blood  when doing punch and kick combos at the same time.		
+//green blood when doing punch and kick combos at the same time.		
 		TNT1 A 0 A_OverlayFlags(1,PSPF_PLAYERTRANSLATED, false)
 		
 		//Initialize Bloodied Sprites in GZDoom's virtual memory
@@ -582,7 +584,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_TakeInventory("PSeq1",3)
 		TNT1 A 0 A_TakeInventory("PSeq2",3)
 //Added to prevent an issue with the PSPF_PLAYERTRANSLATED flag overwriting the
-//green blood  when doing punch and kick combos at the same time.		
+//green blood when doing punch and kick combos at the same time.		
 		TNT1 A 0 A_OverlayFlags(1,PSPF_PLAYERTRANSLATED, false)
 		//Initialize Bloodied Sprites in GZDoom's virtual memory
 		P2NE ABCDEFGHIJKLM 0 
@@ -671,7 +673,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_TakeInventory("PSeq2",3)
 		TNT1 A 0 A_TakeInventory("PSeq3",3)
 //Added to prevent an issue with the PSPF_PLAYERTRANSLATED flag overwriting the
-//green blood  when doing punch and kick combos at the same time.		
+//green blood when doing punch and kick combos at the same time.		
 		TNT1 A 0 A_OverlayFlags(1,PSPF_PLAYERTRANSLATED, false)
 		//Initialize Bloodied Sprites in GZDoom's virtual memory
 		P2NH ABCDEFGHIJKLMNOPQRST 0 
@@ -753,7 +755,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		}
 		Goto ReadyFists
 		
-    AltFire: //Right Handed Punches
+	AltFire: //Right Handed Punches
 		TNT1 A 0 A_JumpIfInventory ("GrabbedBarrel", 1, "PlaceBarrel")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedFlameBarrel", 1, "PlaceFlameBarrel")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedIceBarrel", 1, "PlaceIceBarrel")
@@ -782,7 +784,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_SetInventory("Punching",1)
 		TNT1 A 0 A_GiveInventory("PSeq1",1)
 //Added to prevent an issue with the PSPF_PLAYERTRANSLATED flag overwriting the
-//green blood  when doing punch and kick combos at the same time.		
+//green blood when doing punch and kick combos at the same time.		
 		TNT1 A 0 A_OverlayFlags(1,PSPF_PLAYERTRANSLATED, false)
 		//Initialize Bloodied Sprites in GZDoom's virtual memory
 		P2NA ABCDEFGH 0 
@@ -803,7 +805,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 			if (CountInv("PB_PowerStrength") >= 1 & CountInv("PowerGreenBloodOnVisor") >= 1) { A_SetWeaponSprite("P4NN");}
 			A_SetRoll(roll-0.5);
 			}
-        TNT1 A 0 A_PlaySound("weapons/fistwhoosh2")
+		TNT1 A 0 A_PlaySound("weapons/fistwhoosh2")
 		
 		//Determine berserk strike or not
 		TNT1 A 0 {
@@ -845,7 +847,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_GiveInventory("PSeq2",1)
 		TNT1 A 0 A_SetInventory("PSeq1",0)
 //Added to prevent an issue with the PSPF_PLAYERTRANSLATED flag overwriting the
-//green blood  when doing punch and kick combos at the same time.		
+//green blood when doing punch and kick combos at the same time.		
 		TNT1 A 0 A_OverlayFlags(1,PSPF_PLAYERTRANSLATED, false)
 		
 		//Initialize Bloodied Sprites in GZDoom's virtual memory
@@ -1133,7 +1135,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_SetInventory("PSeq4",0)
 		TNT1 A 0 A_GiveInventory("PSeq3",1)
 		KIC4 ABCDEF 1 A_SetRoll(roll+1)
-        TNT1 A 0 A_PlaySound("KICK", 5)
+		TNT1 A 0 A_PlaySound("KICK", 5)
 		KIC4 GG 1
 		TNT1 A 0 A_JumpIfInventory("PB_PowerStrength", 1, 3)
 		TNT1 A 0 A_FireCustomMissile("KickAttack", 0, 0, 5, 5)
@@ -1167,7 +1169,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_SetInventory("PSeq4",0)
 		TNT1 A 0 A_GiveInventory("PSeq3",1)
 		KIC5 ABCDEF 1 A_SetRoll(roll-1)
-        TNT1 A 0 A_PlaySound("KICK", 5)
+		TNT1 A 0 A_PlaySound("KICK", 5)
 		KIC5 GG 1
 		TNT1 A 0 A_JumpIfInventory("PB_PowerStrength", 1, 3)
 		TNT1 A 0 A_FireCustomMissile("KickAttack", 0, 0, -5, 5)
@@ -1258,7 +1260,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		Goto ReadyFists
 		
 	
-    ThrustKick:
+	ThrustKick:
 		TNT1 A 0 A_JumpIfInventory("Kicking", 1, "ReadyFists")
 		TNT1 A 0 {
 			A_SetInventory("Kicking",1);
@@ -1304,8 +1306,8 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 			A_SetPitch(+1.25 + pitch, SPF_INTERPOLATE);
 			A_ZoomFactor(0.950);
 			}
-        KIC1 E 1 A_Recoil(-1)
-        KIC1 F 1 { //No more unneeded Super states here, this now unified into a single state with an if else statement.
+		KIC1 E 1 A_Recoil(-1)
+		KIC1 F 1 { //No more unneeded Super states here, this now unified into a single state with an if else statement.
 			if(CountInv("PB_PowerStrength") == 1) {
 				A_FireCustomMissile("SuperKickAttack", 0, 0, 0, -7);
 			}
@@ -1313,7 +1315,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 				A_FireCustomMissile("KickAttack", 0, 0, 0, -7);
 			}
 		}
-        KIC1 GG 1 
+		KIC1 GG 1 
 		KIC1 I 1 {
 			A_ZoomFactor(0.965);
 			A_SetAngle(+1 + angle, SPF_INTERPOLATE);
@@ -1372,7 +1374,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		AKCK B 1 A_SetRoll(roll-2, SPF_INTERPOLATE)
 		AKCK C 1 A_SetRoll(roll-2, SPF_INTERPOLATE)
 		AKCK DEFGH 1
-        RIFF A 0 {
+		RIFF A 0 {
 			if(CountInv("PB_PowerStrength") == 1) {
 				A_FireCustomMissile("SuperAirKickAttack", 0, 0, 0, -31);
 			}
@@ -1381,7 +1383,7 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 			}
 		}
 		TNT1 A 0 A_ZoomFactor(0.975)
-        AKCK IJK 1
+		AKCK IJK 1
 		TNT1 A 0 A_ZoomFactor(0.995)
 		TNT1 A 0 
 		AKCK LM 1
@@ -1481,12 +1483,12 @@ ACTOR PoorLostSoul
 	Radius 6
 	Height 8
 	Speed 22
-    Fastspeed 26
+	Fastspeed 26
 	Damage 15
 	Projectile 
-    Scale 1.0
+	Scale 1.0
 	+FORCEXYBILLBOARD
-    DamageType Fire
+	DamageType Fire
 ExplosionRadius 70
 ExplosionDamage 50
 	Alpha 1
@@ -1495,21 +1497,21 @@ ExplosionDamage 50
 	States
 	{
 	Spawn:
-        TNT1 A 0 A_CustomMissile ("FlameTrails", 24, 0, 0, 0, 0)
-        LSOL B 2 BRIGHT A_SpawnItem("RedFlare",0,0)
+		TNT1 A 0 A_CustomMissile ("FlameTrails", 24, 0, 0, 0, 0)
+		LSOL B 2 BRIGHT A_SpawnItem("RedFlare",0,0)
 		Loop
 	Death:
-    
+	
 		LSOL F 2 BRIGHT
 		LSOL G 2 BRIGHT
 		TNT1 A 0 A_Explode
 	EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("FlameTrails", 6, 0, random (0, 360), 2, random (0, 360))
 		EXPL A 0 A_SpawnItemEx("ExplosionParticleSpawner", 0, 0, 0, 0, 0, 0, 0, 0)
-    TNT1 AAA 0 A_CustomMissile ("LSpart1", 42, 0, random (0, 360), 2, random (0, 160))
-    TNT1 A 0 A_CustomMissile ("LSpart3", 42, 0, random (0, 360), 2, random (0, 160))
-    TNT1 AAAA 0 A_CustomMissile ("LSpart2", 42, 0, random (0, 360), 2, random (0, 160))
+	TNT1 AAA 0 A_CustomMissile ("LSpart1", 42, 0, random (0, 360), 2, random (0, 160))
+	TNT1 A 0 A_CustomMissile ("LSpart3", 42, 0, random (0, 360), 2, random (0, 160))
+	TNT1 AAAA 0 A_CustomMissile ("LSpart2", 42, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0
-        LSOL HI 6
+		LSOL HI 6
 		Stop
 		Stop
 	}
@@ -1520,12 +1522,12 @@ ACTOR PoorPhantasm
 	Radius 6
 	Height 8
 	Speed 28
-    Fastspeed 32
+	Fastspeed 32
 	Damage 20
 	Projectile 
-    Scale 1.0
+	Scale 1.0
 	+FORCEXYBILLBOARD
-    DamageType GreenFire
+	DamageType GreenFire
 ExplosionRadius 80
 ExplosionDamage 60
 	Alpha 1
@@ -1534,16 +1536,16 @@ ExplosionDamage 60
 	States
 	{
 	Spawn:
-        TNT1 A 0 A_CustomMissile ("GreenFlameTrails", 24, 0, 0, 0, 0)
-        STLK B 1 BRIGHT A_SpawnItem("GreenFlare",0,0)
+		TNT1 A 0 A_CustomMissile ("GreenFlameTrails", 24, 0, 0, 0, 0)
+		STLK B 1 BRIGHT A_SpawnItem("GreenFlare",0,0)
 		Loop
 	Death:
 
 		STLK F 2 BRIGHT
 		STLK G 2 BRIGHT
-		  TNT1 AAA 0 A_SpawnItemEx("PlasmaParticleSpawner", 0, 0, 0, 0, 0, 0, 0, 128)
-	   TNT1 A 0 A_SpawnItemEx ("BFGAltExplosion",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
-	   TNT1 A 0 A_SpawnItem("BFGAltShockWave",0,0)
+		TNT1 AAA 0 A_SpawnItemEx("PlasmaParticleSpawner", 0, 0, 0, 0, 0, 0, 0, 128)
+		TNT1 A 0 A_SpawnItemEx ("BFGAltExplosion",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SpawnItem("BFGAltShockWave",0,0)
 		TNT1 A 0 A_Explode
 		EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("GreenFlameTrails", 6, 0, random (0, 360), 2, random (0, 360))
 		EXPL A 0 A_SpawnItemEx("ExplosionParticleSpawner", 0, 0, 0, 0, 0, 0, 0, 0)
@@ -1551,7 +1553,7 @@ ExplosionDamage 60
 		TNT1 A 0 A_CustomMissile ("Phantasmpart3", 42, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Phantasmpart2", 42, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0
-        LSOL HI 6
+		LSOL HI 6
 		Stop
 	}
 }
@@ -1567,8 +1569,8 @@ ACTOR KickAttack: FastProjectile
 	+NOGRAVITY
 	RenderStyle Add
 	Alpha 0.6
-    Damage (random(38,42))
-    Speed 30
+	Damage (random(38,42))
+	Speed 30
 	//HitObituary "$OB_IMPHIT"
 	SeeSound "none"
 	DeathSound "none"
@@ -1578,13 +1580,13 @@ ACTOR KickAttack: FastProjectile
 	{
 	Spawn:
 		TNT1 A 1 BRIGHT
-        TNT1 A 1 //A_PlaySound("weapons/gswing")
+		TNT1 A 1 //A_PlaySound("weapons/gswing")
 		Stop
 	Death:
 			TNT1 A 0
 			TNT1 A 0 A_CheckFloor("DeathOnGround")
 			TNT1 A 0 A_JumpIfInTargetInventory("IsSlideKicking", 1, 13)
-		    PUFF A 0 A_PlaySound("FOOTWALL", 3) //A_PlaySound("player/cyborg/fist", 3)
+			PUFF A 0 A_PlaySound("FOOTWALL", 3) //A_PlaySound("player/cyborg/fist", 3)
 			TNT1 A 0 A_SpawnItemEx ("PLOFT2",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 			EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
 			TNT1 A 0 A_GiveToTarget("KickHasHit", 1)
@@ -1622,7 +1624,7 @@ ACTOR KickAttack: FastProjectile
 	DeathOnGround:
 			TNT1 A 0
 			TNT1 A 0 A_JumpIfInTargetInventory("IsSlideKicking", 1, 2)
-		    PUFF A 0 A_PlaySound("FOOTWALL", 3) //A_PlaySound("player/cyborg/fist", 3)
+			PUFF A 0 A_PlaySound("FOOTWALL", 3) //A_PlaySound("player/cyborg/fist", 3)
 			TNT1 A 0
 			TNT1 A 0 A_SpawnItemEx ("PLOFT2",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 			EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
@@ -1643,7 +1645,7 @@ ACTOR KickAttackLow: KickAttack
 	Death:
 			TNT1 A 0
 			TNT1 A 0 A_CheckFloor("DeathOnGround")
-		    PUFF A 0 A_PlaySound("player/cyborg/fist", 3)
+			PUFF A 0 A_PlaySound("player/cyborg/fist", 3)
 			EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
 			TNT1 A 0 Radius_Quake (3, 6, 0, 5, 0)//(intensity, duration, damrad, tremrad, tid)
 			TNT1 A 1
@@ -1655,20 +1657,20 @@ ACTOR KickAttackLow: KickAttack
 
 ACTOR SuperKickAttack: KickAttack
 {
-    Damage (random(64,70))
+	Damage (random(64,70))
 	-NOEXTREMEDEATH
 	DamageType ExtremePunches
 }
 
 ACTOR StompAttack: KickAttack
 {
-    Damage (random(150,200))
+	Damage (random(150,200))
 	speed 100
 	DamageType Trample
 	States
 	{
 	Death:
-		    PUFF A 0 A_PlaySound("player/cyborg/fist")
+			PUFF A 0 A_PlaySound("player/cyborg/fist")
 			TNT1 A 0 A_Explode(150, 15, 0)
 			EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
 			TNT1 A 10
@@ -1678,13 +1680,13 @@ ACTOR StompAttack: KickAttack
 
 ACTOR SuperStompAttack: KickAttack
 {
-    Damage (random(300,500))
+	Damage (random(300,500))
 	Speed 100
 	DamageType HeavyTrample
 		States
 	{
 	Death:
-		    PUFF A 0 A_PlaySound("player/cyborg/fist")
+			PUFF A 0 A_PlaySound("player/cyborg/fist")
 			TNT1 A 0 A_Explode(300, 15, 0)
 			EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
 			TNT1 A 10
@@ -1694,14 +1696,14 @@ ACTOR SuperStompAttack: KickAttack
 
 ACTOR HookAttack: KickAttack
 {
-    Speed 30
+	Speed 30
 }
 
 ACTOR AirKickAttack: KickAttack
 {
 	Radius 12
 	Height 32
-    Damage (random(54,62))
+	Damage (random(54,62))
 }
 
 ACTOR SuperAirKickAttack: KickAttack
@@ -1710,11 +1712,11 @@ ACTOR SuperAirKickAttack: KickAttack
 	Height 32
 	-NOEXTREMEDEATH
 	DamageType Extremepunches
-    Damage (random(92,110))
+	Damage (random(92,110))
 		States
 	{
 	Death:
-		    PUFF A 0 A_PlaySound("player/cyborg/fist", 3)
+			PUFF A 0 A_PlaySound("player/cyborg/fist", 3)
 			TNT1 A 0 A_SpawnItemEx ("PLOFT2",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 			EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
 			TNT1 A 0 A_GiveToTarget("KickHasHit", 1)
@@ -1736,7 +1738,7 @@ States
 		TNT1 A 1 BRIGHT
 		Stop
 	Death:
-	    TNT1 A 0
+		TNT1 A 0
 		PUFF A 0 A_PlaySound("player/cyborg/fist")
 		EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
 		TNT1 A 10
@@ -1794,7 +1796,7 @@ States
 {
 Spawn:
 TNT1 A 0
-        TNT1 A 0 A_Explode(25,150, 0)
+		TNT1 A 0 A_Explode(25,150, 0)
 Stop
  }
 }
@@ -1818,7 +1820,7 @@ States
 {
 Spawn:
 TNT1 A 0
-       // TNT1 A 0 A_Explode(20,30, 0)
+		// TNT1 A 0 A_Explode(20,30, 0)
 Stop
  }
 }
@@ -1841,7 +1843,7 @@ States
 {
 Spawn:
 TNT1 A 0
-        TNT1 A 0 A_Explode(20,30, 0)
+		TNT1 A 0 A_Explode(20,30, 0)
 Stop
  }
 }
@@ -1866,7 +1868,7 @@ States
 {
 Spawn:
 TNT1 A 0
-        TNT1 A 0 A_Explode(20,30, 0)
+		TNT1 A 0 A_Explode(20,30, 0)
 Stop
  }
 }
@@ -1890,7 +1892,7 @@ States
 {
 Spawn:
 TNT1 A 2
-        TNT1 A 0 A_Explode(10,30, 0)
+		TNT1 A 0 A_Explode(10,30, 0)
 Stop
  }
 }
@@ -1900,21 +1902,21 @@ ACTOR MeleeStrikeSuperRound: SuperKickAttack
 Damage 42
 DamageType ExtremePunches
 Decal "Crack"
-  states
-  {
-  XDeath:
-    PUFF A 0 A_PlaySound("player/cyborg/kick")
-    PUFF BCD 3
-    stop
-  Death:
-    PUFF A 3 A_PlaySound("player/cyborg/kick")
-    PUFF BCD 3
-    stop
-  Crash:
-    PUFF A 3 A_PlaySound("player/cyborg/kick")
-    PUFF BCD 3
-    stop
-  }
+	states
+	{
+	XDeath:
+	PUFF A 0 A_PlaySound("player/cyborg/kick")
+	PUFF BCD 3
+	stop
+	Death:
+	PUFF A 3 A_PlaySound("player/cyborg/kick")
+	PUFF BCD 3
+	stop
+	Crash:
+	PUFF A 3 A_PlaySound("player/cyborg/kick")
+	PUFF BCD 3
+	stop
+	}
 }
 
 ///////////////////KNIFE
@@ -1976,45 +1978,45 @@ ACTOR SuperKnifeSwing : KnifeSwing
 
 Actor FistAttack : FastProjectile
 {
-    Radius 2
-    Height 2
-    Damage (0)
-    Speed 96 //64
-    RenderStyle Add
-    Alpha 0.6
-    Scale 0.65
-    SeeSound "none"
-    DeathSound "none"
-    Species "Player"
-    DamageType "none"
-    Projectile
-    +BLOODSPLATTER
-    +THRUSPECIES
-    +THRUGHOST
-    +EXTREMEDEATH
-    +FORCERADIUSDMG
-    Decal WallCrack
-    -RIPPER
-    States
-    {
-    Spawn:
-        TNT1 A 2
-        Stop
-    Death:
-    Crash:
-        TNT1 A 0 A_Stop
-        TNT1 A 1 A_GiveToTarget("FistHit",1)
+	Radius 2
+	Height 2
+	Damage (0)
+	Speed 96 //64
+	RenderStyle Add
+	Alpha 0.6
+	Scale 0.65
+	SeeSound "none"
+	DeathSound "none"
+	Species "Player"
+	DamageType "none"
+	Projectile
+	+BLOODSPLATTER
+	+THRUSPECIES
+	+THRUGHOST
+	+EXTREMEDEATH
+	+FORCERADIUSDMG
+	Decal WallCrack
+	-RIPPER
+	States
+	{
+	Spawn:
+		TNT1 A 2
 		Stop
-    XDeath:
-        TNT1 A 0 A_Stop
-        TNT1 A 1 A_GiveToTarget("FistHit",1)
-        Stop
+	Death:
+	Crash:
+		TNT1 A 0 A_Stop
+		TNT1 A 1 A_GiveToTarget("FistHit",1)
+		Stop
+	XDeath:
+		TNT1 A 0 A_Stop
+		TNT1 A 1 A_GiveToTarget("FistHit",1)
+		Stop
 	}
 }
 
 ACTOR ExecutionAttackKick: KickAttack
 {
-    Damage 22
+	Damage 22
 	speed 100
 	DamageType Kick
 	Radius 2
@@ -2026,7 +2028,7 @@ ACTOR ExecutionAttackKick: KickAttack
 	States
 	{
 	Death:
-		    PUFF A 0 A_PlaySound("player/cyborg/fist")
+			PUFF A 0 A_PlaySound("player/cyborg/fist")
 			TNT1 A 0 A_Explode(10, 10, 0)
 			EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
 			TNT1 A 10
@@ -2072,7 +2074,7 @@ ACTOR ExecutionFrontWallDetect: ExecutionAttackKick
 			TNT1 A 2
 			Stop
 		Death:
-		    TNT1 A 1
+			TNT1 A 1
 			TNT1 A 0 A_GiveToTarget("ExecuteStompWall", 1)
 			Stop
 		Xdeath:
@@ -2097,7 +2099,7 @@ ACTOR ExecutionLeftWallDetect: ExecutionAttackKick
 			TNT1 A 2
 			Stop
 		Death:
-		    TNT1 A 1
+			TNT1 A 1
 			TNT1 A 0 A_GiveToTarget("ExecuteBashWall", 1)
 			Stop
 		Xdeath:

--- a/actors/Weapons/Slot3/AUTOSHOTGUN.dec
+++ b/actors/Weapons/Slot3/AUTOSHOTGUN.dec
@@ -68,8 +68,8 @@ Actor PB_AutoshotgunUpgrade: PB_UpgradeItem
 	SpawnID 9350
 	Height 24
 	//-COUNTITEM
-	+INVENTORY.ALWAYSPICKUP
-	+COUNTITEM
+	-INVENTORY.ALWAYSPICKUP
+	-COUNTITEM
 	+DONTGIB
 	Inventory.Pickupsound "H4SGCOCK"
 	Inventory.PickupMessage "Auto Shotgun Upgrade!"
@@ -85,22 +85,22 @@ Actor PB_AutoshotgunUpgrade: PB_UpgradeItem
 		"####" A 0 A_PbvpInterpolate()
 		LOOP
 	
-    Pickup:
-	  TNT1 A 0 ACS_NamedExecuteAlways("AutoShotgunDrumMag", 0)
-	  TNT1 A 1
-	  {
-		A_GiveInventory("PB_Autoshotgun", 1);
-		A_GiveInventory("Autoshotgunammo", 24);
-		A_GiveInventory("LeftASGAmmo", 24);
-		if (CountInv("AutoshotgunDrumMag") == 0) {A_GiveInventory("DrumMagNotInserted", 1);}
-		A_GiveInventory("AutoshotgunDrumMag", 1);
-	  }
-	  TNT1 A 1
-	  {
-		A_GiveInventory("Autoshotgunammo", 24);
-		A_GiveInventory("LeftASGAmmo", 24);
-	  }
-      Stop
+	Pickup:
+		//TNT1 A 0 ACS_NamedExecuteAlways("AutoShotgunDrumMag", 0)
+		TNT1 A 0 A_JumpIf(!FindInventory("AutoshotgunDrumMag") || !FindInventory("PB_Autoshotgun") || CountInv("PB_Shell") < GetAmmoCapacity("PB_Shell"),1)
+		fail
+		TNT1 A 1{
+		if (CountInv("AutoshotgunDrumMag") == 0) {
+			A_GiveInventory("DrumMagNotInserted", 1);
+			SetAmmoCapacity("AutoShotgunAmmo",24);
+			SetAmmoCapacity("LeftASGAmmo",24);
+			A_GiveInventory("Autoshotgunammo", 24);
+			A_GiveInventory("LeftASGAmmo", 24);
+		}
+			A_GiveInventory("PB_Autoshotgun", 1);
+			A_GiveInventory("AutoshotgunDrumMag", 1);
+		}
+		Stop
 	}
 }
 
@@ -2319,39 +2319,39 @@ ACTOR PB_Autoshotgun  : PB_Weapon
 
 ACTOR AutoShotgunAmmo : Ammo 
 {
-   Inventory.Amount 0
-   Inventory.MaxAmount 12
-   Ammo.BackpackAmount 0
-   Ammo.BackpackMaxAmount 12
-   +INVENTORY.IGNORESKILL
-   Inventory.Icon "AUSCA0"
+	Inventory.Amount 0
+	Inventory.MaxAmount 12
+	Ammo.BackpackAmount 0
+	Ammo.BackpackMaxAmount 12
+	+INVENTORY.IGNORESKILL
+	Inventory.Icon "AUSCA0"
 }
 
 ACTOR LeftASGAmmo : Ammo
 {
-   Inventory.Amount 0
-   Inventory.MaxAmount 12
-   Ammo.BackpackAmount 0
-   Ammo.BackpackMaxAmount 12
-   +INVENTORY.IGNORESKILL
-   Inventory.Icon "AUSCA0"
+	Inventory.Amount 0
+	Inventory.MaxAmount 12
+	Ammo.BackpackAmount 0
+	Ammo.BackpackMaxAmount 12
+	+INVENTORY.IGNORESKILL
+	Inventory.Icon "AUSCA0"
 }
 
 ACTOR FlakTrail
 { 
-    RenderStyle Add
-    Scale 0.016
-    Alpha 0.65
-    +NOINTERACTION
-    +NOGRAVITY
-    States
-    {
-    Spawn:
+	RenderStyle Add
+	Scale 0.016
+	Alpha 0.65
+	+NOINTERACTION
+	+NOGRAVITY
+	States
+	{
+	Spawn:
 	YAE4 A 0 NoDelay A_JumpIf(ScaleX <= 0, "NULL")
 	YAE4 A 0 A_SetScale(ScaleX-0.002)
-    YA36 C 1 bright A_FadeOut(0.05)
-    Loop
-    }
+	YA36 C 1 bright A_FadeOut(0.05)
+	Loop
+	}
 }
 
 ACTOR Chunk1
@@ -2404,8 +2404,8 @@ ACTOR Chunk2 : Chunk1
 ACTOR Chunk3 : Chunk1
 {
 	Damagetype Blast
-    States
-    {
+	States
+	{
 		Spawn:
 			FLAS C 1 Bright {
 				A_CustomMissile("YellowFlareSpawn", 0, 0, 0, 0);
@@ -2413,14 +2413,14 @@ ACTOR Chunk3 : Chunk1
 				A_SetRoll(Roll+45);
 			}
 			loop
-    }
+	}
 }
 
 ACTOR Chunk4 : Chunk1
 {
 	Damagetype Shotgun
-    States
-    {
+	States
+	{
 		Spawn:
 			FLAS D 1 Bright {
 				A_CustomMissile("YellowFlareSpawn", 0, 0, 0, 0);
@@ -2428,5 +2428,5 @@ ACTOR Chunk4 : Chunk1
 				A_SetRoll(Roll+45);
 			}
 			loop
-    }
+	}
 }

--- a/actors/Weapons/Slot4/PBRIFLE.dec
+++ b/actors/Weapons/Slot4/PBRIFLE.dec
@@ -150,8 +150,8 @@ Actor RifleUpgrade: PB_UpgradeItem
 	Height 24
 	//-COUNTITEM
 	Scale 0.43
-	+INVENTORY.ALWAYSPICKUP
-	+COUNTITEM
+	-INVENTORY.ALWAYSPICKUP
+	-COUNTITEM
 	Inventory.Pickupsound "weapons/rifle/up"
 	Inventory.PickupMessage "Heavy DMR (Slot 4, Upgrade)"
 	Tag "Heavy DMR"
@@ -163,6 +163,8 @@ Actor RifleUpgrade: PB_UpgradeItem
 			"####" "#" 0 A_PbvpInterpolate()
 			Loop
 		Pickup:
+			TNT1 A 0 A_JumpIf(!FindInventory("Rifle") || !FindInventory("DMRUpgraded") || CountInv("PB_HighCalMag") < GetAmmoCapacity("PB_HighCalMag"),1)
+			fail
 			TNT1 A 0
 			TNT1 A 0 A_SetInventory("UnderBarrelGrenadeLoaded", 1)
 			TNT1 A 0 A_GiveInventory("Rifle", 1)

--- a/actors/Weapons/Slot5/MINIGUN.dec
+++ b/actors/Weapons/Slot5/MINIGUN.dec
@@ -36,8 +36,8 @@ Actor PB_MinigunUpgrade: PB_UpgradeItem
 	SpawnID 9410
 	Height 24
 	//-COUNTITEM
-	+INVENTORY.ALWAYSPICKUP
-	+COUNTITEM
+	-INVENTORY.ALWAYSPICKUP
+	-COUNTITEM
 	Inventory.Pickupsound "CHGNPKUP"
 	Inventory.PickupMessage "Minigun Upgrade!"
 	Tag "Minigun Upgrade"
@@ -52,10 +52,12 @@ Actor PB_MinigunUpgrade: PB_UpgradeItem
 		LOOP
 
 	
-    Pickup:
-	  TNT1 A 0 A_SetInventory("MinigunUpgraded", 1)
-	  TNT1 A 0 A_GiveInventory("PB_Minigun", 3)
-      Stop
+	Pickup:
+		TNT1 A 0 A_JumpIf(!FindInventory("PB_Minigun") || !FindInventory("MinigunUpgraded") || CountInv("PB_HighCalMag") < GetAmmoCapacity("PB_HighCalMag"),1)
+		fail
+		TNT1 A 0 A_SetInventory("MinigunUpgraded", 1)
+		TNT1 A 0 A_GiveInventory("PB_Minigun", 3)
+		Stop
 	}
 }
 
@@ -105,7 +107,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 	Weapon.AmmoType "PB_HighCalMag"
 	Weapon.AmmoGive 30
 	Weapon.AmmoUse 1
-    +WEAPON.NOAUTOAIM
+	+WEAPON.NOAUTOAIM
 	Inventory.PickupSound "CBOXPKUP"
 	Inventory.PickupMessage "UAC-R51 Mach-3 Minigun (Slot 5)"
 	Obituary "%o became Swiss Cheese by %k's Gatling Gun"
@@ -182,7 +184,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 				}
 			TNT1 A 0 A_JumpIfInventory("TripleBarrelMode", 1, "Ready_DeathDealer")
 			TNT1 A 0 A_JumpIfInventory("MinigunUpgraded", 1, "RealReady_Upgraded")
-            TNT1 A 0 A_JumpIfInventory("Spin",1,"Ready2")
+			TNT1 A 0 A_JumpIfInventory("Spin",1,"Ready2")
 		ReadyToFire:
 			//Not Upgraded, Idle
 			TNT1 A 0 A_JumpIfInventory("MinigunUpgraded", 1, "RealReady_Upgraded")
@@ -197,7 +199,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 				}
 			Loop
 		RealReady_Upgraded:
-            TNT1 A 0 A_JumpIfInventory("Spin",1,"Ready2_Upgraded")
+			TNT1 A 0 A_JumpIfInventory("Spin",1,"Ready2_Upgraded")
 			TNT1 A 0 A_JumpIfInventory("TripleBarrelMode", 1, "Ready_DeathDealer")
 		ReadyToFire_Upgraded:
 		ReadyToFire2: //To make the kicking animation work
@@ -268,7 +270,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 				A_SetInventory("PB_LockScreenTilt",0);
 				A_Overlay(10,"DeathDealerCore");
 				}
-            TNT1 A 0 A_JumpIfInventory("Spin",1,"Ready2_DeathDealer")
+			TNT1 A 0 A_JumpIfInventory("Spin",1,"Ready2_DeathDealer")
 		ReadyToFire_DeathDealer:
 		Ready4: //To make the kicking animation work
 			8HAF A 0 A_JumpIf(CountInv("TripleBarrelMode") < 1, "ReadyToFire")
@@ -454,7 +456,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 		TNT1 A 0 A_JumpIfInventory("TripleBarrelMode", 1, "DeselectDeathDealer")
 		
 		MG23 DCBA 0 
-        MG04 DCBA 1 {
+		MG04 DCBA 1 {
 				if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("MG23");}
 		}
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
@@ -477,11 +479,11 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 		TNT1 A 0 A_ClearOverlays(3,4)
 		1CHT LKJIHGFEDCBA 1
 		UCHG EDCBA 1
-        MG03 BCDG 1
+		MG03 BCDG 1
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		Wait
 
-    Select:
+	Select:
 		TNT1 A 0 {
 			A_WeaponOffset(0,32);
 			A_SetRoll(0);
@@ -620,7 +622,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltIdle_Upgraded");}
 			else {A_Overlay(4,"AmmoBeltIdle");}
 		}
-    Hold:
+	Hold:
 		TNT1 A 0 {
 			if(CountInv("ChainGunMode") >=1) {return state("Hold_Chaingun");}
 			if(CountInv("spin") >= 1 && CountInv("ChainGunMode") !=1) {return state("Fire2");}
@@ -634,7 +636,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			}
 	Holding1:
 		TNT1 A 0 A_GunFlash("FireGlow")
-        CHAF A 1 BRIGHT {
+		CHAF A 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			//A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
@@ -651,12 +653,12 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Giveinventory("OverHeating",1);
 			////A_GunFlash;
 		}
-        CHAF B 1 BRIGHT {
+		CHAF B 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
-            PB_WeaponRecoil(-0.6,frandom(1.6, -1.6));
+			PB_WeaponRecoil(-0.6,frandom(1.6, -1.6));
 			}
-        CHAF C 1 BRIGHT {
+		CHAF C 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			//A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
@@ -672,12 +674,12 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Giveinventory("OverHeating",1);
 			////A_GunFlash;
 		}
-        CHAF D 1 BRIGHT {
+		CHAF D 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
-            PB_WeaponRecoil(-0.6,frandom(1.6, -1.6));
+			PB_WeaponRecoil(-0.6,frandom(1.6, -1.6));
 			}
-        CHAF E 1 BRIGHT {
+		CHAF E 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			//A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
@@ -693,12 +695,12 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Giveinventory("OverHeating",1);
 			////A_GunFlash;
 		}
-        CHAF F 1 BRIGHT {
+		CHAF F 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
-            PB_WeaponRecoil(-0.6,frandom(1.6, -1.6));
+			PB_WeaponRecoil(-0.6,frandom(1.6, -1.6));
 			}
-        CHAF G 1 BRIGHT {
+		CHAF G 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			//A_FireBullets(4, 4, 1, 10, "MachineGunBulletPuff", 1);
@@ -716,7 +718,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 		CHAF H 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
-            PB_WeaponRecoil(-0.6,frandom(1.6, -1.6));
+			PB_WeaponRecoil(-0.6,frandom(1.6, -1.6));
 			PB_ReFire("Holding1");
 			}
 			////A_GunFlash;
@@ -729,7 +731,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_OverlayFlags(9,PSPF_RENDERSTYLE,true);
 			A_OverlayRenderStyle(9,STYLE_Add);
 		}
-        CHAG ABCD 1 {
+		CHAG ABCD 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHG");}
 			A_Overlay(3,"AmmoMeterOverlayIdle");
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltIdle_Upgraded");}
@@ -742,7 +744,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 		A_OverlayFlags(9,PSPF_RENDERSTYLE,true);
 		A_OverlayRenderStyle(9,STYLE_Add);
 		}
-        CHAG EFGG 1 {
+		CHAG EFGG 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHG");}
 			A_Overlay(3,"AmmoMeterOverlayIdle");
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltIdle_Upgraded");}
@@ -764,7 +766,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			//A_ZoomFactor(0.98);
 			PB_ReFire("LateHolding");
 			}
-        CHAG BB 1 {
+		CHAG BB 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHG");}
 			A_Overlay(3,"AmmoMeterOverlayIdle");
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltIdle_Upgraded");}
@@ -796,7 +798,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_FireCustomMissile("SmokeSpawner11",0,0,0,0);
 			PB_ReFire("LateHolding");
 			}
-        goto RealReady
+		goto RealReady
 		
 		
 	Fire_Chaingun:
@@ -968,7 +970,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltIdle_Upgraded");}
 			else {A_Overlay(4,"AmmoBeltIdle");}
 		}
-    Hold_Chaingun:
+	Hold_Chaingun:
 		TNT1 A 0 {
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltChaingun_Upgraded");}
 			else {A_Overlay(4,"AmmoBeltChaingun");}
@@ -976,7 +978,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			}
 	Holding1_Chaingun:
 		TNT1 A 0 A_GunFlash("FireGlow")
-        CHAF A 1 BRIGHT {
+		CHAF A 1 BRIGHT {
 			PB_FireOffset;
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
@@ -992,10 +994,10 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Giveinventory("OverHeating",1);
 			////A_GunFlash;
 			}
-        CHAF B 1 {
+		CHAF B 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
-            PB_WeaponRecoil(-0.4,frandom(1.2, -1.2));
+			PB_WeaponRecoil(-0.4,frandom(1.2, -1.2));
 			}
 		TNT1 A 0 A_GunFlash("FireGlow")
 		CHAG C 1 {
@@ -1003,7 +1005,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(3,"AmmoMeterOverlayFire");
 		}
 		//CHAG C 1
-        CHAF D 1 BRIGHT {
+		CHAF D 1 BRIGHT {
 			PB_FireOffset;
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
@@ -1021,10 +1023,10 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			////A_GunFlash;
 			}
 		TNT1 A 0 A_GunFlash("FireGlow")
-        CHAF E 1 {
+		CHAF E 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
-            PB_WeaponRecoil(-0.4,frandom(1.2, -1.2));
+			PB_WeaponRecoil(-0.4,frandom(1.2, -1.2));
 			}
 		CHAG F 1 {
 			A_Overlay(3,"AmmoMeterOverlayFire");
@@ -1032,7 +1034,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			}
 		//CHAG C 1
 		TNT1 A 0 A_GunFlash("FireGlow")
-        CHAF G 1 BRIGHT {
+		CHAF G 1 BRIGHT {
 			PB_FireOffset;
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
@@ -1048,20 +1050,20 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Giveinventory("OverHeating",1);
 		//	//A_GunFlash;
 			}
-        CHAF H 1 {
+		CHAF H 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
-            PB_WeaponRecoil(-0.4,frandom(1.2, -1.2));
+			PB_WeaponRecoil(-0.4,frandom(1.2, -1.2));
 			}
 		CHAG H 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
-            PB_WeaponRecoil(-0.4,frandom(1.2, -1.2));
+			PB_WeaponRecoil(-0.4,frandom(1.2, -1.2));
 			}
 		TNT1 A 0 A_GunFlash("FireGlow")
 		//CHAG C 1 A_Overlay(3,"AmmoMeterOverlayFire")
 		
-        TNT1 A 0 PB_ReFire("Holding1_Chaingun")
+		TNT1 A 0 PB_ReFire("Holding1_Chaingun")
 		TNT1 A 0 A_JumpIfInventory("Spin",1,"Ready2")
 	
 	//Stop firing chaingun
@@ -1072,7 +1074,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_OverlayFlags(9,PSPF_RENDERSTYLE,true);
 			A_OverlayRenderStyle(9,STYLE_Add);
 		}
-        CHAG ABCD 1 {
+		CHAG ABCD 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHG");}
 			A_Overlay(3,"AmmoMeterOverlayIdle");
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltIdle_Upgraded");}
@@ -1085,7 +1087,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 		A_OverlayFlags(9,PSPF_RENDERSTYLE,true);
 		A_OverlayRenderStyle(9,STYLE_Add);
 		}
-        CHAG EFGH 1 {
+		CHAG EFGH 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHG");}
 			A_Overlay(3,"AmmoMeterOverlayIdle");
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltIdle_Upgraded");}
@@ -1098,7 +1100,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 		A_OverlayFlags(9,PSPF_RENDERSTYLE,true);
 		A_OverlayRenderStyle(9,STYLE_Add);
 		}
-        CHAG ABCD 1 {
+		CHAG ABCD 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHG");}
 			A_Overlay(3,"AmmoMeterOverlayIdle");
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltIdle_Upgraded");}
@@ -1120,7 +1122,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			//A_ZoomFactor(0.98);
 			PB_ReFire("LateHolding_Chaingun");
 			}
-        CHAG FF 1 {
+		CHAG FF 1 {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHG");}
 			A_Overlay(3,"AmmoMeterOverlayIdle");
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltIdle_Upgraded");}
@@ -1152,14 +1154,14 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_FireCustomMissile("SmokeSpawner11",0,0,0,0);
 			PB_ReFire("LateHolding_Chaingun");
 			}
-        goto RealReady
+		goto RealReady
 		
 		
 	
 	Fire2:
 		TNT1 A 0 A_JumpIfInventory("TripleBarrelMode", 1, "HoldDeathDealer")
 		TNT1 A 0 A_JumpIfInventory("ChainGunMode", 1, "Hold_Chaingun")
-        TNT1 A 0 {
+		TNT1 A 0 {
 			A_StartSound("weapons/minigunfirefast", CHAN_WEAPON, CHANF_LOOP );
 			if (CountInv("MinigunUpgraded") == 1) {A_Overlay(4,"AmmoBeltAnimation_Upgraded");}
 			else {A_Overlay(4,"AmmoBeltAnimation");}
@@ -1186,7 +1188,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			PB_SpawnCasing("LMGBeltLink", 19,-13,24,0,-frandom(1,2),frandom(-3,3), false);
 			A_Giveinventory("OverHeating",1);
 		//	//A_GunFlash;
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		CHAF B 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
@@ -1201,9 +1203,9 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			//PB_SpawnCasing("PB_EmptyBrass", 19,-13,24,0,-frandom(3,6),frandom(-1,1), false);
 			A_Giveinventory("OverHeating",1);
 		//	//A_GunFlash;
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
-        CHAF C 1 BRIGHT {
+		CHAF C 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			//A_FireBullets(4, 3, -1, 10, "MachineGunBulletPuff", 1);
@@ -1218,7 +1220,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Giveinventory("OverHeating",1);
 		//	//A_GunFlash;
 			}
-        CHAF D 1 BRIGHT {
+		CHAF D 1 BRIGHT {
 			PB_FireOffset;
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
@@ -1233,7 +1235,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			PB_SpawnCasing("LMGBeltLink", 19,-13,24,0,-frandom(1,2),frandom(-3,3), false);
 			A_Giveinventory("OverHeating",1);
 		//	//A_GunFlash;
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		CHAF E 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
@@ -1248,9 +1250,9 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			//PB_SpawnCasing("PB_EmptyBrass", 19,-13,24,0,-frandom(3,6),frandom(-1,1), false);
 			A_Giveinventory("OverHeating",1);
 		//	//A_GunFlash;
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
-        CHAF F 1 BRIGHT {
+		CHAF F 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			//A_FireBullets(4, 3, -1, 10, "MachineGunBulletPuff", 1);
@@ -1265,7 +1267,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Giveinventory("OverHeating",1);
 		//	//A_GunFlash;
 			}
-        CHAF G 1 BRIGHT {
+		CHAF G 1 BRIGHT {
 			PB_FireOffset;
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
@@ -1280,9 +1282,9 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			//PB_SpawnCasing("LMGBeltLink", 19,-13,24,0,-frandom(1,2),frandom(-3,3), false);
 			A_Giveinventory("OverHeating",1);
 		//	//A_GunFlash;
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
-        CHAF H 1 BRIGHT {
+		CHAF H 1 BRIGHT {
 			if (CountInv("MinigunUpgraded") == 1) {A_SetWeaponSprite("UCHF");}
 			A_Overlay(3,"AmmoMeterOverlayFire");
 			//A_FireBullets(4, 3, -1, 10, "MachineGunBulletPuff", 1);
@@ -1298,7 +1300,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 		//	//A_GunFlash;
 			PB_ReFire("FiringFast");
 			}
-        TNT1 A 0 {
+		TNT1 A 0 {
 			A_StopSound(1);
 			A_Overlay(9,"PostGlow");
 			A_OverlayFlags(9,PSPF_RENDERSTYLE,true);
@@ -1313,10 +1315,10 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			PB_ReFire("Fire2");
 			A_FireCustomMissile("SmokeSpawner",0,0,0,0);
 		}
-        goto RealReady
+		goto RealReady
 		
 	FireDeathDealer:
-	    TNT1 A 0 A_JumpIfInventory("Spin",1,"HoldDeathDealer") 
+		TNT1 A 0 A_JumpIfInventory("Spin",1,"HoldDeathDealer") 
 		TNT1 A 0 {
 			A_StartSound("CHAINSTA",CHAN_AUTO);
 			A_StartSound("DTHDLRST",CHAN_AUTO);
@@ -1356,9 +1358,9 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
 			A_Overlayoffset(3,-27,0,WOF_ADD);
 		}
-    HoldDeathDealer:
+	HoldDeathDealer:
 		//TNT1 A 0 A_JumpIf(CountInv("PB_HighCalMag") < 1, "HoldingDeathDealer_Stop")
-        TNT1 A 0 {
+		TNT1 A 0 {
 			A_StartSound("8HAINFIR", CHAN_WEAPON, CHANF_LOOP);
 			A_Overlay(4,"AmmoBeltAnimation_Upgraded");
 			A_OverlayOffset(4,22,0,WOF_ADD);
@@ -1368,7 +1370,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			}
 	HoldingDeathDealer:
 		//TNT1 A 0 A_JumpIf(CountInv("PB_HighCalMag") < 1, "HoldingDeathDealer_Stop")
-        8HBF A 1 BRIGHT {
+		8HBF A 1 BRIGHT {
 			PB_FireOffset;
 			PB_GunSmoke_Basic(0,0,2);//A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 			PB_GunSmoke_Basic(5,0,-1);//A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
@@ -1390,7 +1392,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(-5,"MuzzleFlash");
 			A_OverlayOffset(-4,-27,14,WOF_ADD);
 			A_OverlayOffset(-5,27,14,WOF_ADD);
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		8HBF B 1 BRIGHT {
 			PB_FireOffset;
@@ -1410,7 +1412,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(-5,"MuzzleFlash");
 			A_OverlayOffset(-4,-27,14,WOF_ADD);
 			A_OverlayOffset(-5,27,14,WOF_ADD);
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		8HBF C 1 BRIGHT {
 			PB_FireOffset;
@@ -1435,7 +1437,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(-5,"MuzzleFlash");
 			A_OverlayOffset(-4,-27,14,WOF_ADD);
 			A_OverlayOffset(-5,27,14,WOF_ADD);
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		8HBF D 1 BRIGHT {
 			PB_FireOffset;
@@ -1456,7 +1458,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(-5,"MuzzleFlash");
 			A_OverlayOffset(-4,-27,14,WOF_ADD);
 			A_OverlayOffset(-5,27,14,WOF_ADD);
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		8HBF E 1 BRIGHT {
 			PB_FireOffset;
@@ -1481,7 +1483,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(-5,"MuzzleFlash");
 			A_OverlayOffset(-4,-27,14,WOF_ADD);
 			A_OverlayOffset(-5,27,14,WOF_ADD);
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		8HBF F 1 BRIGHT {
 			PB_FireOffset;
@@ -1499,7 +1501,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(-5,"MuzzleFlash");
 			A_OverlayOffset(-4,-27,14,WOF_ADD);
 			A_OverlayOffset(-5,27,14,WOF_ADD);
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		8HBF G 1 BRIGHT {
 			PB_FireOffset;
@@ -1523,7 +1525,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(-5,"MuzzleFlash");
 			A_OverlayOffset(-4,-27,14,WOF_ADD);
 			A_OverlayOffset(-5,27,14,WOF_ADD);
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		8HBF H 1 BRIGHT {
 			PB_FireOffset;
@@ -1542,10 +1544,10 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_Overlay(-5,"MuzzleFlash");
 			A_OverlayOffset(-4,-27,14,WOF_ADD);
 			A_OverlayOffset(-5,27,14,WOF_ADD);
-            PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
+			PB_WeaponRecoil(-0.8,frandom(2.4, -2.4));
 			}
 		
-        TNT1 A 0 PB_ReFire("HoldingDeathDealer")
+		TNT1 A 0 PB_ReFire("HoldingDeathDealer")
 	HoldingDeathDealer_Stop:
 		TNT1 A 0 A_StopSound(1)
 		TNT1 A 0 A_JumpIfInventory("Spin",1,"Ready2_DeathDealer")
@@ -1553,7 +1555,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_StartSound("CHAINSTO", CHAN_AUTO);
 			A_StartSound("DTHDLRSP", CHAN_AUTO);
 			}
-        8HAF A 1 {
+		8HAF A 1 {
 			A_FireCustomMissile("SmokeSpawner11",0,0,0,0);
 			//A_ZoomFactor(0.98);
 			A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
@@ -1562,7 +1564,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_OverlayOffset(4,22,0,WOF_ADD);
 			PB_ReFire("HoldDeathDealer");
 			}
-        8HAF B 1 {
+		8HAF B 1 {
 			A_FireCustomMissile("SmokeSpawner11",0,0,0,0);
 			//A_ZoomFactor(0.99);
 			A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
@@ -1589,7 +1591,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_OverlayOffset(4,22,0,WOF_ADD);
 			PB_ReFire("HoldDeathDealer");
 			}
-        8HAF EEFFGGHH 1 {
+		8HAF EEFFGGHH 1 {
 			A_FireCustomMissile("SmokeSpawner11",0,0,0,0);
 			A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
 			A_Overlayoffset(3,-27,0,WOF_ADD);
@@ -1597,7 +1599,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_OverlayOffset(4,22,0,WOF_ADD);
 			PB_ReFire("HoldDeathDealer");
 			}
-        8HAF AABBCCDD 1 {
+		8HAF AABBCCDD 1 {
 			A_FireCustomMissile("SmokeSpawner11",0,0,0,0);
 			A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
 			A_Overlayoffset(3,-27,0,WOF_ADD);
@@ -1613,9 +1615,9 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_OverlayOffset(4,22,0,WOF_ADD);
 			PB_ReFire("HoldDeathDealer");
 			}
-        goto Ready3
+		goto Ready3
 	
-	  AltFire:
+		AltFire:
 		TNT1 A 0 A_JumpIfInventory ("GrabbedBarrel", 1, "PlaceBarrel")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedFlameBarrel", 1, "PlaceFlameBarrel")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedIceBarrel", 1, "PlaceIceBarrel")
@@ -1768,7 +1770,7 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 				A_Overlayoffset(3,-27,0,WOF_ADD);
 		}
 		 8HAF AAABBBCCCDDD 1
-		  {
+			{
 			if (CountInv("PB_HighCalMag") > 0 ) { A_Overlay(4,"AmmoBeltIdle_Upgraded"); }
 				A_OverlayOffset(4,22,0,WOF_ADD);
 				A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
@@ -1781,14 +1783,14 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 				A_OverlayOffset(4,22,0,WOF_ADD);
 				A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
 				A_Overlayoffset(3,-27,0,WOF_ADD);
-		  }
+			}
 		 8HAF AAABBBCCCDDD 1
-		  {
+			{
 			if (CountInv("PB_HighCalMag") > 0 ) { A_Overlay(4,"AmmoBeltIdle_Upgraded"); }
 				A_OverlayOffset(4,22,0,WOF_ADD);
 				A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
 				A_Overlayoffset(3,-27,0,WOF_ADD);
-		  }
+			}
 		 Goto Ready2_DeathDealer
 		 
 	DeathDealerStopAlt:
@@ -1800,14 +1802,14 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 			A_StartSound("DTHDLRSP", CHAN_AUTO);
 		 }
 		 8HAF ABCD 1
-		  {
+			{
 			if (CountInv("PB_HighCalMag") > 0 ) { A_Overlay(4,"AmmoBeltIdle_Upgraded"); }
 				A_OverlayOffset(4,22,0,WOF_ADD);
 				A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
 				A_Overlayoffset(3,-27,0,WOF_ADD);
-		  }	  
+			}		
 		 8HAF AABBCCDD 1
-		  {
+			{
 			if (CountInv("PB_HighCalMag") > 0 ) { A_Overlay(4,"AmmoBeltIdle_Upgraded"); }
 				A_OverlayOffset(4,22,0,WOF_ADD);
 				A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
@@ -1819,21 +1821,21 @@ ACTOR PB_Minigun : PB_Weapon //Replaces Chaingun
 				A_OverlayOffset(4,22,0,WOF_ADD);
 				A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
 				A_Overlayoffset(3,-27,0,WOF_ADD);
-		  }	 
+			}	 
 		 8HAF AAABBB 1
-		  {
+			{
 			if (CountInv("PB_HighCalMag") > 0 ) { A_Overlay(4,"AmmoBeltIdle_Upgraded"); }
 				A_OverlayOffset(4,22,0,WOF_ADD);
 				A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
 				A_Overlayoffset(3,-27,0,WOF_ADD);
-		  }	  
+			}		
 		 8HAF CCCCDDDD 1
-		  {
+			{
 			if (CountInv("PB_HighCalMag") > 0 ) { A_Overlay(4,"AmmoBeltIdle_Upgraded"); }
 				A_OverlayOffset(4,22,0,WOF_ADD);
 				A_Overlay(3,"AmmoMeterOverlayIdle_DeathDealer");
 				A_Overlayoffset(3,-27,0,WOF_ADD);
-		  }	  
+			}		
 		 Goto Ready3
 	 
 	FlashKicking:

--- a/actors/Weapons/Slot5/Nailgun.dec
+++ b/actors/Weapons/Slot5/Nailgun.dec
@@ -30,12 +30,12 @@ Inventory.MaxAmount 1
 
 ACTOR PB_NailgunAmmo : Ammo
 {
-   Inventory.Amount 0
-   Inventory.MaxAmount 120
-   Ammo.BackpackAmount 0
-   Ammo.BackpackMaxAmount 120
-   +INVENTORY.IGNORESKILL
-   Inventory.Icon "NLMGF0"
+	Inventory.Amount 0
+	Inventory.MaxAmount 120
+	Ammo.BackpackAmount 0
+	Ammo.BackpackMaxAmount 120
+	+INVENTORY.IGNORESKILL
+	Inventory.Icon "NLMGF0"
 }
 
 // --------------------------------------------------------------------------
@@ -706,15 +706,31 @@ ACTOR PB_Nailgun : PB_Weapon
 				A_ZoomFactor(1.0);
 				PB_WeaponRecoil(-1.5,+0.5);
 			}
+			N5N0 Y 1 { A_WeaponOffset(0, 33);
+				if (CountInv("NailgunOverHeating") >= 120 ) {A_SetWeaponSprite("N9N3");}
+				A_ZoomFactor(1.0);
+				PB_WeaponRecoil(-1.5,+0.5);
+			}
+			TNT1 A 0 A_WeaponOffset(0, 32)
+			TNT1 A 0 A_JumpIfInventory("PB_NailgunAmmo",20,1)
+			Goto AltNailFireEmptied
 			N8N0 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA 1 {
-				A_DoPBWeaponAction(WRF_ALLOWRELOAD | WRF_NOFIRE | WRF_NOSWITCH);
+				A_DoPBWeaponAction(WRF_ALLOWRELOAD | WRF_NOFIRE);
 				//A_FireCustomMissile("GunFireSmoke", 0, 0, -2, -8, 0, 0);
 				//A_FireCustomMissile("GunFireSmoke", 0, 0, 2, -8, 0, 0);
 				PB_GunSmoke_Basic(2,0,0);
 				PB_GunSmoke_Basic(-2,0,0);
-				}
+			}
 			Goto Ready3
-		
+		AltNailFireEmptied:
+			N1N1 DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD 1 {
+				A_DoPBWeaponAction(WRF_ALLOWRELOAD | WRF_NOFIRE);
+				//A_FireCustomMissile("GunFireSmoke", 0, 0, -2, -8, 0, 0);
+				//A_FireCustomMissile("GunFireSmoke", 0, 0, 2, -8, 0, 0);
+				PB_GunSmoke_Basic(2,0,0);
+				PB_GunSmoke_Basic(-2,0,0);
+			}
+			Goto Ready3
 		FireJavelin:
 			TNT1 A 0 A_JumpIfInventory("PB_NailgunAmmo",20,1)
 			Goto Reload

--- a/actors/Weapons/Slot5/Nailgun.dec
+++ b/actors/Weapons/Slot5/Nailgun.dec
@@ -712,18 +712,9 @@ ACTOR PB_Nailgun : PB_Weapon
 				PB_WeaponRecoil(-1.5,+0.5);
 			}
 			TNT1 A 0 A_WeaponOffset(0, 32)
-			TNT1 A 0 A_JumpIfInventory("PB_NailgunAmmo",20,1)
-			Goto AltNailFireEmptied
-			N8N0 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA 1 {
-				A_DoPBWeaponAction(WRF_ALLOWRELOAD | WRF_NOFIRE);
-				//A_FireCustomMissile("GunFireSmoke", 0, 0, -2, -8, 0, 0);
-				//A_FireCustomMissile("GunFireSmoke", 0, 0, 2, -8, 0, 0);
-				PB_GunSmoke_Basic(2,0,0);
-				PB_GunSmoke_Basic(-2,0,0);
-			}
-			Goto Ready3
-		AltNailFireEmptied:
-			N1N1 DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD 1 {
+			N8N0 A 0 A_JumpIfInventory("PB_NailgunAmmo",20,2)
+			N1N1 D 0 
+			"----" AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA 1 {
 				A_DoPBWeaponAction(WRF_ALLOWRELOAD | WRF_NOFIRE);
 				//A_FireCustomMissile("GunFireSmoke", 0, 0, -2, -8, 0, 0);
 				//A_FireCustomMissile("GunFireSmoke", 0, 0, 2, -8, 0, 0);

--- a/actors/Weapons/Slot7/M2PLASMA.dec
+++ b/actors/Weapons/Slot7/M2PLASMA.dec
@@ -16,7 +16,7 @@ ACTOR M2Plasma : CustomInventory //12000
 		"####" "#" 0 A_PbvpInterpolate()
 		LOOP*/
 	Pickup:
-        TNT1 A 0 A_GiveInventory ("PB_M2Plasma")
+		TNT1 A 0 A_GiveInventory ("PB_M2Plasma")
 		Stop
 	}
 }
@@ -46,15 +46,15 @@ Actor ActivateStunCooldown : PowerUpGiver
 	+AUTOACTIVATE
 }
 
-Actor PB_M2Upgrade: Custominventory
+Actor PB_M2Upgrade: PB_UpgradeItem
 {
 //$Category Project Brutality - Weapon Upgrades
 	Game Doom
 	SpawnID 9370
 	Height 24
 	Scale 0.49
-	+INVENTORY.ALWAYSPICKUP
-	+COUNTITEM
+	-INVENTORY.ALWAYSPICKUP
+	-COUNTITEM
 	Inventory.Pickupsound "PLSM2UP"
 	Inventory.PickupMessage "M2 Lightning Mode Upgrade!"
 	Tag "M2 Upgrade"
@@ -71,6 +71,8 @@ Actor PB_M2Upgrade: Custominventory
 			LOOP*/
 
 		Pickup:
+			TNT1 A 0 A_JumpIf(!FindInventory("PB_M2Plasma") || !FindInventory("HasLightningGunUpgrade") || CountInv("PB_Cell") < GetAmmoCapacity("PB_Cell"),1)
+			fail
 			TNT1 A 0 A_GiveInventory ("PB_M2Plasma")
 			TNT1 A 0 A_SetInventory("HasLightningGunUpgrade", 1)
 			Stop
@@ -106,11 +108,11 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 	Weapon.AmmoGive1 50
 	Weapon.AmmoUse2 0
 	Weapon.AmmoGive2 0
-    Inventory.PickupSound "PLSDRAW"
+	Inventory.PickupSound "PLSDRAW"
 	Weapon.AmmoType1 "PB_Cell"
 	Weapon.AmmoType2 "M2PlasmaAmmo"
 	PB_WeaponBase.AmmoTypeLeft "LeftM2PlasmaAmmo"
-   	+WEAPON.NOAUTOAIM
+		+WEAPON.NOAUTOAIM
 	+WEAPON.NOAUTOFIRE
 	+FLOORCLIP
 	+DONTGIB
@@ -399,7 +401,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 			PB_LowAmmoSoundWarning("hdmr", "LeftM2PlasmaAmmo");
 			A_Takeinventory("LeftM2PlasmaAmmo",2);
 			A_GunFlash;
-            PB_WeaponRecoil(-1.44,-1.04);
+			PB_WeaponRecoil(-1.44,-1.04);
 		}	
 		
 		M234 B 1 BRIGHT {
@@ -409,7 +411,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 			if(CountInv("LeftM2PlasmaAmmo")<=0 || CountInv("M2PlasmaAmmo")>0 ){
 				A_GiveInventory("DualFiring",1);
 			}
-            PB_WeaponRecoil(-1.44,-1.04);
+			PB_WeaponRecoil(-1.44,-1.04);
 			}
 		M234 C 1 BRIGHT {
 			A_FireCustomMissile("ShakeYourAss", 0, 0, 0, 0);
@@ -623,8 +625,8 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 			A_StopSound(6);
 			A_WeaponOffset(0,32);
 			}
-        TNT1 A 0 A_JumpIfInventory("Reloading",1,"Reload")
-        TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",2,1)
+		TNT1 A 0 A_JumpIfInventory("Reloading",1,"Reload")
+		TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",2,1)
 		Goto Reload
 		TNT1 A 0 A_JumpIfInventory("LightningGunMode",1,"FireLightningGun1")
 		PR2F ABCDE 0
@@ -639,7 +641,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 			PB_LowAmmoSoundWarning("hdmr");
 			A_Takeinventory("M2PlasmaAmmo",2);
 			A_GunFlash;
-            PB_WeaponRecoil(-0.84,+0.26);
+			PB_WeaponRecoil(-0.84,+0.26);
 		}	
 		
 		M211 B 1 BRIGHT {
@@ -707,7 +709,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 			A_FireCustomMissile("ShakeYourAss", 0, 0, 0, 0);
 			A_GunFlash;
 			}
-        TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",1,1)
+		TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",1,1)
 		Goto Reload
 		PR1F B 1 BRIGHT PB_ReFire("LightningGunLoop")
 		TNT1 A 0 {
@@ -741,7 +743,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 	FireStunBomb:
 		TNT1 A 0 A_JumpIfInventory("StunBombCooldown",1,"NoFireStun")
 		TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",25,1)
-        Goto Reload
+		Goto Reload
 		TNT1 A 0 A_PlaysoundEx("PZPCHR2", "Auto")
 		PR1F XYZABACABACABAC 1 BRIGHT A_FireCustomMissile("ElectroBlastTrail2", 0, 0, 0, 0)
 		TNT1 A 0 {
@@ -764,7 +766,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 		Goto ReallyReady2
 	LeftToRight:
 		TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",10,1)
-        Goto Reload
+		Goto Reload
 		PR4L A 0 A_JumpIfInventory("HasLightningGunUpgrade", 1,2)
 		PR3L A 0
 		"####" A 0 A_Setinventory("PB_LockScreenTilt",1)
@@ -834,7 +836,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 	RightToLeft:
 		TNT1 A 0 A_JumpIfInventory("Reloading",1,"Reload")
 		TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",10,1)
-        Goto Reload
+		Goto Reload
 		PR4L A 0 A_JumpIfInventory("HasLightningGunUpgrade", 1,2)
 		PR3L A 0
 		"####" A 0 A_Setinventory("PB_LockScreenTilt",1)
@@ -969,7 +971,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 		M220 ZZZ 1
 		M221 ABCD 1 A_Setroll(roll-1.0)
 		M221 EFGH 1 A_Setroll(roll+1.0)
-    InsertBullets:
+	InsertBullets:
 		TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",50,"FinishReload")
 		TNT1 A 0 A_JumpIfInventory("PB_Cell",1,1)
 		Goto FinishReload
@@ -980,7 +982,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 		Goto InsertBullets
 	FinishReload:
 		TNT1 A 0 A_Setinventory("M2PlasmaUnloaded",0)
-        Goto ready3
+		Goto ready3
 		
 	ReloadDualWield:
 		TNT1 A 0 {
@@ -989,8 +991,8 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 			}
 			return state("");
 		}
-        TNT1 A 0 A_JumpIfInventory("PB_Cell",1,1)
-        Goto ReadyDualWield
+		TNT1 A 0 A_JumpIfInventory("PB_Cell",1,1)
+		Goto ReadyDualWield
 		TNT1 A 0 {
 			A_SetCrosshair(5);
 			A_Setinventory("PB_LockScreenTilt",1);
@@ -1098,8 +1100,8 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 			A_StopSound(6);
 			A_Setinventory("Unloading",0);
 			}
-        TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",1,1)
-        Goto ready3
+		TNT1 A 0 A_JumpIfInventory("M2PlasmaAmmo",1,1)
+		Goto ready3
 		TNT1 A 0 A_JumpIfInventory("HasLightningGunUpgrade", 1,"UpgradedUnloading")	
 		TNT1 A 0 A_JumpIfInventory("DualWieldingM2Plasma",1, "UnloadDualWield")
 		M221 HGFEDCBA 1
@@ -1164,7 +1166,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 	
 	Flash:
 		TNT1 A 4
-        Goto LightDone
+		Goto LightDone
 		
 	Spawn:
 		M2PR A -1
@@ -1192,7 +1194,7 @@ ACTOR PB_M2Plasma : PB_Weapon //12222
 		TNT1 A 15
 		Stop
 	
-    FlashKicking:
+	FlashKicking:
 		TNT1 A 0 A_JumpIfInventory ("GrabbedBarrel", 1, "FlashBarrelKicking")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedFlameBarrel", 1, "FlashBarrelKicking")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedIceBarrel", 1, "FlashBarrelKicking")
@@ -1259,7 +1261,7 @@ ACTOR HeavyPlasmaBall: Plasma_ball
 	Height 10
 	Speed 80
 	Damage 10
-    DamageType Plasma
+	DamageType Plasma
 	Decal "Scorch"
 	Projectile
 	+RANDOMIZE
@@ -1268,7 +1270,7 @@ Scale 0.2
 	//Translation "0:255=%[0,0,0]:[0,0,1]"
 	DeathSound "weapons/plasmax"
 	//SeeSound "PLSM8"
-    SeeSound "None"
+	SeeSound "None"
 	Obituary "$OB_MPPLASMARIFLE"
 	States
 	{
@@ -1281,28 +1283,28 @@ Scale 0.2
 		Loop
 
 Xdeath:
-    TNT1 A 0 A_SpawnItem ("Plasma_Puff", 0)
+	TNT1 A 0 A_SpawnItem ("Plasma_Puff", 0)
 	TNT1 AAAA 0 A_CustomMissile ("BluePlasmaFireSmall2", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAA 0 A_CustomMissile ("SuperPlasmaFire", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAAAA 0 A_CustomMissile ("BluePlasmaParticle", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAAAA 0 A_CustomMissile ("CryoRifleTrailSparksSmall", 0, 0, random (0, 360), 2, random (0, 360))
-    TNT1 A 0 A_Explode(6,90,0)
+	TNT1 A 0 A_Explode(6,90,0)
 	TNT1 A 1 Light("LightningImpactLight")
 	TNT1 B 4
 		
 		Stop
 
 	Death:
-    TNT1 A 0 A_SpawnItem ("Plasma_Puff", 0)
-    //TNT1 A 0 A_SpawnItem ("RailPuff", 0)
-    TNT1 A 0 A_Explode(6,90,0)
+	TNT1 A 0 A_SpawnItem ("Plasma_Puff", 0)
+	//TNT1 A 0 A_SpawnItem ("RailPuff", 0)
+	TNT1 A 0 A_Explode(6,90,0)
 	TNT1 AAAA 0 A_CustomMissile ("BluePlasmaFireSmall2", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAA 0 A_CustomMissile ("SuperPlasmaFire", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAAAAAAAAAAAAAA 0 A_CustomMissile ("BluePlasmaParticle", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 A 0 A_SpawnItemEx ("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 	TNT1 A 0 A_SpawnItemEx ("DetectCeilCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 	TNT1 A 1 Light("LightningImpactLight")
-    TNT1 B 4	
+	TNT1 B 4	
 	TNT2 AAAA 4 A_CustomMissile ("PlasmaSmoke", 1, 0, random (0, 360), 2, random (0, 160))
 		Stop
 		
@@ -1317,7 +1319,7 @@ ACTOR AltHeavyPlasmaBall: Plasma_ball
 	Height 10
 	Speed 80
 	Damage 12
-    DamageType SuperPlasma
+	DamageType SuperPlasma
 	Decal "Scorch"
 	Projectile
 	+RANDOMIZE
@@ -1326,7 +1328,7 @@ Scale 0.2
 	//Translation "0:255=%[0,0,0]:[0,0,1]"
 	DeathSound "weapons/plasmax"
 	//SeeSound "PLSM8"
-    SeeSound "None"
+	SeeSound "None"
 	Obituary "$OB_MPPLASMARIFLE"
 	States
 	{
@@ -1340,28 +1342,28 @@ Scale 0.2
 
 
 Xdeath:
-    TNT1 A 0 A_SpawnItem ("Plasma_Puff", 0)
+	TNT1 A 0 A_SpawnItem ("Plasma_Puff", 0)
 	TNT1 AAAA 0 A_CustomMissile ("BluePlasmaFireSmall2", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAA 0 A_CustomMissile ("SuperPlasmaFire", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAAAA 0 A_CustomMissile ("BluePlasmaParticle", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAAAA 0 A_CustomMissile ("CryoRifleTrailSparksSmall", 0, 0, random (0, 360), 2, random (0, 360))
-    TNT1 A 0 A_Explode(6,90,0)
+	TNT1 A 0 A_Explode(6,90,0)
 	TNT1 A 1 Light("LightningImpactLight")
 	TNT1 B 4
 	TNT2 AAAA 4 A_CustomMissile ("PlasmaSmoke", 1, 0, random (0, 360), 2, random (0, 160))
 		Stop
 
 	Death:
-    TNT1 A 0 A_SpawnItem ("Plasma_Puff", 0)
-    //TNT1 A 0 A_SpawnItem ("RailPuff", 0)
-    TNT1 A 0 A_Explode(6,90,0)
+	TNT1 A 0 A_SpawnItem ("Plasma_Puff", 0)
+	//TNT1 A 0 A_SpawnItem ("RailPuff", 0)
+	TNT1 A 0 A_Explode(6,90,0)
 	TNT1 AAAA 0 A_CustomMissile ("BluePlasmaFireSmall2", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAA 0 A_CustomMissile ("SuperPlasmaFire", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 AAAAAAAAAAAAAAAAA 0 A_CustomMissile ("BluePlasmaParticle", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 A 0 A_SpawnItemEx ("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 	TNT1 A 0 A_SpawnItemEx ("DetectCeilCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 	TNT1 A 1 Light("LightningImpactLight")
-    TNT1 B 4	
+	TNT1 B 4	
 		Stop
 		
 		
@@ -1388,7 +1390,7 @@ Actor SuperPlasmaFire
   Scale 0.035
   //Speed 2
   Speed 2
-    +NoGravity
+	+NoGravity
   -DOOMBOUNCE
   RenderStyle Add
   Scale 0.7
@@ -1397,8 +1399,8 @@ Actor SuperPlasmaFire
   {
   Spawn:
   Death:
-    FIR6 ABCDEFGHIJKLMNOP 1 Bright A_FadeOut(0.04)
-    Stop
+	FIR6 ABCDEFGHIJKLMNOP 1 Bright A_FadeOut(0.04)
+	Stop
   }
 }
 
@@ -1419,7 +1421,7 @@ Actor BluePlasmaFireSmall2
   RenderStyle Add
   Scale 0.035
   Speed 0
-    +NoGravity
+	+NoGravity
   -DOOMBOUNCE
   RenderStyle Add
   Scale 0.19
@@ -1428,8 +1430,8 @@ Actor BluePlasmaFireSmall2
   {
   Spawn:
   Death:
-    FIR6 ABCDEFGHIJKLMNOP 1 Bright A_FadeOut(0.05)
-    Stop
+	FIR6 ABCDEFGHIJKLMNOP 1 Bright A_FadeOut(0.05)
+	Stop
   }
 }
 
@@ -1450,7 +1452,7 @@ Actor BluePlasmaFireSmall
   RenderStyle Add
   Scale 0.035
   Speed 0
-    +NoGravity
+	+NoGravity
   -DOOMBOUNCE
   RenderStyle Add
   Scale 0.25
@@ -1459,8 +1461,8 @@ Actor BluePlasmaFireSmall
   {
   Spawn:
   Death:
-    FIR5 ABCDEFGHIJKLMNOP 1 Bright A_FadeOut(0.05)
-    Stop
+	FIR5 ABCDEFGHIJKLMNOP 1 Bright A_FadeOut(0.05)
+	Stop
   }
 }
 
@@ -1566,7 +1568,7 @@ Actor LightningGunPuff_Big
   +NODAMAGETHRUST
   +DONTSPLASH
   +RANDOMIZE
-	  RenderStyle Add
+		RenderStyle Add
 		Scale 2.50
 		States 
 		{
@@ -1719,69 +1721,69 @@ Actor StunElectrocute : ElectroBlastTrail
 
 Actor ElectroBombFX
 {
-   Speed 0
-   Damage 0
-   PROJECTILE
-   RENDERSTYLE ADD
-   Damagetype plasma
-   Scale 0.35
-   +THRUGHOST
-   +THRUACTORS
-   +FORCEXYBILLBOARD
-   +NoGravity
-   +DONTSPLASH
-   States
-   {
-   Spawn:
-	  TNT1 A 0
-	  TNT1 A 0 A_PlaySound("LGBOMB")
-	  STFL ABCDEFGHIJKLMNOP 1 Bright A_SetScale(ScaleX+0.05,ScaleY+0.05)
-	  STFL ABCDE 1 BRIGHT A_FadeOut(0.2)
-	  Stop
-	  }
+	Speed 0
+	Damage 0
+	PROJECTILE
+	RENDERSTYLE ADD
+	Damagetype plasma
+	Scale 0.35
+	+THRUGHOST
+	+THRUACTORS
+	+FORCEXYBILLBOARD
+	+NoGravity
+	+DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 0
+		TNT1 A 0 A_PlaySound("LGBOMB")
+		STFL ABCDEFGHIJKLMNOP 1 Bright A_SetScale(ScaleX+0.05,ScaleY+0.05)
+		STFL ABCDE 1 BRIGHT A_FadeOut(0.2)
+		Stop
+		}
 }
 
 /*Actor StunBomb
 {
-   Radius 2
-   Height 2
-   Speed 24
-   Damage 0
+	Radius 2
+	Height 2
+	Speed 24
+	Damage 0
   // PROJECTILE
-   RENDERSTYLE ADD
-   //Alpha 0.80
-   Damagetype Stun //New Damage type!
-   Scale 0.1
-    +MISSILE
-   +THRUGHOST
-   +FORCEXYBILLBOARD
-    Gravity .5
-   SeeSound ""
-   DeathSound "LGBOMB"
-   States
-   {
-   Spawn:
-      TNT1 A 0
-      TNT1 A 0 A_PlaySound("PZAPFLY", 6,1,1)
-      STFL ABCD 1 A_SetScale(ScaleX+0.02,ScaleY+0.02)
-	  Fly:
-	  STFL EFGH 1 Bright A_CustomMissile("ElectroBlastTrail",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(-40,40))
-	  STFL IJKL 1 Bright Light("LightningImpactLight") A_CustomMissile("ElectroBlastTrail",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(-40,40))
-	  STFL MNOP 1 Bright A_CustomMissile("ElectroBlastTrail",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(-40,40))
-      STFL ABCD 1 Bright Light("LightningImpactLight") A_CustomMissile("ElectroBlastTrail",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(-40,40))
-	  Loop
-	  
-   Death:
-	  TNT1 A 0
-	  TNT1 A 0 A_ChangeFlag("NOGRAVITY", 1)
-	  TNT1 A 0 A_StopSound(6)
-      STFL ABCDEFGHIJKL 1 BRIGHT Light("LightningImpactLight") A_SetScale(ScaleX+0.1,ScaleY+0.1)
-	  TNT1 A 0 BRIGHT A_SpawnItem("LightningGunPuff_Bigger",0)
-	  TNT1 A 0 BRIGHT A_SpawnItem("BlueFlare",0)
-	  TNT1 A 0 A_explode(2, 300,0,0,300)
-	  TNT1 A 0 A_PlaySound("STNBOEX", 3)
-	  TNT1 AAAAAAAAAAA 0 A_CustomMissile("ElectroBlastTrail3",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(30,270))
-	  XELC AABBCCDDEEFF 1 Bright Light("LightningImpactLight") A_CustomMissile("ElectroBlastTrail3",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(30,270))
-	  Stop
-	  }
+	RENDERSTYLE ADD
+	//Alpha 0.80
+	Damagetype Stun //New Damage type!
+	Scale 0.1
+	+MISSILE
+	+THRUGHOST
+	+FORCEXYBILLBOARD
+	Gravity .5
+	SeeSound ""
+	DeathSound "LGBOMB"
+	States
+	{
+	Spawn:
+		TNT1 A 0
+		TNT1 A 0 A_PlaySound("PZAPFLY", 6,1,1)
+		STFL ABCD 1 A_SetScale(ScaleX+0.02,ScaleY+0.02)
+		Fly:
+		STFL EFGH 1 Bright A_CustomMissile("ElectroBlastTrail",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(-40,40))
+		STFL IJKL 1 Bright Light("LightningImpactLight") A_CustomMissile("ElectroBlastTrail",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(-40,40))
+		STFL MNOP 1 Bright A_CustomMissile("ElectroBlastTrail",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(-40,40))
+		STFL ABCD 1 Bright Light("LightningImpactLight") A_CustomMissile("ElectroBlastTrail",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(-40,40))
+		Loop
+		
+	Death:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("NOGRAVITY", 1)
+		TNT1 A 0 A_StopSound(6)
+		STFL ABCDEFGHIJKL 1 BRIGHT Light("LightningImpactLight") A_SetScale(ScaleX+0.1,ScaleY+0.1)
+		TNT1 A 0 BRIGHT A_SpawnItem("LightningGunPuff_Bigger",0)
+		TNT1 A 0 BRIGHT A_SpawnItem("BlueFlare",0)
+		TNT1 A 0 A_explode(2, 300,0,0,300)
+		TNT1 A 0 A_PlaySound("STNBOEX", 3)
+		TNT1 AAAAAAAAAAA 0 A_CustomMissile("ElectroBlastTrail3",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(30,270))
+		XELC AABBCCDDEEFF 1 Bright Light("LightningImpactLight") A_CustomMissile("ElectroBlastTrail3",6,0,random(0,359),CMF_AIMDIRECTION|CMF_TRACKOWNER,random(30,270))
+		Stop
+		}
 }*/

--- a/actors/Weapons/Slot8/Flamethrower.dec
+++ b/actors/Weapons/Slot8/Flamethrower.dec
@@ -123,7 +123,7 @@ ACTOR LandedNuke
 		FMN4 E 0 A_Jump(128, 2)
 		FMN4 E 0
 	Spawn2:
-	    FMN4 "#" 2 BRIGHT Light("InvulnerabilitySphere") {
+		FMN4 "#" 2 BRIGHT Light("InvulnerabilitySphere") {
 			A_SpawnItem("GreenTrailSparks");
 		}
 		Loop
@@ -167,7 +167,7 @@ States {
 		FMN5 E 0 A_Jump(128, 2)
 		FMN5 E 0
 	Spawn2:
-	    FMN5 "#" 2 BRIGHT Light("InvulnerabilitySphere") {
+		FMN5 "#" 2 BRIGHT Light("InvulnerabilitySphere") {
 			A_SpawnItem("GreenTrailSparks");
 		}
 		Loop
@@ -178,7 +178,7 @@ Actor PB_FlamethrowerUpgrade : CustomInventory
 {
 	//$Title Flamethrower Upgrade
 	//$Category Project Brutality - Weapon Upgrades
-	+INVENTORY.ALWAYSPICKUP
+	-INVENTORY.ALWAYSPICKUP
 	Inventory.PickupSound "FLMDRAW"
 	Scale 0.5
 	Inventory.PickupMessage "UAC-M3 Flamethrower Upgrade! (Slot 8)"
@@ -189,6 +189,8 @@ Actor PB_FlamethrowerUpgrade : CustomInventory
 			FSPW B 1 
 			Loop
 		Pickup:
+			TNT1 A 0 A_JumpIf(!FindInventory("PB_Flamethrower") || !FindInventory("FlamerUpgraded") || CountInv("PB_Fuel") < GetAmmoCapacity("PB_Fuel"),1)
+			fail
 			TNT1 A 0 A_GiveInventory("PB_Flamethrower")
 			TNT1 A 0 A_JumpIfInventory("FlamerUpgraded",1,3)
 			TNT1 A 0 A_SetInventory("FlamerUpgraded",1)
@@ -225,8 +227,8 @@ ACTOR PB_Flamethrower : PB_Weapon
 	Weapon.AmmoType1 "PB_Fuel"
 	Weapon.AmmoType2 "FlamerAmmo"
 	PB_WeaponBase.respectItem "RespectFlamerGoon"
-    Inventory.PickupSound "weapons/flamethrower/respect1"
-     +WEAPON.NOAUTOAIM
+	Inventory.PickupSound "weapons/flamethrower/respect1"
+	+WEAPON.NOAUTOAIM
 	+FLOORCLIP
 	+DONTGIB
 	Inventory.PickupMessage "UAC-M3 Flamethrower (Slot 8)"
@@ -335,18 +337,18 @@ ACTOR PB_Flamethrower : PB_Weapon
 		TNT1 A 0 A_JumpIfInventory("FlamerUpgraded", 1, "SelectAnimationUpgraded")
 		FLS2 ABCD 0
 		FLS1 ABCD 0
-        TNT1 A 0 A_StartSound("weapons/flamethrower/respect1", CHAN_AUTO)
+		TNT1 A 0 A_StartSound("weapons/flamethrower/respect1", CHAN_AUTO)
 		FLS1 ABCD 1 {
 			if(CountInv("FlamerAmmo") == 0) {A_SetWeaponSprite("FLS2");}
 			}
 		TNT1 A 0 A_JumpIfInventory("FlamerNukageMode", 1, "Ready4")
-        Goto Ready3
+		Goto Ready3
 
 	SelectAnimationUpgraded:
 		TNT1 A 0 A_StartSound("weapons/flamethrower/respect1", CHAN_AUTO)
 		FLT2 ABCD 0
 		FLT1 A 0
-	    TNT1 A 0
+		TNT1 A 0
 		FLT1 ABCD 1 {
 			if(CountInv("PB_Fuel") == false || CountInv("FlamerNukageMode") == 1) {A_SetWeaponSprite("FLT2");}
 			}
@@ -392,30 +394,30 @@ ACTOR PB_Flamethrower : PB_Weapon
 		TNT1 A 0 A_JumpIfInventory("FlamerAmmo", 1, 1)
 		Goto NoAmmo
 	ReallyReady:
-	    FRR2 AABBCC 1 {
+		FRR2 AABBCC 1 {
 			if(CountInv("FlamerTankNotInserted") >= 1) {
 				return state("StartUpgradeRespect");
 				}
 			return A_DoPBWeaponAction;
 		}
-	    Loop
+		Loop
 
 	Ready2:
 		TNT1 A 0 A_JumpIfInventory("PB_Fuel", 1, 1)
 		Goto NoAmmo
 	ReadyToFire2:
-        TNT1 A 0 A_PlaySound("FLMRIDL",6,1,1)
-	    FRR1 AABBCC 1 A_DoPBWeaponAction
-	    Loop
+		TNT1 A 0 A_PlaySound("FLMRIDL",6,1,1)
+		FRR1 AABBCC 1 A_DoPBWeaponAction
+		Loop
 
 	Ready5:
 		TNT1 A 0 A_JumpIfInventory("FlamerTankNotInserted", 1, "StartUpgradeRespect")
 		TNT1 A 0 A_StartSound("weapons/flamethrower/click",CHAN_6,CHANF_LOOPING,0.8)
-        FRR1 A 0 A_JumpIfInventory("FlamerUpgraded", 1, 2)
+		FRR1 A 0 A_JumpIfInventory("FlamerUpgraded", 1, 2)
 		FRR2 A 0 
 		"####" A 0
-	    "####" D 1 A_DoPBWeaponAction
-	    Loop
+		"####" D 1 A_DoPBWeaponAction
+		Loop
 
 
 	WeaponSpecialUpgraded:
@@ -720,7 +722,7 @@ ACTOR PB_Flamethrower : PB_Weapon
 		Stop
 	ReloadLoop:
 		TNT1 A 0 A_JumpIfInventory("PB_Fuel",1,2)
-        Goto Ready3
+		Goto Ready3
 		TNT1 A 0
 		TNT1 A 0 A_Giveinventory("FlamerAmmo",1)
 		TNT1 A 0 A_Takeinventory("PB_Fuel",1)
@@ -761,7 +763,7 @@ ACTOR PB_Flamethrower : PB_Weapon
 	
 	UnloadLoop:
 		TNT1 A 0 A_JumpIfInventory("FlamerAmmo",1,2)
-        Goto Ready3
+		Goto Ready3
 		TNT1 A 0
 		TNT1 A 0 A_Giveinventory("PB_Fuel",1)
 		TNT1 A 0 A_Takeinventory("FlamerAmmo",1)
@@ -778,10 +780,10 @@ ACTOR PB_Flamethrower : PB_Weapon
 		"####" D 2 A_DoPBWeaponAction
 		"####" A 0 {
 				if (CountInv("FlamerUpgraded") == 1 && CountInv("PB_Fuel") > 2) {
-					 A_PlaySound("FLIDLE",CHAN_WEAPON,10,1);
+					A_PlaySound("FLIDLE",CHAN_WEAPON,10,1);
 					}
 				else if (CountInv("FlamerAmmo") > 2 && CountInv("FlamerUpgraded") != 0) {
-					 A_PlaySound("FLIDLE",CHAN_WEAPON,10,1);
+					A_PlaySound("FLIDLE",CHAN_WEAPON,10,1);
 					}
 				return state ("");
 			}
@@ -791,7 +793,7 @@ ACTOR PB_Flamethrower : PB_Weapon
 		TNT1 A 0 A_JumpIfInventory ("GrabbedBarrel", 1, "PlaceBarrel")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedFlameBarrel", 1, "PlaceFlameBarrel")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedIceBarrel", 1, "PlaceIceBarrel")
-	    TNT1 A 0 {
+		TNT1 A 0 {
 			A_StopSound(CHAN_WEAPON);
 			A_StopSound(CHAN_BODY);
 			A_StopSound(CHAN_6);
@@ -827,11 +829,11 @@ ACTOR PB_Flamethrower : PB_Weapon
 		TNT1 A 0 PB_WeapTokenSwitch("FlameCannonSelected")
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Raise
 		TNT1 AAAAAAAA 1 A_Raise
-	    wait
+		wait
 		
-    Spawn:
-        FSPW A -1
-        Stop
+	Spawn:
+		FSPW A -1
+		Stop
 
 	////////////////////////////////////////////////////////
 	Fire:
@@ -840,9 +842,9 @@ ACTOR PB_Flamethrower : PB_Weapon
 		TNT1 A 0 A_JumpIfInventory ("GrabbedIceBarrel", 1, "ThrowIceBarrel")
 		FLF2 A 0 A_JumpIfInventory("FlamerUpgraded", 1, "FireUpgraded")
 		TNT1 A 0 A_JumpIfInventory("FlamerNukageMode", 1, "FireNuke")
-        TNT1 A 0 A_JumpIfInventory("FlamerAmmo",3,1)
+		TNT1 A 0 A_JumpIfInventory("FlamerAmmo",3,1)
 		Goto Reload
-        TNT1 A 0 {
+		TNT1 A 0 {
 			A_AlertMonsters;
 			A_StartSound("weapons/flamethrower/burst", CHAN_5 );
 			}
@@ -893,7 +895,7 @@ ACTOR PB_Flamethrower : PB_Weapon
 	FireNuke:
 		TNT1 A 0 A_JumpIfInventory("FlamerAmmo",2,1)
 		Goto Reload
-        TNT1 A 0 {
+		TNT1 A 0 {
 			A_TakeInventory("FlamerAmmo", 2);
 			A_AlertMonsters;
 			A_StopSound(CHAN_6);
@@ -905,13 +907,13 @@ ACTOR PB_Flamethrower : PB_Weapon
 			A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
 			PB_FireOffset;
 		}
-        "####" A 0 A_JumpIfInventory("FlamerAmmo",2,1)
+		"####" A 0 A_JumpIfInventory("FlamerAmmo",2,1)
 		Goto Reload
 		"####" A 0 A_AlertMonsters
-        FLN1 ABC 1 BRIGHT{
-			 A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
-			 A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
-			 A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
+		FLN1 ABC 1 BRIGHT{
+			A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
+			A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
+			A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
 			PB_FireOffset;
 		}
 		"####" A 0 {
@@ -929,9 +931,9 @@ ACTOR PB_Flamethrower : PB_Weapon
 
 	FireUpgraded:
 		TNT1 A 0 A_JumpIfInventory("FlamerNukageMode", 1, "FireNukeUpgraded")
-        TNT1 A 0 A_JumpIfInventory("PB_Fuel",3,1)
+		TNT1 A 0 A_JumpIfInventory("PB_Fuel",3,1)
 		Goto Ready3
-        TNT1 A 0 {
+		TNT1 A 0 {
 			A_AlertMonsters;
 			A_StartSound("weapons/flamethrower/burst", CHAN_5 );
 			}
@@ -984,7 +986,7 @@ ACTOR PB_Flamethrower : PB_Weapon
 	FireNukeUpgraded:
 		TNT1 A 0 A_JumpIfInventory("PB_Fuel",2,1)
 		Goto Reload
-        TNT1 A 0 {
+		TNT1 A 0 {
 			A_TakeInventory("PB_Fuel", 2);
 			A_AlertMonsters;
 			A_StopSound(CHAN_BODY);
@@ -997,14 +999,14 @@ ACTOR PB_Flamethrower : PB_Weapon
 			A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
 			PB_FireOffset;
 		}
-        "####" A 0 A_JumpIfInventory("PB_Fuel",2,1)
+		"####" A 0 A_JumpIfInventory("PB_Fuel",2,1)
 		Goto Ready3
 		"####" A 0 A_AlertMonsters
-        FLN1 EFG 1 BRIGHT{
-			 PB_FireOffset;
-			 A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
-			 A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
-			 A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
+		FLN1 EFG 1 BRIGHT{
+			PB_FireOffset;
+			A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
+			A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
+			A_FireCustomMissile("NukageStreamMissile", 0, 1, 0, -5);
 		}
 		"####" A 0 {
 			A_TakeInventory("PB_Fuel", 2);
@@ -1197,7 +1199,7 @@ ACTOR PB_Flamethrower : PB_Weapon
 		Stop
 		
 	
-    FlashKicking:
+	FlashKicking:
 		TNT1 A 0 A_JumpIfInventory ("GrabbedBarrel", 1, "FlashBarrelKicking")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedFlameBarrel", 1, "FlashBarrelKicking")
 		TNT1 A 0 A_JumpIfInventory ("GrabbedIceBarrel", 1, "FlashBarrelKicking")
@@ -1308,11 +1310,11 @@ ACTOR BigFireBallWithGravity: BigFireBall
 
 ACTOR FlamerAmmo : Ammo
 {
-   Inventory.Amount 90
-   Inventory.MaxAmount 90
-   Ammo.BackpackAmount 0
-   Ammo.BackpackMaxAmount 90
-   +INVENTORY.IGNORESKILL
+	Inventory.Amount 90
+	Inventory.MaxAmount 90
+	Ammo.BackpackAmount 0
+	Ammo.BackpackMaxAmount 90
+	+INVENTORY.IGNORESKILL
 }
 
 
@@ -1326,33 +1328,33 @@ ACTOR Flames
 	Projectile 
 	+RANDOMIZE
 	+FORCEXYBILLBOARD
-    +RIPPER
-    +BLOODLESSIMPACT 
+	+RIPPER
+	+BLOODLESSIMPACT 
 	RenderStyle Add
-    DamageType Flames
-    Scale 2.0
+	DamageType Flames
+	Scale 2.0
 	Alpha 1
 	SeeSound "fatso/attack"
 	DeathSound "fatso/shotx"
-    Decal "BigScorch"
+	Decal "BigScorch"
 	States
 	{
-    Spawn:
-        TNT1 C 6
-        Goto See
+	Spawn:
+		TNT1 C 6
+		Goto See
 	See:
-        TNT1 A 0 A_Explode (15, 40)
-        FRFX C 2 BRIGHT A_SpawnItem("RedFlareMedium",0,0)
-        TNT1 A 0 A_Explode (15, 40)
-        FRFX C 2 BRIGHT A_SpawnItem("RedFlareMedium",0,0)
-        TNT1 A 0 A_Explode (15, 40)
-	    EXPL AA 0 A_CustomMissile ("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
-        TNT1 A 0 A_Explode (15, 40)
-        FRFX FGHIJKLMNOPG 2 BRIGHT A_SpawnItem("RedFlareMedium",0,0)
+		TNT1 A 0 A_Explode (15, 40)
+		FRFX C 2 BRIGHT A_SpawnItem("RedFlareMedium",0,0)
+		TNT1 A 0 A_Explode (15, 40)
+		FRFX C 2 BRIGHT A_SpawnItem("RedFlareMedium",0,0)
+		TNT1 A 0 A_Explode (15, 40)
+		EXPL AA 0 A_CustomMissile ("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
+		TNT1 A 0 A_Explode (15, 40)
+		FRFX FGHIJKLMNOPG 2 BRIGHT A_SpawnItem("RedFlareMedium",0,0)
 		Goto Death
 	Death:
-	    EXPL AA 0 A_CustomMissile ("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
-	    TNT1 A 0 A_SpawnItem("RedFlareMedium",0,0)
+		EXPL AA 0 A_CustomMissile ("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
+		TNT1 A 0 A_SpawnItem("RedFlareMedium",0,0)
 		Stop
 	}
 }
@@ -1382,20 +1384,20 @@ Damagetype "Fire"
 			TNT1 A 0 A_SpawnItemEx("FT_GroundFire2", random(-24,24), random(-7,7), random(1,2))
 			TNT1 A 0 A_Explode(12, 36, 0, 0, 36)
 			TNT1 A 0 
-        {
-         if(GetCVar("pb_performance_fire") == false) 
-         {
+		{
+		if(GetCVar("pb_performance_fire") == false) 
+		{
 			A_SpawnItemEx("BurningEmberParticlesFloating_Bigger_Faster", random(-7,7), random(-7,-7), random(22,38), 0, 0, 0, 0, 128, 0);
-         }
-        }
+		}
+		}
 
 			TNT1 A 0 
-        {
-         if(GetCVar("pb_performance_fire") == false) 
-         {
+		{
+		if(GetCVar("pb_performance_fire") == false) 
+		{
 			A_SpawnItemEx("BigBlackSmokeMedium", random(-7,7), random(-7,7), random(12,24), 0, 0 , random(2,4));
-         }
-        }
+		}
+		}
 			TNT1 A 0 A_Jump(7, "StopBurning")
 			Loop
 		
@@ -1403,7 +1405,7 @@ Damagetype "Fire"
 			TNT1 A 0 A_StopSound(CHAN_BODY)
 			TNT1 AAAAAAAA 2 Light("HUEHUESMALL")
 			Stop
-    }
+	}
 }
 
 ACTOR FT_GroundFireSpawnerPerf : FT_GroundFireSpawner
@@ -1420,7 +1422,7 @@ ACTOR FT_GroundFireSpawnerPerf : FT_GroundFireSpawner
 			TNT1 A 0 A_Explode(10, 36, 0, 0, 36)
 			TNT1 A 0 A_Jump(7, "StopBurning")
 			Loop
-    }
+	}
 }
 
 ACTOR FT_GroundFire
@@ -1435,17 +1437,17 @@ ACTOR FT_GroundFire
 		Spawn:
 			TNT1 A 0 
 				CFCF ABCDEFGHIJKLMABCDEFGHIJKLM 1 BRIGHT
-        {
-         if(GetCVar("pb_performance_fire") == false) 
-         {
-          A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire');
-         }
-        }
+		{
+		if(GetCVar("pb_performance_fire") == false) 
+		{
+			A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire');
+		}
+		}
 				CFCF A 1 A_Setscale(0.1)
 				CFCF B 1 A_Setscale(0.05)
 				CFCF C 1 A_Setscale(0.01)
 				Stop
-    }
+	}
 }
 
 ACTOR FT_GroundFire2
@@ -1460,17 +1462,17 @@ ACTOR FT_GroundFire2
 		Spawn:
 			TNT1 A 0 
 				FLME ABCDEFGHIJKLMNABCDEFGHIJKLMN 1 BRIGHT
-        {
-         if(GetCVar("pb_performance_fire") == false) 
-         {
-          A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire');
-         }
-        }
+		{
+		if(GetCVar("pb_performance_fire") == false) 
+		{
+			A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire');
+		}
+		}
 				FLME A 1 A_Setscale(0.3)
 				FLME B 1 A_Setscale(0.2)
 				FLME C 1 A_Setscale(0.05)
 				Stop
-    }
+	}
 }
 */
 ACTOR NukeSplashSmall
@@ -1489,7 +1491,7 @@ ACTOR NukeSplashSmall
 			Spawn1:
 				X009 DEFGHIJKLMNO 1 BRIGHT //A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire')
 				Stop
-    }
+	}
 }
 
 
@@ -1505,5 +1507,5 @@ ACTOR NukeSplashLarge : NukeSplashSmall
 			Spawn1:
 				X009 DEFGHIJKLMNO 1 BRIGHT //A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire')
 				Stop
-    }
+	}
 }

--- a/zscript/Monsters/Chaingunner/Commando.zc
+++ b/zscript/Monsters/Chaingunner/Commando.zc
@@ -884,7 +884,7 @@ Class PB_Chaingunguy : PB_Monster
 			TNT1 A 0 A_WallCheck(1, "RollRNow", "See");
 		RollRNow:
 			TNT1 AAA 0 A_FaceTarget(0);
-			ZRO2 A 1 A_FaceTarget;
+			ZRO2 A 1 A_FaceTarget();
 			TNT1 A 0
 			{
 				bNODROPOFF = true;
@@ -907,8 +907,8 @@ Class PB_Chaingunguy : PB_Monster
 		SideHop:
 			TNT1 A 0 A_Jump(256, "SHR", "SHL");
 		SHR:
-			POSS A 3 A_FaceTarget;
-			POSS E 3 A_FaceTarget;
+			POSS A 3 A_FaceTarget();
+			POSS E 3 A_FaceTarget();
 			TNT1 A 0 ThrustThingZ(0, 20, 0, 0);
 			TNT1 A 0 ThrustThing(angle*256/360+192, 8, 0, 0);
 			ZRO1 A 12;
@@ -917,12 +917,12 @@ Class PB_Chaingunguy : PB_Monster
 			ZRO1 A 1;
 			Loop;
 		SHRE:
-			ZRO1 A 1 A_FaceTarget;
+			ZRO1 A 1 A_FaceTarget();
 			TNT1 A 0 A_Jump(256, "RollR", "See", "Missile");
 			Goto See;
 		SHL:
-			POSS A 3 A_FaceTarget;
-			POSS E 3 A_FaceTarget;
+			POSS A 3 A_FaceTarget();
+			POSS E 3 A_FaceTarget();
 			TNT1 A 0 ThrustThingZ(0, 20, 0, 0);
 			TNT1 A 0 ThrustThing(angle*256/360+64, 8, 0, 0);
 			ZRO2 A 12;
@@ -931,10 +931,795 @@ Class PB_Chaingunguy : PB_Monster
 			ZRO2 A 1 A_CheckCeiling("SHLE");
 			Loop;
 		SHLE:
-			ZRO2 A 1 A_FaceTarget;
+			ZRO2 A 1 A_FaceTarget();
 			TNT1 A 0 A_Jump(256, "RollL", "See", "Missile");
 			Goto See;
+		Death.Execution:
+			TNT1 A 0 {
+	// 			A_Stop;
+				 A_StopSound();
+				A_FaceTarget();
+				A_NoBlocking();
+			}
+			MPOS A 8 ;
+			TNT1 A 0 A_Pain;
+			MPOS G 21;
+			TNT1 A 0 A_Recoil(4);
+			Goto Death.SSG;
+		Death.Shrink:
+			TNT1 A 1 A_PlaySound("Shrink", 3);
+			TNT1 A 0 A_SpawnItemEx("ChaingunGuy1ShrinkFX1", 0, 0,  5, 0, 0);
+			TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX2", 0, 0, 5, 0, 0);
+			TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX3", 0, 0, 5, 0, 0);
+			TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX4", 0, 0, 5, 0, 0);
+			TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX5", 0, 0, 5, 0, 0);
+			TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX6", 0, 0, 5, 0, 0);
+			TNT1 A 1 A_SpawnItemEx("ChaingunGuy1ShrinkFX7", 0, 0, 5, 0, 0);
+			TNT1 A 1 A_SpawnItemEx("LilChaingunGuy1", 1);
+			stop;
 			
+		Death.Blackhole:
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("BlackHoledHuman");
+			Stop;
+		Death.Cutless:
+			TNT1 A 0;
+			TNT1 A 0 A_Jump(30,"Death.Arm");
+			TNT1 A 0 A_Jump(22, "Death.Saw", "Death.Tear");
+			TNT1 A 0 A_JumpIfInventory("IsFiring", 1, "Death.Rare");
+		Death.Minigun:
+			TNT1 A 0;
+			TNT1 A 0 A_FaceTarget();
+			TNT1 A 0 A_Scream;
+			TNT1 O 0 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_SpawnItem("BrutalizedChaingunCommando1", 1);
+			Stop;
+		
+		Death.Shotgun:
+			TNT1 A 0 A_JumpIfCloser(220, 2);
+			Goto Death;
+		Death.HKFT:
+			TNT1 AAA 0;
+			TNT1 A 0 A_FaceTarget();
+			TNT1 A 0 A_JumpIfCloser(90, "Death.Blast");
+			TNT1 A 0 ThrustThingZ(0,30,0,1);
+			TNT1 A 0 A_Recoil(6);
+			TNT1 A 0 A_JumpIfInventory("IsFiring", 1, "Death.Rare");
+			TNT1 A 0 A_Scream;
+			TNT1 A 0 A_NoBlocking();
+			CPHM AB 4;
+			CPHM CD 4 A_JumpIf((MomY == 0), "TakeASit");
+			CPHM EF 4;
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_SpawnItem("DeadChaingunGuy_KilledByMinorHead", 3);
+			Stop;
+			
+		Death:
+			TNT1 A 0;
+			TNT1 A 0 A_JumpIfInventory("IsFiring", 1, "Death.Rare");
+			TNT1 A 0 A_Jump(30,"Death.Arm");
+			TNT1 A 0 A_Jump(80,"Death3");
+			TNT1 A 0 A_Jump(132,"Death2");
+			TNT1 A 0 A_Jump(64,"Death.Rare");
+			CPOD A 8 A_Scream;
+			CPOD B 6 A_NoBlocking();
+			CPOD CDEF 6;
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_Jump(62, "SufferBitch");
+			CPOD G 6;
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_SpawnItem("DeadChaingunGuy1", 3);
+			Stop;
+			
+		Death2:	
+			CPSC I 7 A_Scream;
+			CPSC J 6 A_NoBlocking();
+			CPSC KLM 6;
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			CPSC N 6;
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_SpawnItem("DeadChaingunGuyCPSCN", 3);
+			Stop;
+			
+		Death3:
+			TNT1 A 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160));
+			CP04 A 8 A_Scream;
+			CP04 B 6 A_NoBlocking();
+			CP04 CD 6;
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CP04 EF 6;
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_SpawnItemEx("DeadChaingunGuyCP04F",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);
+			Stop;
+		
+		SufferBitch:
+			TNT1 A 0;
+			TNT1 A 0 A_SpawnItem("SufferingCommandoGuts");
+			Stop;
+			
+		Death.Rare:
+			TNT1 A 0;
+			TNT1 A 0 A_FaceTarget();
+			TNT1 A 0 A_Recoil(2);
+			CPDR A 3 A_Scream;
+			TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0);
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 32, 15, 0, 2, -20);
+			CPDR B 3 BRIGHT A_NoBlocking();
+			
+			CPDR A 3;
+			TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0);
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 32, 15, 0, 2, -20);
+			CPDR B 3 BRIGHT A_NoBlocking();
+			
+	
+			CPDR C 2;
+			TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0);
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -20, 2, -20);
+			CPDR D 2 BRIGHT;
+			
+			CPDR C 2;
+			TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0);
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -20, 2, -20);
+			CPDR D 2 BRIGHT;
+			
+			CPDR E 2;
+			TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0);
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -20, 2, 20);
+			CPDR F 2 BRIGHT;
+			
+			CPDR G 2;
+			TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0);
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -10, 2, 40);
+			CPDR H 2 BRIGHT;
+			
+			TNT1 A 0 A_Recoil(1);
+			CPDR I 2;
+			TNT1 A 0 A_JumpIf((MomY == 0), "TakeASit");
+			TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0);
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 24, 15, -10, 2, 40);
+			CPDR J 2 BRIGHT;
+			TNT1 A 0 A_JumpIf((MomY == 0), "TakeASit");
+			
+			CPDR K 2;
+			TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0);
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 12, 15, -20, 2, 40);
+			CPDR L 2 BRIGHT;
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			CPDR M 2;
+			TNT1 A 0 A_SpawnItem("RifleCaseSpawn", 0, 30,0);
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 12, 15, -20, 2, 20);
+			CPDR N 2 BRIGHT;
+			
+			CPDR M 2;
+			TNT1 A 0 A_CustomMissile("PB_MonsterMinigunTracer", 12, 15, -20, 2, 20);
+			CPDR N 2 BRIGHT;
+			
+			
+			TNT1 A 0 A_SpawnItemEx("DropedMinigun", 0, 30);
+			TNT1 A 0 A_SpawnItem("DeadChaingunguyCPDRO", 3);
+			Stop;
+		
+		TakeASit:
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 6, 0, random (170, 190), 2, random (0, 40));
+			TNT1 A 0;
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_SpawnItemEx("DropedMinigun", 0, 30);
+			TNT1 A 0 A_SpawnItemEx("DeadChaingunguy_Slumped", 10);
+			Stop;
+		
+			
+		Death.OriginalGibz:
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 AAA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathChainArm", 35, 0, random (0, 360), 2, random (60, 120));
+			TNT1 A 0 A_CustomMissile("XDeath1", 35, 0, random (0, 360), 2, random (60, 120));
+			TNT1 AA 0 A_CustomMissile("XDeath2", 35, 0, random (0, 360), 2, random (60, 120));
+			TNT1 AA 0 A_CustomMissile("XDeath3", 35, 0, random (0, 360), 2, random (60, 120));
+			TNT1 AAA 0 A_CustomMissile("SmallBrainPiece", 35, 0, random (0, 360), 2, random (60, 120));
+			TNT1 A 0 A_XScream;
+			TNT1 O 0 A_NoBlocking();
+			CPSC ABCDEFGH 4;
+			CPSC H 1;
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 1 A_SpawnItem("DeadChaingunGuy_Half", 3);
+			Stop;
+		
+			
+		Death.Arm:
+			TNT1 A 0 A_Jump(140, "DeathArm2");
+			TNT1 A 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_Scream;
+			CPOD H 10 A_NoBlocking();
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CPOD I 5;
+			CPOD I 1 A_NoBlocking();
+			TNT1 A 1 A_SpawnItem("BrutalizedCommando1");
+			Stop;
+			
+		DeathArm2:
+			TNT1 AA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathChainArm", 45, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeath1", 45, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_Scream;
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CP05 A 10 A_NoBlocking();
+			TNT1 A 0 A_SpawnItemEx("DyingChaingunGuyNoArm1",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);
+			Stop;
+			
+		XDeath:
+			TNT1 A 0 A_JumpIfInTargetInventory("HasCutingWeapon",1,"Death.Saw");
+			TNT1 A 1 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 1 A_JumpIfInTargetInventory("SSGSelected", 1, "Death.SSG");
+			TNT1 A 1 A_XScream;
+			TNT1 A 1 A_NoBlocking();
+			TNT1 A 1 A_SpawnItemEx("ChainXDeath",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0,0);
+			Stop;
+			
+			
+		HeadExploder:
+			TNT1 A 0 A_Jump(72, "Death.HeadExplode");
+			Goto Death.HeadMinor;
+			
+		Death.Head:
+			TNT1 A 0;
+			TNT1 A 0 A_JumpIfInTargetInventory("HasPlasmaWeapon", 1, "Death.Plasma");
+			TNT1 A 0 A_JumpIfInTargetInventory("HasIncendiaryWeapon",1,"Death.Incinerate");
+			TNT1 A 0 A_JumpIfInTargetInventory("HasCutingWeapon", 1, "Death.Decaptate");
+			TNT1 A 0 A_JumpIfHealthLower(-50, "Death.HeadExplode");
+			TNT1 A 0 A_JumpIfInTargetInventory("RandomHeadExploder", 1, "HeadExploder");
+		Death.HeadMinor:
+			TNT1 A 0;
+			TNT1 A 0 A_Playsound("MinorHeadshot", 0);
+			TNT1 AA 0 A_CustomMissile("BloodMistBig", 60, 0, random (0, 360), 2, random (30, 90));
+			TNT1 AAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AA 0 A_CustomMissile("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40));
+			TNT1 A 0 A_CustomMissile("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			CPHM I 6;
+			CPHM C 6 A_NoBlocking();
+			CPHM DEF 6 ;
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_SpawnItem("DeadChaingunGuy_KilledByMinorHead", 3);
+			Stop;
+			
+			Death.Melee:
+			TNT1 A 0;
+			CPHM A 9;
+			CPHM B 9 A_Scream;
+			CPHM C 8 A_NoBlocking();
+			CPHM DEF 8 ;
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("DeadChaingunGuy_KilledByMinorHead", 3);
+			Stop;
+			
+		Death.headExplode:
+			
+			TNT1 A 0;
+			TNT1 A 0 A_SpawnItem("ChaingunguyHeadExplode", 0, 50);
+			TNT1 A 0 A_Jump(132, "HeadExplode2", "HeadExplode3");
+			CPHS AAA 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120));
+			CPHS BBB 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120));
+			CPHS CCC 2 A_CustomMissile("Brutal_LiquidBlood2", 40, 0, random (0, 360), 2, random (60, 120));
+			TNT1 A 0 A_NoBlocking();
+			CPHS DDDDDDDDDDDDEEE 2 A_CustomMissile("Brutal_LiquidBlood2", 30, 0, random (0, 360), 2, random (60, 120));
+			
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			CPHS FFFFFFFFFFFFFFF 2 A_CustomMissile("Brutal_LiquidBlood2", 5, 0, random (0, 360), 2, random (10, 40));
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 1 A_SpawnItem("DeadChaingunGuy_NoHead", 3);
+			Stop;
+			
+		HeadExplode2:
+			TNT1 A 0 A_PlaySound("misc/xdeath4");
+			CP04 GGGG 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120));
+			CP04 HHHH 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120));
+			CP04 III 2 A_CustomMissile("Brutal_LiquidBlood2", 40, 0, random (0, 360), 2, random (60, 120));
+			TNT1 A 0 A_NoBlocking();
+			CP04 JJJKKK 2 A_CustomMissile("Brutal_LiquidBlood2", 30, 0, random (0, 360), 2, random (60, 120));
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			CP04 LLLLLLLLLLLLLLLLLL 2 A_CustomMissile("Brutal_LiquidBlood2", 5, 0, random (0, 360), 2, random (10, 40));
+			TNT1 A 1 A_SpawnItem("DeadChaingunGuyCP04L", 3);
+			Stop;
+			
+		HeadExplode3:
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("ChaingunguyHeadExplode", 0, 50);
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CPHS GGG 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120));
+			TNT1 A 0 A_SpawnItem("BrutalizedCommandoLostHead");
+			Stop;
+			
+		Death.decaptate:
+			TNT1 AAAAA 0 A_CustomMissile("BloodMistLarge", 50, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_PlaySound("misc/xdeath4");
+			TNT1 A 0 A_SpawnItemEx("XDeathChaingunguyHeadBeheaded", 50, 0, random (0, 360), 2, random (40, 90));
+			CP04 GGGGGGG 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120));
+			CP04 HHHH 2 A_CustomMissile("Brutal_LiquidBlood2", 50, 0, random (0, 360), 2, random (60, 120));
+			TNT1 A 0 A_XScream;
+			CP04 IIII 2 A_CustomMissile("Brutal_LiquidBlood2", 40, 0, random (0, 360), 2, random (60, 120));
+			TNT1 A 0 A_NoBlocking();
+			CP04 JJJJKKKK 2 A_CustomMissile("Brutal_LiquidBlood2", 30, 0, random (0, 360), 2, random (60, 120));
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			CP04 LLLLLLLLLLLLLLLLLL 2 A_CustomMissile("Brutal_LiquidBlood2", 5, 0, random (0, 360), 2, random (10, 40));
+			TNT1 A 1 A_SpawnItem("DeadChaingunGuyCP04L", 3);
+			Stop;
+			
+			
+		
+		Death.cut:
+			TNT1 A 0;
+			TNT1 AA 0 A_CustomMissile("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_XScream;
+			TNT1 O 0 A_NoBlocking();
+			TNT1 A 0 A_CustomMissile("RipChaingunGuy1", 0, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40));
+			CP06 AABC 9 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40));
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CP06 DDDDDDDDDDDDDDDDDDDDDDDDD 1 A_CustomMissile("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90));
+			TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP06D");
+			Stop;
+			
+		Death.Saw:
+			TNT1 A 0 A_Jump(64, "Death.cut");
+			TNT1 A 0 A_Jump(12, "Death.arm");
+		Death.Tear:
+			TNT1 A 0;
+			TNT1 AA 0 A_CustomMissile("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160));
+			TNT1 O 0 A_NoBlocking();
+			TNT1 A 0 A_CustomMissile("RipChaingunGuy2", 0, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40));
+			CP06 EE 9 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40));
+			CP06 FGHI 6;
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CP06 JJJJJJJJJJJJJJJJJJJJJJJJ 1 A_CustomMissile("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90));
+			TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP06J");
+			Stop;
+			
+		
+		Death.ExplosiveImpact:
+		TNT1 A 0 A_ChangeFLag("NODROPOFF", 0);
+			TNT1 A 0;
+			TNT1 A 0 ThrustThingZ(0,30,0,1);
+			TNT1 A 0 A_FaceTarget();
+			TNT1 A 1;
+			TNT1 A 0 A_JumpIf(angle < 180, "IsFacingNorth");
+			TNT1 A 0 A_JumpIf(velx < 0, "BlownAwayRight");
+			TNT1 A 0 A_JumpIf(velx > 0, "BlownAwayLeft");
+			Goto XDeath;
+			IsFacingNorth:
+			TNT1 A 0 A_JumpIf(velx > 0, "BlownAwayRight");
+			TNT1 A 0 A_JumpIf(velx < 0, "BlownAwayLeft");
+			Goto XDeath;
+			
+		BlownAwayLeft:	
+			TNT1 A 0 A_NoBlocking();
+			TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
+			TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
+			TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 ThrustThingZ(0,30,0,1);
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CPDE A 1 A_Scream;
+			CPDE A 1;
+			CPDE A 2 A_CheckFloor ("Dead.Landmine");
+			CPDE BCDEFGH 2 A_CheckFloor ("Dead.Landmine");
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			CPDE A 0 A_SpawnItem("GrowingBloodPool");
+			CPDE A 0 A_SpawnItem("DeadChaingunguyCPDEI");
+			Stop;
+			
+		BlownAwayRight:
+			TNT1 A 0 A_Jump(96, "Death.ExtremePunches");
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_CustomMissile("XDeath1", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_ChangeFlag("NOBLOCKMONST", 1);
+			TNT1 A 0 A_SpawnItemEx("XDeathChaingunguyHeadBeheaded", 50, 0, random (0, 360), 2, random (40, 90));
+			TNT1 AAAA 0 A_CustomMissile("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10));
+			TNT1 AAAA 0 A_CustomMissile("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AA 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeath3", 40, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
+			TNT1 A 0 ThrustThingZ(0,30,0,1);
+			TNT1 A 0 A_XScream;
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			4N02 ABCDCBA 3 A_CustomMissile("Brutal_FlyingBlood", 0, 0, 0, 2, 90);
+			TNT1 A 0 A_CheckFloor("Land8472");
+			4N02 ABCDCBABCDCBA 5 A_CheckFloor("Land8472");
+			Land8472:
+			SXS2 N 0;
+			TNT1 A 0 A_Stop;
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			CPDE A 0 A_SpawnItem("DeadChaingunguy4N02E");
+			Stop;
+		
+		
+		Death.ExtremePunches:
+		Death.Landmine:
+		Death.LandMine2:
+		TNT1 A 0 A_NoBlocking();
+		TNT1 A 0 ThrustThingZ(0,40,0,1);
+		TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
+		TNT1 AA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+		TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
+		TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
+		TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160));
+		TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
+		TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
+		TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CPDE A 1 A_Scream;
+			CPDE A 1;
+			CPDE A 2 A_CheckFloor ("Dead.Landmine");
+			CPDE BCDEFGH 2 A_CheckFloor ("Dead.Landmine");
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			CPDE A 0 A_SpawnItem("GrowingBloodPool");
+			CPDE A 0 A_SpawnItem("DeadChaingunguyCPDEI");
+			Stop;
+		
+		Dead.Landmine:
+			TNT1 A 0;
+			TNT1 A 0 A_SpawnItem("Ploft");
+			TNT1 AAAA 0 A_SpawnItem("Blood");
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			CPDE I 1;
+			CPDE A 0 A_SpawnItem("DeadChaingunguyCPDEI");
+			Stop;
+		
+		Death.Plasma: Death.Plasma2:
+			TNT1 A 0;
+			TNT1 A 0 A_Stop;
+			TNT1 A 0 A_PlaySound("plasmaflesh");
+			TNT1 AAAAAAAAA 0 A_CustomMissile("Ashes1", 32, 0, random (0, 360), 2, random (0, 180));
+			TNT1 AAAAAAAAA 0 A_CustomMissile("Ashes2", 32, 0, random (0, 360), 2, random (0, 180));
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1Blue",random(-2,2),random(-2,2),18,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			TNT1 AAAA 0 A_CustomMissile("BluePlasmaFireNonStatic", 42, 0, random (0, 360), 2, random (0, 180));
+			TNT1 AAAA 0 A_CustomMissile("BloodMistBig", 32, 0, random (0, 360), 2, random (0, 180));
+			TNT1 AAAAAA 0 A_CustomMissile("SuperGoreMistSmall", 32, 0, random (0, 360), 2, random (10, 90));
+			TNT1 AAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (0, 360), 2, random (0, 180));
+			PBR1 B 6 A_NoBlocking();
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1Blue",random(-2,2),random(-2,2),10,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			TNT1 A 0 A_SpawnItemEx("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);
+			TNT1 A 0 A_SpawnItem("BarrelExplosionSmokeColumn");
+			TNT1 A 0 A_SpawnItemEx("TinyBurningPiece", random (-15, 15), random (-15, 15));
+			TNT1 A 0 A_SpawnItemEx("TinyBurningPiece2", random (-35, 35), random (-35, 35));
+			TNT1 A 0 A_SpawnItemEx("TinyBurningPiece3", random (-45, 45), random (-45, 35));
+			PBR1 CCDD 3 A_CustomMissile("BluePlasmaFireNonStatic", 32, 0, random (0, 360), 2, random (0, 180));
+			PBR1 EEFF 3;
+			PBR1 GG 3;
+			PBR1 H -1;
+			Stop;
+		
+		Death.SuperPlasma:
+			TNT1 A 0;
+			TNT1 A 0 A_XScream;
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_NoBlocking();
+			XBRN AA 2 BRIGHT A_SpawnItem("BlueFlare",0,43);
+			TNT1 AAAA 0 A_CustomMissile("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160));
+			
+			TNT1 A 0 A_CustomMissile("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160));
+	
+			XBRN BB 2 BRIGHT A_SpawnItem("BlueFlare",0,43);
+			TNT1 A 0 A_CustomMissile("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160));
+			XBRN CC 2 BRIGHT A_SpawnItem("BlueFlare",0,43);
+			TNT1 AAAAA 0 A_CustomMissile("PlasmaParticleX", 48, 0, random (0, 360), 2, random (0, 360));
+			TNT1 AAA 0 A_CustomMissile("BigPlasmaParticleX", 42, 0, random (0, 360), 2, random (0, 360));
+			TNT1 A 0;
+			Stop;
+			
+				Death.GreenFire:
+			TNT1 A 0;
+			TNT1 A 0 A_XScream;
+			TNT1 A 0 A_NoBlocking();
+			TNT1 AAAA 0 A_CustomMissile("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160));
+			
+			TNT1 A 0 A_CustomMissile("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160));
+			
+			EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile("GreenFlameTrails", 50, 0, random (0, 360), 2, random (0, 360));
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			XBRN AAAA 2 BRIGHT A_SpawnItem("GreenFlare",0,43);
+			Stop;
+		
+			Death.Incinerate:
+			TNT1 A 0;
+			TNT1 A 0 A_Stop;
+			TNT1 A 0 A_Playsound("MELT");
+			TNT1 A 0 A_NoBlocking();
+			TNT1 AAAAAA 0 A_CustomMissile("ExplosionParticleHeavy", 32, 0, random (0, 360), 2, random (0, 360));
+			TNT1 AAAAAA 0 A_CustomMissile("ExplosionParticleVeryFast", 32, 0, random (0, 360), 2, random (0, 360));
+			TNT1 A 0 A_SpawnItemEx("ExplosionFlareSpawner",0,0,32,0,0,0,0,SXF_NOCHECKPOSITION,0);
+			TNT1 A 0 A_SpawnItemEx("TinyBurningPiece", random (-15, 15), random (-15, 15));
+			TNT1 A 0 A_SpawnItemEx("TinyBurningPiece2", random (-35, 35), random (-35, 35));
+			TNT1 A 0 A_SpawnItemEx("TinyBurningPiece3", random (-45, 45), random (-45, 35));
+			TNT1 AAAAAAAAAAAA 0 A_CustomMissile("Ashes1", 28, 0, random (0, 360), 2, random (0, 180));
+			TNT1 AAAAAAAAAAAA 0 A_CustomMissile("Ashes2", 40, 0, random (0, 360), 2, random (0, 180));
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),32,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			CB06 AAAAA 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 36, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),28,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			CB06 BBBBB 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),24,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			CB06 CCCCCC 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 28, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_Playsound("SZZLL", 3);
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),20,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			CB06 DDDDDD 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 20, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),16,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			CB06 EEEEEE 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 12, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),12,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			CB06 FFFFF 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 10, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			TNT1 A 0 A_SpawnItem("BarrelExplosionSmokeColumn");
+			CB06 GGGG 2 BRIGHT Light("IncinerationGlow");
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			CB06 FFGGFFGGFFGGFFGG 2 BRIGHT Light("IncinerationGlow") A_CustomMissile("PlasmaSmoke", 14, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			CB06 FFGGFFGGFFGGFFGG 2 Light("IncinerationGlow") A_CustomMissile("PlasmaSmoke", 14, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),8,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
+			CB06 FFGGFFGGFFHHHHHH 2;
+			CB06 IIIIIII 12 A_CustomMissile("PlasmaSmoke", 14, 0, random (0, 360), 2, random (0, 160));
+			CB06 I -1;
+			Stop;
+			
+		Death.fire:
+		Death.FireExplosion:
+		Death.burn:
+		Death.flames:
+			TNT1 A 0 A_JumpIfInTargetInventory("HasIncendiaryWeapon",1,"Death.Incinerate");
+			TNT1 A 0 A_Scream;
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 1 A_SpawnItemEx("BurningcHAINGUNGUY",0,0,0,0,0,0,0,288);
+			Stop;
+	
+	
+		Death.Throwable:
+			Goto Death;
+			
+		Death.Disintegrate:
+			TNT1 A 0 A_Scream;
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 1 A_SpawnItemEx("DisintegratedHuman",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION);
+			Stop;
+			
+		Death.Fatality:
+			TNT1 A 0 A_Pain;
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_JumpIfIntargetInventory("FistsSelected", 1, 1);
+			Goto Death.ExplosiveImpact;
+			TNT1 A 0 A_GiveToTarget("GoFatality", 1);
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_Jump(130,5);
+			TNT1 A 0 A_GiveToTarget("ComandoFatality", 1);
+			Stop;
+			TNT1 AAAAAAA 0;
+			TNT1 A 0 A_GiveToTarget("ComandoFatality2", 1);
+			TNT1 A 1;
+			TNT1 A 0;
+			Stop;
+			
+			Death.Eat:
+			TNT1 A 0;
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_GiveToTarget("ComandoFatality",1);
+			Stop;
+		
+		Raise:
+			CPOS N 5;
+			CPOS MLKJIH 5;
+			Goto See;
+		Crush:
+		Death.Stomp:
+			TNT1 AAAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile("Brutal_FlyingBloodTrail8", 0, 0, random (0, 360), 2, random (0, 360));
+			TNT1 AAAAAA 0 bright A_CustomMissile("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180));
+			TNT1 AAAAAA 0 bright A_CustomMissile("XDeath1", 5, 0, random (0, 360), 2, random (30, 180));
+			TNT1 AA 0 bright A_CustomMissile("XDeath2", 55, 0, random (0, 360), 2, random (30, 180));
+			TNT1 AA 0 bright A_CustomMissile("XDeath3", 55, 0, random (0, 360), 2, random (30, 180));
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_SpawnItem("CrushedRemains");
+			TNT1 A 1;
+			TNT1 A 1 A_XScream;
+			TNT1 A 1 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			Stop;
+	
+		Pain.KillMe:
+		Pain.Taunt:
+			TNT1 A 0;
+			Goto Missile;
+		Death.KillMe:
+		Death.Taunt:
+			TNT1 A 0 A_ChangeFlag("SOLID", 0);
+			TNT1 A 0 A_SpawnItem("Pb_Commando");
+			Stop;
+		
+		
+		Death.SSG:
+			TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AA 0 A_CustomMissile("XDeath4", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAAAAAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
+			TNT1 AA 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160));
+			CP06 AAAAAAA 2 A_CustomMissile("Brutal_LiquidBlood2", 44, 0, random (0, 60), 2, random (30, 60));
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			TNT1 A 0 A_Jump(129, "SSGDeathFallForward");
+			
+			CP06 BC 9 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40));
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			CP06 DDDDDDDDDDDDDDDDDDDDDDDDD 1 A_CustomMissile("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90));
+			TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP06D");
+			Stop;
+			
+		SSGDeathFallForward:
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			CP04 SSSSSSS 2 A_CustomMissile("Brutal_LiquidBlood2", 44, 0, random (0, 60), 2, random (30, 60));
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			CP04 UV 9 A_CustomMissile("Brutal_LiquidBlood", 30, 0, random (0, 360), 2, random (0, 40));
+			CP04 VVVVVVVVVVVVVVVVVVVVVV 1 A_CustomMissile("Brutal_LiquidBlood", 12, 0, random (0, 360), 2, random (0, 90));
+			TNT1 A 0 A_SpawnItem("DeadChaingunGuyCP04V");
+			Stop;
+			
+			
+		Death.SuperPunch:
+		Death.Blast:
+			TNT1 A 0 A_Jump(138, "DeathBlast2", "DeathBlast3");
+		DeathBlast1:
+			MPSD A 1 ;
+			MPSD A 1 A_FaceTarget();
+			TNT1 A 0 A_SpawnItem("BloodSplasher2");
+			TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));
+			//TNT1 A 0 A_CustomMissile("MeatDeath", 0, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
+			TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
+			TNT1 A 0 A_XScream;
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			MPSD AAAA 6 A_CustomMissile("Brutal_LiquidBlood2", 64, 0, random (0, 360), 2, random (30, 60));
+			MPSD BBBBCCCC 2 A_CustomMissile("Brutal_LiquidBlood2", 34, 0, random (0, 60), 2, random (30, 60));
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			MPSD DDDDDDDDDDDDDDDDDDDDD 6 A_CustomMissile("Brutal_LiquidBlood2", 16, 0, random (0, 60), 2, random (30, 60));
+			TNT1 A 0 A_SpawnItem("DeadChaingunguyMPSDD");
+			Stop;
+			
+		DeathBlast2:
+			CPOD T 1 ;
+			CPOD T 1 A_FaceTarget();
+			TNT1 A 0 A_SpawnItem("BloodSplasher2");
+			TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAAA 0 A_CustomMissile("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90));
+			TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
+			TNT1 A 0 A_XScream;
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CPOD TTTT 2 A_CustomMissile("Brutal_LiquidBlood2", 64, 0, random (0, 360), 2, random (30, 60));
+			CPOD UUUVVV 2 A_CustomMissile("Brutal_LiquidBlood2", 34, 0, random (0, 60), 2, random (30, 60));
+			CPOD WWW 2 A_CustomMissile("Brutal_LiquidBlood2", 14, 0, random (0, 360), 2, random (30, 60));
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			CPOD XXXXXXXXXXXXXXXX 4 A_CustomMissile("Brutal_LiquidBlood2", 16, 0, random (0, 60), 2, random (30, 60));
+			TNT1 A 0 A_SpawnItem("DeadChaingunguyCPODX");
+			Stop;
+			
+		DeathBlast3:
+			CP04 M 1 ;
+			CP04 M 1 A_FaceTarget();
+			TNT1 A 0 A_SpawnItem("BloodSplasher2");
+			TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAAA 0 A_CustomMissile("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90));
+			TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
+			TNT1 A 0 A_XScream;
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
+			CP04 NNNN 2 A_CustomMissile("Brutal_LiquidBlood2", 64, 0, random (0, 360), 2, random (30, 60));
+			CP04 OOOOOPPP 2 A_CustomMissile("Brutal_LiquidBlood2", 34, 0, random (0, 60), 2, random (30, 60));
+			CP04 QQQ 2 A_CustomMissile("Brutal_LiquidBlood2", 14, 0, random (0, 360), 2, random (30, 60));
+			TNT1 A 0 A_PlaySound("BODYF",6);
+			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
+			CP04 RRRRRRRRRRRRRRRRR 3 A_CustomMissile("Brutal_LiquidBlood2", 16, 0, random (0, 60), 2, random (30, 60));
+			TNT1 A 0 A_SpawnItem("DeadChaingunguyCP04R");
+			Stop;
+		
+		Death.Ice:
+		Death.IceExplosion:
+		Death.Freeze:
+		Death.Frost:
+			TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0);
+			TNT1 A 0 A_ChangeFlag("SOLID", 0);
+			TNT1 A 0 A_SpawnItem("FrozenCommando");
+			Stop;
+		
+		Death.Massacre:
+			Goto Death;
+		/*
 	   //If the monster is hit by the "Killme" damage (which is "exploded" by the captured marine), automatically start firing at the target.
 		Pain.KillMe:
 			TNT1 A 0;
@@ -2041,5 +2826,6 @@ Class PB_Chaingunguy : PB_Monster
 				A_GiveToTarget("ZombieManFatality", 1);
 			}
 			Stop;
+		*/
 		}
 }

--- a/zscript/Monsters/Chaingunner/Commando.zc
+++ b/zscript/Monsters/Chaingunner/Commando.zc
@@ -1120,12 +1120,10 @@ Class PB_Chaingunguy : PB_Monster
 			
 		Death.OriginalGibz:
 			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
-			TNT1 AAA 0 A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAA 0 {A_CustomMissile("MuchBlood", 1, 0, random (0, 360), 2, random (0, 160));A_CustomMissile("SmallBrainPiece", 35, 0, random (0, 360), 2, random (60, 120));}
 			TNT1 A 0 A_CustomMissile("XDeathChainArm", 35, 0, random (0, 360), 2, random (60, 120));
 			TNT1 A 0 A_CustomMissile("XDeath1", 35, 0, random (0, 360), 2, random (60, 120));
-			TNT1 AA 0 A_CustomMissile("XDeath2", 35, 0, random (0, 360), 2, random (60, 120));
-			TNT1 AA 0 A_CustomMissile("XDeath3", 35, 0, random (0, 360), 2, random (60, 120));
-			TNT1 AAA 0 A_CustomMissile("SmallBrainPiece", 35, 0, random (0, 360), 2, random (60, 120));
+			TNT1 AA 0 {A_CustomMissile("XDeath2", 35, 0, random (0, 360), 2, random (60, 120));A_CustomMissile("XDeath3", 35, 0, random (0, 360), 2, random (60, 120));}
 			TNT1 A 0 A_XScream;
 			TNT1 O 0 A_NoBlocking();
 			CPSC ABCDEFGH 4;
@@ -1184,9 +1182,8 @@ Class PB_Chaingunguy : PB_Monster
 		Death.HeadMinor:
 			TNT1 A 0;
 			TNT1 A 0 A_Playsound("MinorHeadshot", 0);
-			TNT1 AA 0 A_CustomMissile("BloodMistBig", 60, 0, random (0, 360), 2, random (30, 90));
+			TNT1 AA 0 {A_CustomMissile("BloodMistBig", 60, 0, random (0, 360), 2, random (30, 90));A_CustomMissile("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40));}
 			TNT1 AAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AA 0 A_CustomMissile("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40));
 			TNT1 A 0 A_CustomMissile("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
 			CPHM I 6;
@@ -1210,7 +1207,6 @@ Class PB_Chaingunguy : PB_Monster
 			Stop;
 			
 		Death.headExplode:
-			
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItem("ChaingunguyHeadExplode", 0, 50);
 			TNT1 A 0 A_Jump(132, "HeadExplode2", "HeadExplode3");
@@ -1305,7 +1301,7 @@ Class PB_Chaingunguy : PB_Monster
 			
 		
 		Death.ExplosiveImpact:
-		TNT1 A 0 A_ChangeFLag("NODROPOFF", 0);
+			TNT1 A 0 A_ChangeFLag("NODROPOFF", 0);
 			TNT1 A 0;
 			TNT1 A 0 ThrustThingZ(0,30,0,1);
 			TNT1 A 0 A_FaceTarget();
@@ -1321,14 +1317,12 @@ Class PB_Chaingunguy : PB_Monster
 			
 		BlownAwayLeft:	
 			TNT1 A 0 A_NoBlocking();
-			TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAAA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
 			TNT1 AA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
+			TNT1 AAAAAAAAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
+			TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
-			TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 ThrustThingZ(0,30,0,1);
 			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
 			CPDE A 1 A_Scream;
@@ -1347,14 +1341,11 @@ Class PB_Chaingunguy : PB_Monster
 			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_ChangeFlag("NOBLOCKMONST", 1);
 			TNT1 A 0 A_SpawnItemEx("XDeathChaingunguyHeadBeheaded", 50, 0, random (0, 360), 2, random (40, 90));
-			TNT1 AAAA 0 A_CustomMissile("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10));
-			TNT1 AAAA 0 A_CustomMissile("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAAA 0 {A_CustomMissile("SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), 2, random (-10, 10));A_CustomMissile("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160));}
+			TNT1 AA 0 {A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));}
 			TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AA 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_CustomMissile("XDeath3", 40, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
 			TNT1 AAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
 			TNT1 A 0 ThrustThingZ(0,30,0,1);
 			TNT1 A 0 A_XScream;
@@ -1362,7 +1353,7 @@ Class PB_Chaingunguy : PB_Monster
 			4N02 ABCDCBA 3 A_CustomMissile("Brutal_FlyingBlood", 0, 0, 0, 2, 90);
 			TNT1 A 0 A_CheckFloor("Land8472");
 			4N02 ABCDCBABCDCBA 5 A_CheckFloor("Land8472");
-			Land8472:
+		Land8472:
 			SXS2 N 0;
 			TNT1 A 0 A_Stop;
 			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
@@ -1373,16 +1364,13 @@ Class PB_Chaingunguy : PB_Monster
 		Death.ExtremePunches:
 		Death.Landmine:
 		Death.LandMine2:
-		TNT1 A 0 A_NoBlocking();
-		TNT1 A 0 ThrustThingZ(0,40,0,1);
-		TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
-		TNT1 AA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
-		TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
-		TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
-		TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160));
-		TNT1 AA 0 A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));
-		TNT1 AAAAAA 0 A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));
-		TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_NoBlocking();
+			TNT1 A 0 ThrustThingZ(0,40,0,1);
+			TNT1 AA 0 {A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));A_CustomMissile("XDeath1", 40, 0, random (0, 360), 2, random (0, 160));}
+			TNT1 AAAAAA 0 {A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));A_CustomMissile("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90));}
+			TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
+			TNT1 A 0 A_CustomMissile("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160));
+			TNT1 AAAAAAAAAAA 0 A_CustomMissile("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
 			CPDE A 1 A_Scream;
 			CPDE A 1;
@@ -1406,13 +1394,14 @@ Class PB_Chaingunguy : PB_Monster
 			TNT1 A 0;
 			TNT1 A 0 A_Stop;
 			TNT1 A 0 A_PlaySound("plasmaflesh");
-			TNT1 AAAAAAAAA 0 A_CustomMissile("Ashes1", 32, 0, random (0, 360), 2, random (0, 180));
-			TNT1 AAAAAAAAA 0 A_CustomMissile("Ashes2", 32, 0, random (0, 360), 2, random (0, 180));
+			TNT1 AAAAAAAAA 0 {A_CustomMissile("Ashes1", 32, 0, random (0, 360), 2, random (0, 180));A_CustomMissile("Ashes2", 32, 0, random (0, 360), 2, random (0, 180));}
 			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1Blue",random(-2,2),random(-2,2),18,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
-			TNT1 AAAA 0 A_CustomMissile("BluePlasmaFireNonStatic", 42, 0, random (0, 360), 2, random (0, 180));
-			TNT1 AAAA 0 A_CustomMissile("BloodMistBig", 32, 0, random (0, 360), 2, random (0, 180));
-			TNT1 AAAAAA 0 A_CustomMissile("SuperGoreMistSmall", 32, 0, random (0, 360), 2, random (10, 90));
-			TNT1 AAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (0, 360), 2, random (0, 180));
+			TNT1 AAAA 0 {A_CustomMissile("BluePlasmaFireNonStatic", 42, 0, random (0, 360), 2, random (0, 180));A_CustomMissile("BloodMistBig", 32, 0, random (0, 360), 2, random (0, 180));}
+			TNT1 AAA 0 {
+				A_CustomMissile("SuperGoreMistSmall", 32, 0, random (0, 360), 2, random (10, 90));
+				A_CustomMissile("SuperGoreMistSmall", 32, 0, random (0, 360), 2, random (10, 90));
+				A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (0, 360), 2, random (0, 180));
+			}
 			PBR1 B 6 A_NoBlocking();
 			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1Blue",random(-2,2),random(-2,2),10,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
 			TNT1 A 0 A_SpawnItemEx("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);
@@ -1472,14 +1461,18 @@ Class PB_Chaingunguy : PB_Monster
 			TNT1 A 0 A_Stop;
 			TNT1 A 0 A_Playsound("MELT");
 			TNT1 A 0 A_NoBlocking();
-			TNT1 AAAAAA 0 A_CustomMissile("ExplosionParticleHeavy", 32, 0, random (0, 360), 2, random (0, 360));
-			TNT1 AAAAAA 0 A_CustomMissile("ExplosionParticleVeryFast", 32, 0, random (0, 360), 2, random (0, 360));
+			TNT1 AAAAAA 0 {
+				A_CustomMissile("ExplosionParticleHeavy", 32, 0, random (0, 360), 2, random (0, 360));
+				A_CustomMissile("ExplosionParticleVeryFast", 32, 0, random (0, 360), 2, random (0, 360));
+			}
 			TNT1 A 0 A_SpawnItemEx("ExplosionFlareSpawner",0,0,32,0,0,0,0,SXF_NOCHECKPOSITION,0);
 			TNT1 A 0 A_SpawnItemEx("TinyBurningPiece", random (-15, 15), random (-15, 15));
 			TNT1 A 0 A_SpawnItemEx("TinyBurningPiece2", random (-35, 35), random (-35, 35));
 			TNT1 A 0 A_SpawnItemEx("TinyBurningPiece3", random (-45, 45), random (-45, 35));
-			TNT1 AAAAAAAAAAAA 0 A_CustomMissile("Ashes1", 28, 0, random (0, 360), 2, random (0, 180));
-			TNT1 AAAAAAAAAAAA 0 A_CustomMissile("Ashes2", 40, 0, random (0, 360), 2, random (0, 180));
+			TNT1 AAAAAAAAAAAA 0 {
+				A_CustomMissile("Ashes1", 28, 0, random (0, 360), 2, random (0, 180));
+				A_CustomMissile("Ashes2", 40, 0, random (0, 360), 2, random (0, 180));
+			}
 			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),32,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
 			CB06 AAAAA 1 BRIGHT Light("IncinerationGlow") A_CustomMissile("BurningEmberParticlesFloating_Bigger", 36, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_SpawnItemEx("RealisticFireSparks1",random(-2,2),random(-2,2),28,0,0,0,0,SXF_NOCHECKPOSITION  ,0);
@@ -1535,13 +1528,10 @@ Class PB_Chaingunguy : PB_Monster
 			Goto Death.ExplosiveImpact;
 			TNT1 A 0 A_GiveToTarget("GoFatality", 1);
 			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
-			TNT1 A 0 A_Jump(130,5);
+			TNT1 A 0 A_Jump(130,2);
 			TNT1 A 0 A_GiveToTarget("ComandoFatality", 1);
 			Stop;
-			TNT1 AAAAAAA 0;
-			TNT1 A 0 A_GiveToTarget("ComandoFatality2", 1);
-			TNT1 A 1;
-			TNT1 A 0;
+			TNT1 A 1 A_GiveToTarget("ComandoFatality2", 1);
 			Stop;
 			
 			Death.Eat:
@@ -1558,10 +1548,8 @@ Class PB_Chaingunguy : PB_Monster
 		Crush:
 		Death.Stomp:
 			TNT1 AAAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile("Brutal_FlyingBloodTrail8", 0, 0, random (0, 360), 2, random (0, 360));
-			TNT1 AAAAAA 0 bright A_CustomMissile("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180));
-			TNT1 AAAAAA 0 bright A_CustomMissile("XDeath1", 5, 0, random (0, 360), 2, random (30, 180));
-			TNT1 AA 0 bright A_CustomMissile("XDeath2", 55, 0, random (0, 360), 2, random (30, 180));
-			TNT1 AA 0 bright A_CustomMissile("XDeath3", 55, 0, random (0, 360), 2, random (30, 180));
+			TNT1 AAAAAA 0 {A_CustomMissile("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180));A_CustomMissile("XDeath1", 5, 0, random (0, 360), 2, random (30, 180));}
+			TNT1 AA 0 {A_CustomMissile("XDeath2", 55, 0, random (0, 360), 2, random (30, 180));A_CustomMissile("XDeath3", 55, 0, random (0, 360), 2, random (30, 180));}
 			TNT1 A 0 A_SpawnItem("GrowingBloodPool");
 			TNT1 A 0 A_SpawnItem("CrushedRemains");
 			TNT1 A 1;
@@ -1582,19 +1570,22 @@ Class PB_Chaingunguy : PB_Monster
 		
 		
 		Death.SSG:
-			TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAA 0 {A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));}
 			TNT1 AAAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
 			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40));
 			TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AA 0 A_CustomMissile("XDeath4", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AA 0 {
+				A_CustomMissile("XDeath4", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
+			}
+			TNT1 AAAA 0 {
+				A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			}
 			TNT1 AAAAAAAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
-			TNT1 AA 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160));
 			CP06 AAAAAAA 2 A_CustomMissile("Brutal_LiquidBlood2", 44, 0, random (0, 60), 2, random (30, 60));
 			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
@@ -1624,21 +1615,25 @@ Class PB_Chaingunguy : PB_Monster
 			MPSD A 1 ;
 			MPSD A 1 A_FaceTarget();
 			TNT1 A 0 A_SpawnItem("BloodSplasher2");
-			TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));
 			//TNT1 A 0 A_CustomMissile("MeatDeath", 0, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
 			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40));
 			TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
+			TNT1 AAAA 0 {
+				A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			}
+			TNT1 AAA 0 {
+				A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
+				A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
+				A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
+			}
 			TNT1 A 0 A_CustomMissile("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160));
 			TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
 			TNT1 A 0 A_XScream;
 			TNT1 A 0 A_NoBlocking();
 			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
@@ -1654,19 +1649,22 @@ Class PB_Chaingunguy : PB_Monster
 			CPOD T 1 ;
 			CPOD T 1 A_FaceTarget();
 			TNT1 A 0 A_SpawnItem("BloodSplasher2");
-			TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAA 0 {A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));}
+			TNT1 AAAA 0 {
+				A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			}
 			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40));
 			TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAAA 0 A_CustomMissile("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90));
+			TNT1 AAAAA 0 {
+				A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
+				A_CustomMissile("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90));
+			}
 			TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
 			TNT1 A 0 A_XScream;
 			TNT1 A 0 A_NoBlocking();
 			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
@@ -1683,19 +1681,19 @@ Class PB_Chaingunguy : PB_Monster
 			CP04 M 1 ;
 			CP04 M 1 A_FaceTarget();
 			TNT1 A 0 A_SpawnItem("BloodSplasher2");
-			TNT1 AAA 0 bright A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
+			TNT1 AAA 0 {A_CustomMissile("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40));A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));}
 			TNT1 A 0 A_CustomMissile("XDeath2", 32, 0, random (170, 190), 2, random (0, 40));
 			TNT1 A 0 A_CustomMissile("XDeath3", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAAA 0 A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAA 0 A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
-			TNT1 AAAAA 0 A_CustomMissile("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90));
+			TNT1 AAAA 0 {
+				A_CustomMissile("XDeath1", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40));
+				A_CustomMissile("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40));
+			}
+			TNT1 AAAAA 0 {A_CustomMissile("Instestin", 32, 0, random (0, 360), 2, random (0, 40));A_CustomMissile("BloodMistBig", 50, 0, random (0, 360), 2, random (30, 90));}
 			TNT1 A 0 A_CustomMissile("XDeathChaingunguyHead", 62, 0, random (0, 360), 2, random (0, 160));
-			TNT1 AAA 0 A_CustomMissile("BloodMistBig", 40, 0, random (0, 360), 2, random (30, 90));
 			TNT1 A 0 A_XScream;
 			TNT1 A 0 A_NoBlocking();
 			TNT1 A 0 A_SpawnItem("DropedMinigun", 0, 5,0);
@@ -1720,7 +1718,7 @@ Class PB_Chaingunguy : PB_Monster
 		Death.Massacre:
 			Goto Death;
 		/*
-	   //If the monster is hit by the "Killme" damage (which is "exploded" by the captured marine), automatically start firing at the target.
+		//If the monster is hit by the "Killme" damage (which is "exploded" by the captured marine), automatically start firing at the target.
 		Pain.KillMe:
 			TNT1 A 0;
 			Goto Missile;

--- a/zscript/PBHandler.zc
+++ b/zscript/PBHandler.zc
@@ -474,7 +474,7 @@ class PB_EventHandler : EventHandler
 			//	Stealth Monsters
 			//
 			case 'StealthArachnotron':		e.replacement = 'PBStealthArachnotronSpawner';	break;
-			case 'StealthArchvile':			e.replacement = 'PBArchVileSpawner';	break;
+			case 'StealthArchvile':			e.replacement = 'PBStealthArchVileSpawner';	break;
 			case 'StealthBaron':			e.replacement = 'PBStealthBOHSpawner';	break;
 			case 'StealthCacodemon':		e.replacement = 'PBStealthCacoDemonSpawner';	break;
 			case 'StealthChaingunGuy':		e.replacement = 'PBStealthChainGunGuySpawner';	break;

--- a/zscript/PBHandler.zc
+++ b/zscript/PBHandler.zc
@@ -474,7 +474,7 @@ class PB_EventHandler : EventHandler
 			//	Stealth Monsters
 			//
 			case 'StealthArachnotron':		e.replacement = 'PBStealthArachnotronSpawner';	break;
-			case 'StealthArchvile':			e.replacement = 'PBStealthArachnotronSpawner';	break;
+			case 'StealthArchvile':			e.replacement = 'PBArchVileSpawner';	break;
 			case 'StealthBaron':			e.replacement = 'PBStealthBOHSpawner';	break;
 			case 'StealthCacodemon':		e.replacement = 'PBStealthCacoDemonSpawner';	break;
 			case 'StealthChaingunGuy':		e.replacement = 'PBStealthChainGunGuySpawner';	break;

--- a/zscript/PBHandler.zc
+++ b/zscript/PBHandler.zc
@@ -469,6 +469,22 @@ class PB_EventHandler : EventHandler
 			case 'Cyberdemon':				e.replacement = 'PBCyberDemonSpawner';			break;
 			case 'SpiderMastermind':		e.replacement = 'PBSpiderMasterMindSpawner';	break;
 			case 'WolfensteinSS':			e.replacement = 'EvilNaziSpawner';	WSuSinMap = true;	break;
+
+			//
+			//	Stealth Monsters
+			//
+			case 'StealthArachnotron':		e.replacement = 'PBStealthArachnotronSpawner';	break;
+			case 'StealthArchvile':			e.replacement = 'PBStealthArachnotronSpawner';	break;
+			case 'StealthBaron':			e.replacement = 'PBStealthBOHSpawner';	break;
+			case 'StealthCacodemon':		e.replacement = 'PBStealthCacoDemonSpawner';	break;
+			case 'StealthChaingunGuy':		e.replacement = 'PBStealthChainGunGuySpawner';	break;
+			case 'StealthDemon':			e.replacement = 'PBStealthPinkySpawner';	break;
+			case 'StealthDoomImp':			e.replacement = 'PBStealthImpSpawner';	break;
+			case 'StealthFatso':			e.replacement = 'PBStealthMancubusSpawner';	break;
+			case 'StealthHellKnight':		e.replacement = 'PBStealthHKSpawner';	break;
+			case 'StealthRevenant':			e.replacement = 'PBStealthRevSpawner';	break;
+			case 'StealthShotgunGuy':		e.replacement = 'PBStealthShotgunGuySpawner';	break;
+			case 'StealthZombieMan':		e.replacement = 'PBStealthZombieManSpawner';	break;
 			
 		}
 	}

--- a/zscript/Spawner/Ammo/PB_CellPackSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_CellPackSpawner.zc
@@ -1,7 +1,7 @@
 Class PBCellPackSpawner : PB_SpawnerBase //replaces CellPack
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	 //Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -37,7 +37,7 @@ Class PBCellPackSpawner : PB_SpawnerBase //replaces CellPack
 			TNT1 A 0 A_SpawnItemEx("PB_CellPackSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Ammo/PB_CellSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_CellSpawner.zc
@@ -1,7 +1,7 @@
 Class PBCellSpawner : PB_SpawnerBase //replaces Cell
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	 //Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBCellSpawner : PB_SpawnerBase //replaces Cell
 			TNT1 A 0 A_SpawnItemEx("PB_CellSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_CellSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_CellSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+		Stop;
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_CellSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Ammo/PB_MagBoxSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_MagBoxSpawner.zc
@@ -1,7 +1,7 @@
 Class PBClipBoxSpawner : PB_SpawnerBase //replaces ClipBox
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	 //Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBClipBoxSpawner : PB_SpawnerBase //replaces ClipBox
 			TNT1 A 0 A_SpawnItemEx("PB_ClipBoxSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ClipBoxSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ClipBoxSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+		Stop;
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ClipBoxSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Ammo/PB_MagSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_MagSpawner.zc
@@ -1,7 +1,7 @@
 Class PBClipSpawner : PB_SpawnerBase //replaces Clip
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	 //Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBClipSpawner : PB_SpawnerBase //replaces Clip
 			TNT1 A 0 A_SpawnItemEx("PB_ClipSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ClipSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ClipSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+		Stop;
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ClipSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Ammo/PB_PackSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_PackSpawner.zc
@@ -1,7 +1,7 @@
 Class PBBackpackSpawner : PB_SpawnerBase //replaces Backpack
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	 //Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -29,12 +29,12 @@ Class PBBackpackSpawner : PB_SpawnerBase //replaces Backpack
 			TNT1 A 0 A_SpawnItemEx("PB_PackSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_PackSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
 		RandomJumpT2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_PackSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier1:
@@ -46,7 +46,7 @@ Class PBBackpackSpawner : PB_SpawnerBase //replaces Backpack
 			TNT1 A 1;
 			stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Ammo/PB_RocketSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_RocketSpawner.zc
@@ -1,7 +1,7 @@
 Class PBRocketSpawner : PB_SpawnerBase //replaces RocketAmmo
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	 //Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBRocketSpawner : PB_SpawnerBase //replaces RocketAmmo
 			TNT1 A 0 A_SpawnItemEx("PB_RocketSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_RocketSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_RocketSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+		Stop;
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_RocketSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Ammo/PB_RocketboxSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_RocketboxSpawner.zc
@@ -1,7 +1,7 @@
 Class PBRocketBoxSpawner : PB_SpawnerBase //replaces RocketBox
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	 //Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,11 +25,11 @@ Class PBRocketBoxSpawner : PB_SpawnerBase //replaces RocketBox
 			TNT1 A 0 A_SpawnItemEx("PB_RocketBoxSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_RocketBoxSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_RocketBoxSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier1:
@@ -37,7 +37,7 @@ Class PBRocketBoxSpawner : PB_SpawnerBase //replaces RocketBox
 			TNT1 A 0 A_SpawnItemEx("PB_RocketBoxSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Ammo/PB_ShellSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_ShellSpawner.zc
@@ -1,7 +1,7 @@
 Class PBShellSpawner : PB_SpawnerBase //replaces Shell
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	 //Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBShellSpawner : PB_SpawnerBase //replaces Shell
 			TNT1 A 0 A_SpawnItemEx("PB_ShellSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ShellSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ShellSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+		Stop;
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ShellSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Ammo/PB_ShellboxSpawner.zc
+++ b/zscript/Spawner/Ammo/PB_ShellboxSpawner.zc
@@ -1,7 +1,7 @@
 Class PBShellboxSpawner : PB_SpawnerBase //replaces Shellbox
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	 //Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBShellboxSpawner : PB_SpawnerBase //replaces Shellbox
 			TNT1 A 0 A_SpawnItemEx("PB_ShellboxSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ShellboxSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ShellboxSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+		Stop;
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ShellboxSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Items/PB_APBonusSpawner.zc
+++ b/zscript/Spawner/Items/PB_APBonusSpawner.zc
@@ -1,7 +1,7 @@
 Class PBAPBonusSpawner : PB_SpawnerBase //replaces ArmorBonus
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	//Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBAPBonusSpawner : PB_SpawnerBase //replaces ArmorBonus
 			TNT1 A 0 A_SpawnItemEx("PB_APBonusSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_APBonusSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_APBonusSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+			Stop;
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_APBonusSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Items/PB_BlueSpawner.zc
+++ b/zscript/Spawner/Items/PB_BlueSpawner.zc
@@ -1,7 +1,7 @@
 Class PBBlueSpawner : PB_SpawnerBase //replaces BlueArmor
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	//Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBBlueSpawner : PB_SpawnerBase //replaces BlueArmor
 			TNT1 A 0 A_SpawnItemEx("PB_BlueSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_BlueSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_BlueSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop; //Fix the duplicate copy spawn glitch
+			Stop; //Fix the duplicate copy spawn glitch
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_BlueSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Items/PB_GreenSpawner.zc
+++ b/zscript/Spawner/Items/PB_GreenSpawner.zc
@@ -1,7 +1,7 @@
 Class PBGreenSpawner : PB_SpawnerBase //replaces GreenArmor
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	//Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBGreenSpawner : PB_SpawnerBase //replaces GreenArmor
 			TNT1 A 0 A_SpawnItemEx("PB_GreenSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_GreenSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_GreenSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+			Stop;
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_GreenSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Items/PB_HPBonusSpawner.zc
+++ b/zscript/Spawner/Items/PB_HPBonusSpawner.zc
@@ -1,7 +1,7 @@
 Class PBHPBonusSpawner : PB_SpawnerBase //replaces HealthBonus
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	//Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,19 +25,19 @@ Class PBHPBonusSpawner : PB_SpawnerBase //replaces HealthBonus
 			TNT1 A 0 A_SpawnItemEx("PB_HPBonusSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_HPBonusSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_HPBonusSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+			Stop;
 		Tier1:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_HPBonusSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Items/PB_MedkitSpawner.zc
+++ b/zscript/Spawner/Items/PB_MedkitSpawner.zc
@@ -1,7 +1,7 @@
 Class PBMedikitSpawner : PB_SpawnerBase //replaces Medikit
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	//Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,21 +25,21 @@ Class PBMedikitSpawner : PB_SpawnerBase //replaces Medikit
 			TNT1 A 0 A_SpawnItemEx("PB_MediSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_MediSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
 		RandomJumpT2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_MediSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
-      Stop;
+			Stop;
 		Tier1:
 		Spawn_Shotgun:
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_MediSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Items/PB_PowerUpsSpawner.zs
+++ b/zscript/Spawner/Items/PB_PowerUpsSpawner.zs
@@ -26,7 +26,7 @@ Class PB_InvulSpawner : PB_SpawnerBase //replaces invulnerabilitysphere
 			TNT1 A 0 PB_SpawnerSpawn("PB_InvulSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -98,7 +98,7 @@ Class PB_RadSuitSpawner : PB_SpawnerBase //replaces radsuit
 			TNT1 A 0 PB_SpawnerSpawn("PB_RadSuitSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -170,7 +170,7 @@ Class PB_BlurSpawner : PB_SpawnerBase //replaces blursphere
 			TNT1 A 0 PB_SpawnerSpawn("PB_BlurSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -240,7 +240,7 @@ Class PB_InfraRedSpawner : PB_SpawnerBase //replaces infrared
 			TNT1 A 0 PB_SpawnerSpawn("PB_InfraRedSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -311,7 +311,7 @@ Class PB_SoulSphereSpawner : PB_SpawnerBase //replaces soulsphere
 			TNT1 A 0 PB_SpawnerSpawn("PB_SoulSphereSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -381,7 +381,7 @@ Class PB_MegaSpawner : PB_SpawnerBase //replaces megasphere
 			TNT1 A 0 PB_SpawnerSpawn("PB_MegaSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -451,7 +451,7 @@ Class PB_BerserkSpawner : PB_SpawnerBase //replaces Berserk
 			TNT1 A 0 PB_SpawnerSpawn("PB_BerserkSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -521,7 +521,7 @@ Class PB_AllMapSpawner : PB_SpawnerBase //replaces AllMap
 			TNT1 A 0 PB_SpawnerSpawn("PB_AllMapSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -591,7 +591,7 @@ Class PB_DoomSpawner : PB_SpawnerBase
 			TNT1 A 0 PB_SpawnerSpawn("PB_DoomSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -661,7 +661,7 @@ Class PB_HasteSpawner : PB_SpawnerBase
 			TNT1 A 0 PB_SpawnerSpawn("PB_HasteSpawnerT1");
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Items/PB_StimSpawner.zc
+++ b/zscript/Spawner/Items/PB_StimSpawner.zc
@@ -1,7 +1,7 @@
 Class PBStimSpawner : PB_SpawnerBase //replaces Stimpack
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	//Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -37,7 +37,7 @@ Class PBStimSpawner : PB_SpawnerBase //replaces Stimpack
 			TNT1 A 0 A_SpawnItemEx("PB_StimSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Monsters/PBMastermindSpawner.zc
+++ b/zscript/Spawner/Monsters/PBMastermindSpawner.zc
@@ -35,11 +35,11 @@ Class PBSpiderMasterMindSpawner : PB_SpawnerBase //replaces SpiderMastermind
 			Stop;
 		Tier1:
 		SpawnMastermind:
-            TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 PB_SpawnerSpawn("PB_MasterSpawner_T1");//,0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS | 288,0,tid);
-		    Stop;
+			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Monsters/PBSpectreSpawner.zc
+++ b/zscript/Spawner/Monsters/PBSpectreSpawner.zc
@@ -38,7 +38,7 @@ Class PBSpectreSpawner : PB_SpawnerBase //replaces Spectre
 			TNT1 A 0 PB_SpawnerSpawn("PB_SpectreSpawner_T1");//,0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS | 288,0,tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Monsters/PBStealthMonsterSpawner.zc
+++ b/zscript/Spawner/Monsters/PBStealthMonsterSpawner.zc
@@ -1,0 +1,18 @@
+Class PBStealthArachnotronSpawner : PBArachnotronSpawner {default{+STEALTH}}
+Class PBStealthArchVileSpawner : PBArchVileSpawner {default{+STEALTH}}
+Class PBStealthBOHSpawner : PBBOHSpawner {default{+STEALTH}}
+Class PBStealthCacoDemonSpawner : PBCacoDemonSpawner {default{+STEALTH}}
+Class PBStealthChainGunGuySpawner : PBChainGunGuySpawner {default{+STEALTH}}
+Class PBStealthCyberDemonSpawner : PBCyberDemonSpawner {default{+STEALTH}}
+Class PBStealthHKSpawner : PBHKSpawner {default{+STEALTH}}
+Class PBStealthImpSpawner : PBImpSpawner {default{+STEALTH}}
+Class PBStealthLSSpawner :PBLSSpawner {default{+STEALTH}}
+Class PBStealthMancubusSpawner : PBMancubusSpawner {default{+STEALTH}}
+Class PBStealthSpiderMasterMindSpawner : PBSpiderMasterMindSpawner {default{+STEALTH}}
+Class PBStealthEvilNaziSpawner : EvilNaziSpawner {default{+STEALTH}}
+Class PBStealthPESpawner : PBPESpawner {default{+STEALTH}}
+Class PBStealthPinkySpawner : PBPinkySpawner {default{+STEALTH}}
+Class PBStealthRevSpawner : PBRevSpawner {default{+STEALTH}}
+Class PBStealthShotgunGuySpawner : PBShotgunGuySpawner {default{+STEALTH}}
+Class PBStealthSpectreSpawner : PBSpectreSpawner {default{+STEALTH}}
+Class PBStealthZombieManSpawner : PBZombieManSpawner {default{+STEALTH}}

--- a/zscript/Spawner/Monsters/PBZombiemanSpawner.zc
+++ b/zscript/Spawner/Monsters/PBZombiemanSpawner.zc
@@ -37,7 +37,7 @@ Class PBZombieManSpawner : PB_SpawnerBase //replaces ZombieMan
 			Stop;
 		
 		Death:
-		    TNT1 A 0;
+			 TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/PB_SpawnerBase.zc
+++ b/zscript/Spawner/PB_SpawnerBase.zc
@@ -117,29 +117,29 @@ Class PB_SpawnerBase : Actor
 			case Tier_4:		st = "Tier4";			break;
 			
 			case Tier_Tiered:
-				if(Count <= lvtp) 						{st = "Tier1";}
-				else if(Count <= (lvtp * 2)) 			{st = "Tier2";}
-				else if(Count <= (lvtp * 3)) 			{st = "Tier3";}
-				else if(Count > (lvtp * 3)) 			{st = "Tier4";}
+				if(Count <= lvtp)						{st = "Tier1";}
+				else if(Count <= (lvtp * 2))			{st = "Tier2";}
+				else if(Count <= (lvtp * 3))			{st = "Tier3";}
+				else if(Count > (lvtp * 3))				{st = "Tier4";}
 				break;
 				
 			case Tier_Dynamic:
-				if(Count < (lvtp)) 						{st = "Tier1";}
-				else if(Count == (lvtp)) 				{st = "T2Random64";}
-				else if(Count == ((lvtp) + 1)) 			{st = "T2Random128";}
-				else if(Count == ((lvtp) + 2)) 			{st = "T2Random192";}
+				if(Count < (lvtp))						{st = "Tier1";}
+				else if(Count == (lvtp))				{st = "T2Random64";}
+				else if(Count == ((lvtp) + 1))			{st = "T2Random128";}
+				else if(Count == ((lvtp) + 2))			{st = "T2Random192";}
 					
-				else if(Count < ((lvtp) * 2)) 			{st = "Tier2";}
-				else if(Count == ((lvtp) * 2)) 			{st = "T3Random64";}
-				else if(Count == (((lvtp) * 2) + 1)) 	{st = "T3Random128";}
-				else if(Count == (((lvtp) * 2) + 2)) 	{st = "T3Random192";}
+				else if(Count < ((lvtp) * 2))			{st = "Tier2";}
+				else if(Count == ((lvtp) * 2))			{st = "T3Random64";}
+				else if(Count == (((lvtp) * 2) + 1))	{st = "T3Random128";}
+				else if(Count == (((lvtp) * 2) + 2))	{st = "T3Random192";}
 					
-				else if(Count < ((lvtp) * 3)) 			{st = "Tier3";}
-				else if(Count == ((lvtp) * 3)) 			{st = "T4Random64";}
-				else if(Count == (((lvtp) * 3) + 1)) 	{st = "T4Random128";}
-				else if(Count == (((lvtp) * 3) + 2)) 	{st = "T4Random192";}
+				else if(Count < ((lvtp) * 3))			{st = "Tier3";}
+				else if(Count == ((lvtp) * 3))			{st = "T4Random64";}
+				else if(Count == (((lvtp) * 3) + 1))	{st = "T4Random128";}
+				else if(Count == (((lvtp) * 3) + 2))	{st = "T4Random192";}
 				
-				else if(Count > (((lvtp) * 3) + 2)) 	{st = "Tier4";}
+				else if(Count > (((lvtp) * 3) + 2))		{st = "Tier4";}
 				break;
 		}
 		
@@ -165,15 +165,15 @@ Class PB_SpawnerBase : Actor
 				newmobj.Angle		= Angle;
 				newmobj.Pitch		= Pitch;
 				newmobj.Roll		= Roll;
-				newmobj.SpawnPoint = SpawnPoint;
-				newmobj.special    = special;
-				newmobj.args[0]    = args[0];
-				newmobj.args[1]    = args[1];
-				newmobj.args[2]    = args[2];
-				newmobj.args[3]    = args[3];
-				newmobj.args[4]    = args[4];
-				newmobj.special1   = special1;
-				newmobj.special2   = special2;
+				newmobj.SpawnPoint	= SpawnPoint;
+				newmobj.special		= special;
+				newmobj.args[0]		= args[0];
+				newmobj.args[1]		= args[1];
+				newmobj.args[2]		= args[2];
+				newmobj.args[3]		= args[3];
+				newmobj.args[4]		= args[4];
+				newmobj.special1	= special1;
+				newmobj.special2	= special2;
 				newmobj.SpawnFlags = SpawnFlags & ~(MTF_SECRET|MTF_DORMANT);	// MTF_SECRET needs special treatment to avoid incrementing the secret counter twice. It had already been processed for the spawner itself.
 				SpawnFlags &= ~MTF_DORMANT; //we dont want the spawner to be deactivated
 				newmobj.HandleSpawnFlags();	
@@ -254,34 +254,34 @@ Class PB_SpawnerBase : Actor
 			TNT1 A 1;
 			stop;
 		T2Random64:
-		    TNT1 A 0 A_Jump(64,"Tier2");
-		    TNT1 A 0 A_Jump(256,"Tier1");
+			TNT1 A 0 A_Jump(64,"Tier2");
+			TNT1 A 0 A_Jump(256,"Tier1");
 		T2Random128:
-		    TNT1 A 0 A_Jump(128,"Tier2");
+			TNT1 A 0 A_Jump(128,"Tier2");
 			TNT1 A 0 A_Jump(256,"Tier1");
 		T2Random192:
-		    TNT1 A 0 A_Jump(192,"Tier2");
+			TNT1 A 0 A_Jump(192,"Tier2");
 			TNT1 A 0 A_Jump(256,"Tier1");
 		T3Random64:
-		    TNT1 A 0 A_Jump(64,"Tier3");
+			TNT1 A 0 A_Jump(64,"Tier3");
 			TNT1 A 0 A_Jump(256,"Tier2");
 		T3Random128:
-		    TNT1 A 0 A_Jump(128,"Tier3");
+			TNT1 A 0 A_Jump(128,"Tier3");
 			TNT1 A 0 A_Jump(256,"Tier2");
 		T3Random192:
-		    TNT1 A 0 A_Jump(192,"Tier3");
+			TNT1 A 0 A_Jump(192,"Tier3");
 			TNT1 A 0 A_Jump(256,"Tier2");
 		T4Random64:
-		    TNT1 A 0 A_Jump(64,"Tier4");
+			TNT1 A 0 A_Jump(64,"Tier4");
 			TNT1 A 0 A_Jump(256,"Tier3");
 		T4Random128:
-		    TNT1 A 0 A_Jump(128,"Tier4");
+			TNT1 A 0 A_Jump(128,"Tier4");
 			TNT1 A 0 A_Jump(256,"Tier3");
 		T4Random192:
-		    TNT1 A 0 A_Jump(192,"Tier4");
+			TNT1 A 0 A_Jump(192,"Tier4");
 			TNT1 A 0 A_Jump(256,"Tier3");
 		CHAOTICRANDOM:
-		    TNT1 A 0 A_Jump(256, "Tier4","Tier3", "Tier2", "Tier1");
+			TNT1 A 0 A_Jump(256, "Tier4","Tier3", "Tier2", "Tier1");
 			Stop;
 		Tier4:
 		Tier3:
@@ -299,27 +299,27 @@ CLASS droppedbase:CustomInventory
 {
 default
 {
-    Radius 8;
-    Height 10;
-    Scale 0.5;
-    gravity 1;
+	Radius 8;
+	Height 10;
+	Scale 0.5;
+	gravity 1;
 	Decal "none";
-    //+MOVEWITHSECTOR;
-    +DONTGIB;
-    //+NOTELEPORT;
+	//+MOVEWITHSECTOR;
+	+DONTGIB;
+	//+NOTELEPORT;
 	+FLOORCLIP;
 	Inventory.PickupMessage "";
-    Inventory.PickupSound "";
+	Inventory.PickupSound "";
 	+NOTIMEFREEZE;
 }
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		//TNT1 AA 1
 		TNT1 AA 0;
 	Spawn2:	
-	    TNT1 A 0;
-        Stop;
+		TNT1 A 0;
+		Stop;
 	Pickup:
 		TNT1 A 0;
 		Stop;
@@ -327,9 +327,9 @@ default
 		TNT1 A 0;
 		Stop;
 	Death:
-        TNT1 A 0;
-        Stop;
-    }
+		TNT1 A 0;
+		Stop;
+	}
 }
 
 class PBSpawnInfo play

--- a/zscript/Spawner/PB_SpawnerBase.zc
+++ b/zscript/Spawner/PB_SpawnerBase.zc
@@ -161,7 +161,7 @@ Class PB_SpawnerBase : Actor
 			if (newmobj != null)
 			{
 				// copy everything relevant
-				newmobj.SpawnAngle = SpawnAngle;
+				newmobj.SpawnAngle	= SpawnAngle;
 				newmobj.Angle		= Angle;
 				newmobj.Pitch		= Pitch;
 				newmobj.Roll		= Roll;
@@ -176,7 +176,7 @@ Class PB_SpawnerBase : Actor
 				newmobj.special2	= special2;
 				newmobj.SpawnFlags = SpawnFlags & ~(MTF_SECRET|MTF_DORMANT);	// MTF_SECRET needs special treatment to avoid incrementing the secret counter twice. It had already been processed for the spawner itself.
 				SpawnFlags &= ~MTF_DORMANT; //we dont want the spawner to be deactivated
-				newmobj.HandleSpawnFlags();	
+				newmobj.HandleSpawnFlags();
 				if(isdormant)
 					SpawnFlags |= MTF_DORMANT;
 				newmobj.SpawnFlags = SpawnFlags;
@@ -188,7 +188,7 @@ Class PB_SpawnerBase : Actor
 				newmobj.tracer = tracer;
 				newmobj.CopyFriendliness(self, false);
 				newmobj.bAMBUSH = bAMBUSH;
-				
+				newmobj.bSTEALTH = bSTEALTH; //handles stealth flags for replacing stealth monsters
 				// This handles things such as projectiles with the MF4_SPECTRAL flag that have
 				// a health set to -2 after spawning, for internal reasons.
 				if (health != SpawnHealth()) newmobj.health = health;
@@ -227,6 +227,7 @@ Class PB_SpawnerBase : Actor
 	override void beginplay()
 	{
 		super.beginplay();
+		bSTEALTH = GetDefaultByType(GetReplacee(self.GetClass())).bSTEALTH;
 		bool isdormant = (SpawnFlags & MTF_DORMANT);	//save this
 		
 	}
@@ -471,6 +472,7 @@ class PBRandomSpawner : RandomSpawner abstract
 	override void PostSpawn(Actor spawned)
 	{
 		spawned.bDropped = bDropped;
+		spawned.bSTEALTH = bSTEALTH;
 		return;
 		
 		let wpn = PB_Weapon(spawned);

--- a/zscript/Spawner/Weapons/PB_BFGSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_BFGSpawner.zc
@@ -32,11 +32,11 @@ Class PBBFGSpawner : PB_SpawnerBase //replaces BFG9000
 			TNT1 A 0 A_SpawnItemEx("PB_BFGSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier1:
-		    TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_BFGSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Weapons/PB_ChaingunSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_ChaingunSpawner.zc
@@ -19,7 +19,7 @@ Class PBChaingunSpawner : PB_SpawnerBase //replaces Chaingun
 	States
 	{
 		CHAOTICRANDOM:
-		    TNT1 A 0 A_Jump(256, "Tier4","Tier3", "Tier2", "Tier1");
+			TNT1 A 0 A_Jump(256, "Tier4","Tier3", "Tier2", "Tier1");
 			Stop;
 		Tier4:
 			TNT1 A 0;
@@ -30,15 +30,15 @@ Class PBChaingunSpawner : PB_SpawnerBase //replaces Chaingun
 			TNT1 A 0 A_SpawnItemEx("PB_MGSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_MGSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier1:
-		    TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_MGSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Weapons/PB_ChainsawSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_ChainsawSpawner.zc
@@ -36,7 +36,7 @@ Class PBChainSawSpawner : PB_SpawnerBase //replaces Chainsaw
 			TNT1 A 0 A_SpawnItemEx("PB_SawSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Weapons/PB_PistolSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_PistolSpawner.zc
@@ -1,7 +1,7 @@
 Class PBPistolSpawner : PB_SpawnerBase //replaces Pistol
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	//Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,7 +25,7 @@ Class PBPistolSpawner : PB_SpawnerBase //replaces Pistol
 			TNT1 A 0 A_SpawnItemEx("PB_PistolSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_PistolSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:	
@@ -37,7 +37,7 @@ Class PBPistolSpawner : PB_SpawnerBase //replaces Pistol
 			TNT1 A 0 A_SpawnItemEx("PB_PistolSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Weapons/PB_PlasmaRifleSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_PlasmaRifleSpawner.zc
@@ -34,7 +34,7 @@ Class PBPlasmaRifleSpawner : PB_SpawnerBase //replaces PlasmaRifle
 			TNT1 A 0 A_SpawnItemEx("PB_PlasSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Spawner/Weapons/PB_RLSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_RLSpawner.zc
@@ -28,8 +28,8 @@ Class PBRocketLauncherSpawner : PB_SpawnerBase //replaces RocketLauncher
 			TNT1 A 0 A_SpawnItemEx("PB_RLSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
-	    SpawnSGL:	
-		   TNT1 A 0;
+		SpawnSGL:	
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_RLSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier1:
@@ -38,43 +38,43 @@ Class PBRocketLauncherSpawner : PB_SpawnerBase //replaces RocketLauncher
 			TNT1 A 0 A_SpawnItemEx("PB_RLSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
 
 CLASS SpawnedSGL:droppedbase
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		//TNT1 AA 1
 		TNT1 AA 0;
 		TNT1 A 0 A_SpawnItemEx("PB_SuperGL",0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_NOCHECKPOSITION | 288);
 	Spawn2:	
-	    TNT1 A 1;
-        Loop;
+		TNT1 A 1;
+		Loop;
 	Pickup:
 		TNT1 A 0 A_GiveInventory("PlayerHasSGLPermanent",1);
 		Stop;
-    }
+	}
 }
 
 CLASS SpawnedRL:droppedbase
 {
-    States
-    {
-    Spawn:
+	States
+	{
+	Spawn:
 		//TNT1 AA 1
 		TNT1 AA 0;
 		TNT1 A 0 A_SpawnItemEx("PB_RocketLauncher",0,0,0,0,0,0,0,SXF_TRANSFERSPECIAL | SXF_NOCHECKPOSITION | 288);
 	Spawn2:	
-	    TNT1 A 1;
-        Loop;
+		TNT1 A 1;
+		Loop;
 	Pickup:
 		TNT1 A 0 A_GiveInventory("PlayerHasRLPermanent",1);
 		Stop;
-    }
+	}
 }
 
 class PB_RLSpawnerT1 : PB_WeaponSpawner

--- a/zscript/Spawner/Weapons/PB_SSGSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_SSGSpawner.zc
@@ -21,12 +21,12 @@ Class PBSSGSpawner : PB_SpawnerBase //replaces SuperShotgun
 	{
 		Tier4:
 		SpawnASGDrum:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_SSGSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
 		SpawnQSG:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_SSGSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
@@ -34,12 +34,12 @@ Class PBSSGSpawner : PB_SpawnerBase //replaces SuperShotgun
 			TNT1 A 0 A_SpawnItemEx("PB_SSGSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier1:
-	    SpawnSSG:	
+		SpawnSSG:	
 			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_SSGSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }
@@ -65,7 +65,7 @@ class PB_SSGSpawnerT3 : PB_WeaponSpawner
 	Default
 	{
 		DropItem 'PB_QuadSG', 255, 1;
-	}  
+	}
 	override void HandleSpawnExeptions(in out name toSpawn)
 	{
 		if(DisablePB_QuadSG && toSpawn == "PB_QuadSG")

--- a/zscript/Spawner/Weapons/PB_ShotgunSpawner.zc
+++ b/zscript/Spawner/Weapons/PB_ShotgunSpawner.zc
@@ -1,7 +1,7 @@
 Class PBShotgunSpawner : PB_SpawnerBase //replaces Shotgun
 {
 	//Int WeaponHasBeenSpawned;
-    //Actor ptr;
+	//Actor ptr;
 	default
 	{
 		scale 0.45;
@@ -25,12 +25,12 @@ Class PBShotgunSpawner : PB_SpawnerBase //replaces Shotgun
 			TNT1 A 0 A_SpawnItemEx("PB_ShotSpawnerT4",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier3:
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ShotSpawnerT3",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier2:
 		RandomJumpT2:	
-		   TNT1 A 0;
+			TNT1 A 0;
 			TNT1 A 0 A_SpawnItemEx("PB_ShotSpawnerT2",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Tier1:
@@ -39,13 +39,13 @@ Class PBShotgunSpawner : PB_SpawnerBase //replaces Shotgun
 			TNT1 A 0 A_SpawnItemEx("PB_ShotSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Spawn_Tier_I_SSG:
-		   TNT1 A 0
-		   {
-		    if(pb_SSGRandomSpawn==false)
-		    {
-		    SetStateLabel("Spawn_Shotgun");
-		    }
-		   }
+			TNT1 A 0
+			{
+			if(pb_SSGRandomSpawn==false)
+			{
+			SetStateLabel("Spawn_Shotgun");
+			}
+			}
 			TNT1 A 0;
 			TNT1 A 0 A_Jump(168,"SpawnSSG");
 			TNT1 A 0 A_Jump(256,"Spawn_Shotgun");
@@ -55,7 +55,7 @@ Class PBShotgunSpawner : PB_SpawnerBase //replaces Shotgun
 			TNT1 A 0 A_SpawnItemEx("PB_SSGSpawnerT1",flags:SXF_TRANSFERSPECIAL|SXF_TRANSFERAMBUSHFLAG|SXF_TRANSFERPOINTERS|288,tid:tid);
 			Stop;
 		Death:
-		    TNT1 A 0;
+			TNT1 A 0;
 			Goto Spawn;
 	}
 }

--- a/zscript/Weapons/BaseWeapon.zc
+++ b/zscript/Weapons/BaseWeapon.zc
@@ -742,9 +742,9 @@ class PB_DualWeapon : PB_Weapon
 class PB_UpgradeItem : CustomInventory
 {
 	Default
-	{+DONTGIB;}
+	{+DONTGIB -INVENTORY.ALWAYSPICKUP -COUNTITEM}
 	action void A_SetSpawnSprite(String str)
 	{
-	   sprite = GetSpriteIndex(str);
+		sprite = GetSpriteIndex(str);
 	}
 }

--- a/zscript/Weapons/Projectiles/BulletDef.SmallCal.zsc
+++ b/zscript/Weapons/Projectiles/BulletDef.SmallCal.zsc
@@ -38,7 +38,7 @@ class PB_500SW : PB_Projectile
 	Default
 	{
 		PB_Projectile.BaseDamage 100;
-		PB_Projectile.RipperCount 5;
+		PB_Projectile.RipperCount 3;
 		PB_Projectile.PenetrationCount 3;
 		+PB_Projectile.WHIZCRACK;
 		Obituary "%o was shot at high noon by %k.";

--- a/zscript/Weapons/Slot3/Shotgun.zs
+++ b/zscript/Weapons/Slot3/Shotgun.zs
@@ -1470,7 +1470,7 @@ Class PB_SGMagazine: PB_UpgradeItem
 			LOOP;
 		
 		Pickup:
-			TNT1 A 0 A_JumpIf(!FindInventory("DragonBreathUpgrade") || !FindInventory("PB_Shotgun") || CountInv("ShotgunAmmo") < GetAmmoCapacity("ShotgunAmmo"),1) ;
+			TNT1 A 0 A_JumpIf(!FindInventory("DragonBreathUpgrade") || !FindInventory("PB_Shotgun") || CountInv("PB_Shell") < GetAmmoCapacity("PB_Shell"),1) ;
 			fail;
 			TNT1 A 0
 			{

--- a/zscript/Weapons/Slot3/Shotgun.zs
+++ b/zscript/Weapons/Slot3/Shotgun.zs
@@ -770,7 +770,7 @@ Class PB_Shotgun : PB_WeaponBase
 				 A_Fireprojectile("ShotgunParticles", random(-17,17), 0, -1, random(-17,17));
 				 PB_GunSmoke(-1,0,0);
 				 PB_GunSmoke(1,0,0);
-				 PB_DynamicTail("shotgun", "shotgun");    
+				 PB_DynamicTail("shotgun", "shotgun");
 				 A_SetInventory("CantDoAction",1);
 				 
 				switch(getshellsmode())
@@ -1452,8 +1452,8 @@ Class PB_SGMagazine: PB_UpgradeItem
 		//SpawnID 9310
 		//Game "Doom";
 		Height 24;
-		+INVENTORY.ALWAYSPICKUP
-		+COUNTITEM
+		-INVENTORY.ALWAYSPICKUP
+		-COUNTITEM
 		Inventory.Pickupsound "SHOTPICK";
 		Inventory.PickupMessage "Pump Shotgun Upgrade! (Mag + Dragon's Breath shells)";
 		Tag "Pump Shotgun Magazine";
@@ -1470,8 +1470,8 @@ Class PB_SGMagazine: PB_UpgradeItem
 			LOOP;
 		
 		Pickup:
-			//TNT1 A 0 ACS_NamedExecuteAlways("PumpShotgunMag", 0);
-			TNT1 A 0;
+			TNT1 A 0 A_JumpIf(!FindInventory("DragonBreathUpgrade") || !FindInventory("PB_Shotgun") || CountInv("ShotgunAmmo") < GetAmmoCapacity("ShotgunAmmo"),1) ;
+			fail;
 			TNT1 A 0
 			{
 				A_GiveInventory("PB_Shotgun", 1);


### PR DESCRIPTION
Upgrade Items do not get always picked up if you have nothing to gain from it.

Just a small tweak where the Alt-2fire doesn't show the nails inside the weapon when it cools down from firing its alt fire. Noticed it was a thing.

Added Stealth Monster replacement functionality.