### PR TITLE
Disable zombie drops option

### DIFF
--- a/CVARINFO
+++ b/CVARINFO
@@ -29,6 +29,7 @@ user bool pb_exaggeratedrecoil = true;
 user float pb_exaggeratedrecoilmul = 0.5;
 user int pb_floorwallblooddrawdist = 800;
 server bool pb_keepweapons = false;
+server int PB_WeaponDrops = 1;
 
 user int sd_lasers_densityoffset = 1;
 

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -365,6 +365,13 @@ optionvalue "MG42Spawns"
 	2,"Off"
 }
 
+optionvalue "MonsterDrops"
+{
+	0,"Just ammo"
+	1,"Default"
+	//2,"weapons+"
+}
+
 OptionMenu "GameplaySettings"
 {
 	Title "---------Game Settings---------"
@@ -379,6 +386,9 @@ OptionMenu "GameplaySettings"
 	StaticText " "
 	StaticText " "
 	option "Wall Penetration ","pb_wallpenetration","EnabledOption"
+	StaticText " "
+	StaticText " "
+	option "Monster weapon drops ","PB_WeaponDrops","MonsterDrops"
 	StaticText " "
 	StaticText " "
 	

--- a/ZSCRIPT.zc
+++ b/ZSCRIPT.zc
@@ -160,6 +160,7 @@ const MAXITERATIONS = 32676;
 
 #include "zscript/Monsters/PBMonster.zsc"
 #include "zscript/Monsters/PBMonsterAmmo.zsc"
+#include "zscript/Monsters/PBMonsterDrops.zsc"
 
 #include "zscript/Monsters/Special/BossBrain.zc"
 

--- a/actors/Monsters/T1-Grunts/AutoShottyGuy.dec
+++ b/actors/Monsters/T1-Grunts/AutoShottyGuy.dec
@@ -18,7 +18,7 @@ ACTOR ASGGuy : PB_Sergeant //Replaces ShotgunGuy
 	damagefactor "killme", 0.0
 	dAMAGEFACTOR "Avoid", 0.0
 	damagefactor "TeleportRemover", 0.0
-	DropItem "DropedASG"
+	DropItem "PB_ASGGuyDrop"
 	DropItem "PB_GrenadeAmmo" 5
 	PB_Monster.TailPitch 0.75
     States
@@ -2833,7 +2833,7 @@ ACTOR GibHalfASGGuy2: BigGibBase
 
 Actor Vanilla_ASGGuy : ASGGuy
 {
-	DropItem "DropedASG"
+	DropItem "PB_ASGGuyDrop"
     DropItem "PB_Shell"
 	DropItem "PB_GrenadeAmmo" 5
 	States

--- a/actors/Monsters/T1-Grunts/DemonTechTroop.dec
+++ b/actors/Monsters/T1-Grunts/DemonTechTroop.dec
@@ -534,7 +534,7 @@ ACTOR PB_DemonTechZombie : PB_Sergeant //Replaces ChaingunGuy
 	HT11 GH 2
 		TNT1 A 0 A_PlaySound("BODYF",6)
 	TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-	TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+	TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 	TNT1 A 0 A_SpawnItem ("DeadHellTrooper")
 	Stop
 	
@@ -544,7 +544,7 @@ ACTOR PB_DemonTechZombie : PB_Sergeant //Replaces ChaingunGuy
 	TNT1 A 0 A_XScream
 	TNT1 A 0 A_NoBLocking
 	TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-	TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+	TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 	Goto Death.ExplosiveImpact+1
 	
 	Death.Nailgun:
@@ -556,7 +556,7 @@ ACTOR PB_DemonTechZombie : PB_Sergeant //Replaces ChaingunGuy
 		TNT1 A 0 A_NoBlocking
         TNT1 A 0 A_FaceTarget
         TNT1 A 0 A_Recoil (30)
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
         HT11 G 5 A_CustomMissile ("Brutal_LiquidBlood3", 15, 0, random (0, 360), 2, random (0, 40))
 		TNT1 A 0 A_JumpIf((MomY == 0), "PinToWall")
 		HT11 G 5 A_CustomMissile ("Brutal_LiquidBlood3", 15, 0, random (0, 360), 2, random (0, 40))
@@ -589,7 +589,7 @@ ACTOR PB_DemonTechZombie : PB_Sergeant //Replaces ChaingunGuy
 		TNT1 A 0 A_NoBlocking
         TNT1 A 0 A_FaceTarget
         TNT1 A 0 A_Recoil (8)
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
          HT11 GH 8
 		TNT1 A 0 A_PlaySound("BODYF",6)
 		 HTMS L -1
@@ -598,7 +598,7 @@ ACTOR PB_DemonTechZombie : PB_Sergeant //Replaces ChaingunGuy
 		 
 
    Death.Down:
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		POSS I 0 A_Scream
 		POSS J 0 A_NoBlocking
 		HTMS L 1
@@ -618,7 +618,7 @@ Death.Shotgunontheface:
 		TNT1 A 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_Scream
 		TNT1 A 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
          HT11 GH 8
 		TNT1 A 0 A_PlaySound("BODYF",6)
          TNT1 A 0 A_SpawnItem ("DeadHellTrooper")
@@ -632,7 +632,7 @@ Death.Shotgunontheface:
 		TNT1 AA 0 A_CustomMissile ("brutal_FlyingBlood", 7, 0, random (0, 360), 2, random (0, 160))
         TNT1 A 0 A_Jump(96, "Death.Arm", "Death.Leg")
 		TNT1 A 0 A_Jump(128, "DeathMirror","Death.Vanish")
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		HTMS H 5
 		HTMS I 5 A_Scream
 		HTMS J 5 A_NoBlocking
@@ -643,7 +643,7 @@ Death.Shotgunontheface:
 		Stop
 	
 	DeathMirror:
-	TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+	TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 	    HTMS M 5
 		HTMS N 5 A_Scream
 		HTMS O 5 A_NoBlocking
@@ -656,7 +656,7 @@ Death.Shotgunontheface:
 // own addition
 	Death.Vanish:
 	Death.BlackHole:
-	TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+	TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 	HTD6 A 5
 	HTD6 C 5 A_NoBlocking
 	HTD6 DEFG 5
@@ -665,7 +665,7 @@ Death.Shotgunontheface:
      Death.Arm:
 		TNT1 A 0 A_CustomMissile ("XDeathArm1", 35, 0, random (0, 360), 2, random (0, 160))
         TNT1 A 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		HTD2 A 10 A_Scream
 		TNT1 A 0 A_NoBlocking
         TNT1 A 0 A_SpawnItemEx ("DyingHellTrooperNoArm",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
@@ -673,7 +673,7 @@ Death.Shotgunontheface:
 
        Death.Leg:
 		TNT1 A 0
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
         TNT1 A 0 A_CustomMissile ("MuchBlood2", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
 		
@@ -703,7 +703,7 @@ Death.Shotgunontheface:
 		
 	    Death.Massacre:
         TNT1 A 0
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		TNT1 A 0 A_FaceTarget
 		TNT1 O 0 A_NoBlocking
         TNT1 A 0 A_SpawnItem ("BrutalizedHellTrooper1", 1)
@@ -713,7 +713,7 @@ Death.Shotgunontheface:
 		TNT1 A 0
         TNT1 A 0 A_CustomMissile ("MuchBlood2", 15, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_CustomMissile ("XDeathSargeLeg1", 35, 0, random (0, 360), 2, random (0, 160))
-        TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+        TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		TNT1 A 0 A_NoBlocking
         TNT1 A 0 A_SpawnItem ("BrutalizedHellTrooperLeg")
         Stop
@@ -724,7 +724,7 @@ Death.Shotgunontheface:
         TNT1 AA 0 A_CustomMissile ("MuchBlood2", 35, 0, random (0, 360), 2, random (0, 160))
 		TNT1 O 0 A_NoBlocking
 		TNT1 A 0 A_CustomMissile ("RipHellTrooper", 0, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 	    HTD1 FG 9
 		TNT1 A 0 A_PlaySound("BODYF",6)
         TNT1 A 0 A_SpawnItem ("DeadHellTrooper_Half")
@@ -748,7 +748,7 @@ Death.Shotgunontheface:
 
     Death.Fatality:
         TNT1 A 0 A_NoBlocking
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		TNT1 A 0 A_GiveToTarget("GoFatality", 1)
         TNT1 A 0 A_Jump(256, "Death.Fatality2", "Death.Fatality3") //"Death.Fatality1",
 		Goto Death.Fatality2
@@ -771,7 +771,7 @@ Death.Shotgunontheface:
 		TNT1 A 0
 		TNT1 A 0 A_Playsound("MinorHeadshot", 0)
 	    TNT1 A 0 A_Jump (128, "DeathMinorhead2")
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		HTSH U 5 A_CustomMissile ("MuchBlood2", 40, 0, random (0, 360), 2, random (0, 160))
 		HTSH V 5 A_CustomMissile ("Brutal_LiquidBlood", 40, 0, 120, 2, random (0, 60))
 		TNT1 AA 0 A_CustomMissile ("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40))
@@ -791,7 +791,7 @@ Death.Shotgunontheface:
 		TNT1 A 0 A_CustomMissile ("Brains7", 50, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("Teeth", 50, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("TeethNoBounce", 50, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		HTD5 A 6 A_CustomMissile ("MuchBlood2", 40, 0, random (0, 360), 2, random (0, 160))
 		HTD5 CB 8 A_CustomMissile ("Brutal_LiquidBlood", 40, 0, 120, 2, random (0, 60))
 		
@@ -809,7 +809,7 @@ Death.Shotgunontheface:
 		TNT1 A 0 A_CustomMissile ("Brains7", 50, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("Teeth", 50, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("TeethNoBounce", 50, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		HTD5 A 6 A_CustomMissile ("MuchBlood2", 40, 0, random (0, 360), 2, random (0, 160))
 		HTD5 CB 8 A_CustomMissile ("Brutal_LiquidBlood", 40, 0, 120, 2, random (0, 60))
 		
@@ -828,7 +828,7 @@ Death.Shotgunontheface:
 		ZMAD C 0 A_NoBlocking
 		
 		TNT1 A 0 A_Jump(32, "Deathchickenhead")
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		HTDH ABBC 10 A_CustomMissile ("MuchBlood", 30, 0, random (0, 360), 2, random (0, 160))
 		HTDH DE 6 A_CustomMissile ("Brutal_LiquidBlood", 30, 0, 120, 2, random (0, 60))
 		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
@@ -862,7 +862,7 @@ Death.Shotgunontheface:
 		
 		
 		TNT1 A 0 A_PlaySound("misc/xdeath2c")
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		HTDH ABBC 10 A_CustomMissile ("MuchBlood", 30, 0, random (0, 360), 2, random (0, 160))
 		HTDH DE 6 A_CustomMissile ("Brutal_LiquidBlood", 20, 0, 120, 2, random (0, 60))
 		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
@@ -874,7 +874,7 @@ Death.Shotgunontheface:
 	Death.Decapitate:
 		TNT1 A 0 A_SpawnProjectile ("PB_XDeathHellTrooperHead", 50, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH  , random (40, 90))
         TNT1 A 0 A_CustomMissile ("MuchBlood2", 40, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		HTDH A 15 A_CustomMissile ("MuchBlood", 40, 0, random (0, 360), 2, random (0, 160))
 		HTDH B 9 A_XScream
 		HTDH C 9 A_NoBlocking
@@ -887,7 +887,7 @@ Death.Shotgunontheface:
    Death.Incinerate:
 		TNT1 A 0
 		TNT1 A 0 A_Stop
-	TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+	TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
         TNT1 A 0 A_Playsound("MELT")
         TNT1 A 0 A_NoBlocking
         TNT1 AAAAAA 0 A_CustomMissile ("ExplosionParticleHeavy", 32, 0, random (0, 360), 2, random (0, 360))
@@ -928,7 +928,7 @@ Death.Shotgunontheface:
 		TNT1 A 0 A_JumpIfInTargetInventory("HasIncendiaryWeapon",1,"Death.Incinerate")
 		TNT1 A 1
 		{
-			A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130));
+			A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130));
 			A_ScreamAndUnblock();
 			A_SpawnItemEx("BurningZombie",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION);
 		}
@@ -938,7 +938,7 @@ Death.Shotgunontheface:
 	  Death.Disintegrate:
 		TNT1 A 1
 		{
-			A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130));
+			A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130));
 			A_ScreamAndUnblock();
 			A_SpawnItemEx("DisintegratedHuman",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION);
 		}
@@ -972,7 +972,7 @@ Death.Shotgunontheface:
 	
 	Death.SuperPlasma:
         TNT1 A 0
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
         TNT1 A 0 A_XScream
         TNT1 A 0 A_NoBlocking
 		XBRN AA 2 BRIGHT A_SpawnItem("BlueFlare",0,43)
@@ -996,7 +996,7 @@ Death.Shotgunontheface:
 		
 		Death.GreenFire:
         TNT1 A 0
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
         TNT1 A 0 A_XScream
         TNT1 A 0 A_NoBlocking
         TNT1 AAAA 0 A_CustomMissile ("brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160))
@@ -1016,7 +1016,7 @@ Death.Shotgunontheface:
 	Death.Blast:
 	Death.SSG:
 	Death.Railgun:
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 	    HTD1 D 1 A_Pain
 		HTD1 D 1 A_FaceTarget
         //TNT1 A 0 A_CustomMissile ("MeatDeath", 0, 0, random (0, 360), 2, random (0, 160))
@@ -1042,14 +1042,14 @@ Death.Shotgunontheface:
 		
 	XDeath:
 		TNT1 A 1 A_JumpIfInTargetInventory("HasCutingWeapon",1,"Death.Saw")
-		TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 		TNT1 A 0 A_NoBlocking
         TNT1 A 1 A_CustomMissile ("HellTrooperXDeath", 2, 0, random (0, 360), 2, random (0, 160))
 		Stop
 	
 	 Death.Stomp:
 	 TNT1 A 0 A_Explode(200, 2, 1)
-	TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+	TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 	TNT1 AAAAAA 0 bright A_CustomMissile ("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180))
 	TNT1 AAAAAA 0 bright A_CustomMissile ("XDeath1", 5, 0, random (0, 360), 2, random (30, 180))
 	TNT1 A 0 bright A_CustomMissile ("XDeath2", 55, 0, random (0, 360), 2, random (30, 180))
@@ -1080,7 +1080,7 @@ Death.Shotgunontheface:
 	TNT1 A 0 A_CustomMissile ("XDeathSargeLeg1", 32, 0, random (0, 360), 2, random (0, 160))
     TNT1 AAAA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
 	TNT1 A 0 ThrustThingZ(0,30,0,1)
-	TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+	TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 	    HT14 AB 5
 		HT14 CDEF 5 A_CheckFloor ("Dead.ExplosiveImpact")
 		HT14 FFFFFFFFFF 5 A_CheckFloor ("Dead.ExplosiveImpact")
@@ -1096,7 +1096,7 @@ Death.Shotgunontheface:
 	TNT1 A 0 A_CustomMissile ("GibHand", 42, 0, random (0, 360), 2, random (0, 160))
     TNT1 AAAA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
 	TNT1 A 0 ThrustThingZ(0,50,0,1)
-	TNT1 A 0 A_CustomMissile ("TossedHellRifle", 25, 0, random (0, 360), 2, random (50, 130))
+	TNT1 A 0 A_CustomMissile ("PB_CultistDrop", 25, 0, random (0, 360), 2, random (50, 130))
 	HT16 A 1 A_Scream
 	    HT16 A 9
 		HT16 BCD 9 A_CheckFloor("Dead.Landmine")

--- a/actors/Monsters/T1-Grunts/DyingGuys.dec
+++ b/actors/Monsters/T1-Grunts/DyingGuys.dec
@@ -1746,7 +1746,7 @@ ACTOR BrutalizedCommando1 : SwitchableDecoration
 	Spawn:
 	CPOD JJJJJJJJJJ 10 A_SpawnItem ("DripingBlood", 0, 23)
 	CPOD K 6
-	TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+	TNT1 A 0 A_SpawnItem ("PB_ChaingunGuyDrop1", 0, 5,0)
 	TNT1 A 0 A_SpawnItem ("BrutalizedDeadCommando1")
 	Stop
 	
@@ -1791,7 +1791,7 @@ ACTOR BrutalizedCommando2: BrutalizedCommando1
 	CPOD NNNNN 10 A_SpawnItem ("DripingBlood", 0, 23)
 	CPOD O 5
 	TNT1 A 0 A_SpawnItem ("BrutalizedDeadChaingunGuy")
-	TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+	TNT1 A 0 A_SpawnItem ("PB_ChaingunGuyDrop1", 0, 5,0)
 	Stop
 	
 	Pain:
@@ -1810,7 +1810,7 @@ ACTOR BrutalizedCommando2: BrutalizedCommando1
 		TNT1 AA 0 A_CustomMissile ("PB_SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
 		TNT1 AA 0 A_CustomMissile ("PB_XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_SpawnItem ("BrutalizedCommando3")
-		TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+		TNT1 A 0 A_SpawnItem ("PB_ChaingunGuyDrop1", 0, 5,0)
 		Stop
 		
 	Death.SSG:
@@ -3093,7 +3093,7 @@ ACTOR BrutalizedHelmetCommando1 : BrutalizedCommando1
 	Spawn:
 	CP1D JJJJJJJJJJJ 8 A_CustomMissile ("Brutal_LiquidBlood2", 24, 0, random (0, 60), 2, random (30, 60))
 	CP1D K 6
-	TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+	TNT1 A 0 A_SpawnItem ("PB_ChaingunGuyDrop1", 0, 5,0)
 	TNT1 A 0 A_SpawnItem ("BrutalizedDeadHelmetCommando1")
 	Stop
 	
@@ -3119,7 +3119,7 @@ ACTOR BrutalizedHelmetCommando2: BrutalizedCommando2
 	CP1D NNNNN 10 A_SpawnItem ("DripingBlood", 0, 23)
 	CP1D O 5
 	TNT1 A 0 A_SpawnItem ("BrutalizedDeadHelmetChaingunGuy")
-	TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+	TNT1 A 0 A_SpawnItem ("PB_ChaingunGuyDrop1", 0, 5,0)
 	Stop
 	
 	Pain:
@@ -3137,7 +3137,7 @@ ACTOR BrutalizedHelmetCommando2: BrutalizedCommando2
 		TNT1 AA 0 A_CustomMissile ("PB_SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
 	TNT1 AA 0 A_CustomMissile ("PB_XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
 	TNT1 A 0 A_SpawnItem ("BrutalizedCommando3")
-	TNT1 A 0 A_SpawnItem ("DropedMinigun", 0, 5,0)
+	TNT1 A 0 A_SpawnItem ("PB_ChaingunGuyDrop1", 0, 5,0)
 		Stop
 }}
 

--- a/actors/Monsters/T1-Grunts/NAZIS.dec
+++ b/actors/Monsters/T1-Grunts/NAZIS.dec
@@ -38,7 +38,7 @@ ACTOR PB_Nazi : PB_Monster
 	MaxDropOffHeight 32
 	Species "Nazi"
 damagefactor "Blood", 0.0 damagefactor "BlueBlood", 0.0 damagefactor "GreenBlood", 0.0
-	DropItem "PB_MP40"
+	DropItem "PB_WolfSSdrop"
 	States
 	{
 	
@@ -1442,7 +1442,7 @@ damagefactor "Blood", 0.0 damagefactor "BlueBlood", 0.0 damagefactor "GreenBlood
 // 	SAZI K 15
 // 	SAZI LM 7
 // 	TNT1 A 0 A_NoBlocking
-// 	TNT1 A 0 A_SpawnItem("PB_MP40")
+// 	TNT1 A 0 A_SpawnItem("PB_WolfSSdrop")
 // 	TNT1 A 0 A_SpawnItem("NaziSurrendered")
 // 	Stop
 // 	}
@@ -1616,7 +1616,7 @@ ACTOR FrozenNazi
 		TNT1 AA 0 A_CustomMissile ("XDeath3", 48, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAA 0 A_CustomMissile ("Instestin", 32, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAA 0 A_CustomMissile ("MuchBlood", 48, 0, random (0, 360), 2, random (0, 160))
-		TNT1 A 0 A_SpawnItem("PB_MP40")
+		TNT1 A 0 A_SpawnItem("PB_WolfSSdrop")
 		FRNZ C -1
 		//FZD1 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC 1 A_FadeOut(0.01)
 		Stop

--- a/actors/Monsters/T1-Grunts/PB_NailgunMajor.dec
+++ b/actors/Monsters/T1-Grunts/PB_NailgunMajor.dec
@@ -14,7 +14,7 @@ Actor PB_NailgunMajor : PB_Commando //Replaces ChaingunGuy
   Obituary "%o was perforated by a nailgun major."
   damagefactor "TeleportRemover", 0.0
   Decal Bulletchip
-  Dropitem "DroppedPB_Nailgun", 256
+  Dropitem "PB_NailgunGuydrop", 256
   States
   {
   	Death.Execution:

--- a/actors/Monsters/T1-Grunts/QuadSGGuy.dec
+++ b/actors/Monsters/T1-Grunts/QuadSGGuy.dec
@@ -19,7 +19,7 @@ Actor PB_QSGZombie: PB_HelmetSergeant //Replaces ShotgunGuy
   DamageFactor "Blood", 0.0 DamageFactor "BlueBlood", 0.0 DamageFactor "GreenBlood", 0.0
   damagefactor "TeleportRemover", 0.0
   DropItem "PB_Shell"
-  DropItem "DropedPB_SSG", 64
+  DropItem "PB_QSGZombieDrop", 64
   DropItem "PB_GrenadeAmmo" 5
   States
   {	

--- a/actors/Monsters/T1-Grunts/RocketZombie.dec
+++ b/actors/Monsters/T1-Grunts/RocketZombie.dec
@@ -3,7 +3,7 @@ ACTOR PB_RocketZombie: PB_Sergeant //Replaces ShotgunGuy
 	//$Title Rocket Sergeant
 	//$Category Project Brutality - Monsters/Former Humans/Sergeants
 	//$Sprite MP0SB1
-	DropItem "RocketAmmo"
+	DropItem "PB_RocketZombieDrop"
 	SpawnID 1260
 	+NOTARGET
 	Painchance "Avoid", 0

--- a/actors/Monsters/T1-Grunts/SergeantVariant.dec
+++ b/actors/Monsters/T1-Grunts/SergeantVariant.dec
@@ -182,7 +182,7 @@ Actor PB_PyroSergeant: PB_HelmetSergeant //Replaces ShotgunGuy
 {
 	SpawnID 1250
 	Scale 1.04
-	DropItem "PB_Flamethrower"
+	DropItem "PB_PyroGuyDrop"
 // 	PainChance "Fire", 12
 // 	PainChance "Flames", 12
 // 	PainChance "Burn", 12

--- a/actors/Monsters/T1-Grunts/ZSpecOps.dec
+++ b/actors/Monsters/T1-Grunts/ZSpecOps.dec
@@ -41,7 +41,7 @@ Actor PB_ZSpecOps : PB_Monster //Replaces ChaingunGuy
 	DamageFactor "Fatality", 0.5
 	DamageFactor "SuperPunch", 0.5
 	  Decal BulletChip
-	  DropItem "PB_SMG"
+	  DropItem "PB_ZSpecSMGDrop"
 	 PB_Monster.PBMonSpeed 10, 12, 8, 8
 	 PB_Monster.MonDMGMult 0.8, 1.0, 0.9, 1.0, 1.0, 0.9
 	 PB_Monster.CanIRoll 0

--- a/zscript/Monsters/Chaingunner/Commando.zc
+++ b/zscript/Monsters/Chaingunner/Commando.zc
@@ -47,7 +47,7 @@ Class PB_Chaingunguy : PB_Monster
 		damagefactor "TeleportRemover", 0.0;
 		damagefactor "Execution", 1000.0;
 		damagefactor "head", 1.25;
-		DropItem "PB_Minigun";
+		DropItem "PB_ChaingunGuyDrop1";
 		
 		Obituary "%o has been gunned down by a Commando.";
 		+FLOORCLIP;

--- a/zscript/Monsters/Chaingunner/HelmetCommando.zc
+++ b/zscript/Monsters/Chaingunner/HelmetCommando.zc
@@ -47,7 +47,7 @@ Class PB_MinigunGuy : PB_Monster
 		damagefactor "TeleportRemover", 0.0;
 		damagefactor "Execution", 1000.0;
 		damagefactor "head", 1.25;
-		DropItem "PB_Minigun";
+		DropItem "PB_ChaingunGuyDrop1";
 		
 		Obituary "%o has been gunned down by a Commando.";
 		+FLOORCLIP;

--- a/zscript/Monsters/PBMonsterDrops.zsc
+++ b/zscript/Monsters/PBMonsterDrops.zsc
@@ -1,0 +1,320 @@
+//
+//	base class for monsters weapon drops
+//
+const upgChance = 32; //12.5% chance
+class PB_MonsterDropBase : inventory
+{
+	string		weaponDrop,		//the weapon to drop
+				upgradeDrop,	//upgrade to drop, if any (not necessarily an upgrade, can be a rare weapon)
+				ammoDrop;		//the ammo to drop if weapon drops are disabled
+	
+	string 		weaponCvar,		//the cvar to check for the weapon (to avoid spawn it if its disabled)
+				UpgradeCvar;	//the same as above but for the upgrade (if any)
+				
+	property	weaponDrop:weaponDrop;
+	property	upgradeDrop:upgradeDrop;
+	property	ammoDrop:ammoDrop;
+	property	weaponCvar:weaponCvar;
+	property	UpgradeCvar:UpgradeCvar;
+	
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+	
+	override void postbeginplay()
+	{
+		super.postbeginplay();
+		switch(PB_WeaponDrops)
+		{
+			// PB_WeaponDrops 1 = spawn weapon drop (basically what vanilla doom does)
+			case 1:
+				if(weapondrop && isWeaponEnabled())
+					spawndrop(weapondrop);
+				else
+					spawndrop(ammodrop);
+				break;
+				
+			//	PB_WeaponDrops 2 = spawn upgrade based on rng (can be just a very rare weapon)
+			case 2:
+				int chance = random[upgchan](0,255);
+				bool upg = chance <= upgChance;
+				if(upgradeDrop && upg && isUpgradeEnabled())
+				{
+					//console.printf("Spawning: %s",upgradeDrop);
+					spawndrop(upgradeDrop);
+				}
+				else
+				{
+					//console.printf("paul mcartney explodes and fucking dies");
+					if(weapondrop && isWeaponEnabled())
+						spawndrop(weapondrop);
+					else
+						spawndrop(ammodrop);
+				}
+				break;
+				
+			//spawn just ammo
+			case 0:
+			default:
+				//console.printf("no weapons for you, just %s",ammodrop);
+				spawndrop(ammodrop);
+				break;
+		}
+		
+	}
+	
+	bool isUpgradeEnabled()
+	{
+		if(!upgradecvar)	//if theres no cvar, then it cant be disabled
+			return true;
+		if(upgradecvar && cvar.getcvar(upgradecvar).getbool())
+			return false;
+		return true;
+	}
+	
+	bool isWeaponEnabled()
+	{
+		if(!weaponCvar)
+			return true;
+		if(weaponCvar && cvar.getcvar(weaponCvar).getbool())
+			return false;
+		return true;
+	}
+	
+	void spawndrop(string drop)
+	{
+		if(!drop)
+			return;
+		
+		let dp = spawn(drop,pos);
+		if(dp)
+		{
+			dp.vel = vel;
+			double dropfactor = (G_SkillPropertyFloat(SKILLP_DropAmmoFactor) == -1 ? 0.5:G_SkillPropertyFloat(SKILLP_DropAmmoFactor));
+			if(dp is "weapon")
+			{
+				let wpdp = weapon(dp);
+				if(wpdp)
+					wpdp.ammogive1 = max(1,int(dropfactor * wpdp.ammogive1));
+				return;
+			}
+			if(dp is "ammo")
+			{
+				let amdp = ammo(dp);
+				if(amdp)
+				{
+					amdp.amount = max(1,int(dropfactor * amdp.amount)); //wouldnt make sense to receive 0 of something
+				}
+				return;
+			}
+			
+		}
+		
+	}
+	
+	states
+	{
+		spawn:
+			TNT1 A 1;
+			stop;
+	}
+}
+
+
+class PB_CarbineZombieDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_Carbine";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_HighCalMag";
+		PB_MonsterDropBase.weaponCvar "DisablePB_Carbine";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_PlasmaZombieDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "";
+		PB_MonsterDropBase.upgradeDrop "PB_M1Plasma";
+		PB_MonsterDropBase.ammoDrop "PB_Cell";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_ZombieManDrop1 : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_DMR";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_HighCalMag";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_ShotgunGuyDrop1 : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_Shotgun";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_Shell";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_ChaingunGuyDrop1 : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_Minigun";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_HighCalMag";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_ASGGuyDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_Autoshotgun";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_Shell";
+		PB_MonsterDropBase.weaponCvar "DisablePB_Autoshotgun";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_CultistDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_Demontech";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_DTech";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+
+Class PB_WolfSSdrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_MP40";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_LowCalMag";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_NailgunGuydrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_Nailgun";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_HighCalMag";
+		PB_MonsterDropBase.weaponCvar "DisablePB_Nailgun";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_QSGZombieDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_SSG";
+		PB_MonsterDropBase.upgradeDrop "PB_QuadSG";
+		PB_MonsterDropBase.ammoDrop "PB_Shell";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "DisablePB_QuadSG";
+	}
+}
+
+Class PB_RocketZombieDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "";
+		PB_MonsterDropBase.upgradeDrop "PB_RocketLauncher";
+		PB_MonsterDropBase.ammoDrop "PB_RocketAmmo";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_PyroGuyDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_Flamethrower";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_Fuel";
+		PB_MonsterDropBase.weaponCvar "DisablePB_Flamer";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_ZSpecSMGDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_SMG";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_LowCalMag";
+		PB_MonsterDropBase.weaponCvar "DisablePB_SMG";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_ScientistAxeDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_Axe";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_ScientistSAWDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_ChainsawPickup";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_Fuel";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}
+
+Class PB_PistolGuyDrop : PB_MonsterDropBase
+{
+	default
+	{
+		PB_MonsterDropBase.weaponDrop "PB_Pistol";
+		PB_MonsterDropBase.upgradeDrop "";
+		PB_MonsterDropBase.ammoDrop "PB_LowCalMag";
+		PB_MonsterDropBase.weaponCvar "";
+		PB_MonsterDropBase.UpgradeCvar "";
+	}
+}

--- a/zscript/Monsters/Sergeants/ZombieSergeant.zc
+++ b/zscript/Monsters/Sergeants/ZombieSergeant.zc
@@ -46,7 +46,7 @@ Class PB_ShotgunGuy : PB_Monster
 		damagefactor "Saw", 0.5;
 		damagefactor "Cut", 0.75;
 		damagefactor "Tear", 0.25;
-		DropItem "PB_Shotgun";
+		DropItem "PB_ShotgunGuyDrop1";
 		DropItem "PB_GrenadeAmmo", 7;
 		Obituary "%o was blasted away by a Zombie Sergeant.";
 		+FLOORCLIP;

--- a/zscript/Monsters/ZombieMen/ZombieMan.zc
+++ b/zscript/Monsters/ZombieMen/ZombieMan.zc
@@ -47,7 +47,7 @@ Class PB_ZombieMan : PB_Monster
 		damagefactor "TeleportRemover", 0.0;
 		damagefactor "Execution", 1000.0;
 		damagefactor "head", 1.25;
-		DropItem "PB_DMR";
+		DropItem "PB_ZombieManDrop1";
 		DropItem "PB_GrenadeAmmo", 7;
 		
 		Obituary "%o has been gunned down by a Zombie Soldier.";

--- a/zscript/Monsters/ZombieMen/ZombieManCarbine.zc
+++ b/zscript/Monsters/ZombieMen/ZombieManCarbine.zc
@@ -5,7 +5,7 @@ Class PB_CarbineZombieman: PB_Zombieman //Replaces ZombieMan
 		//$Title Carbine Zombieman
 		//$Category Project Brutality - Monsters/Former Humans/Zombiemen
 		Health 90;
-		DropItem "DropedCarbine";
+		DropItem "PB_CarbineZombieDrop";
 		DropItem "PB_GrenadeAmmo", 15;
 	}
 	States

--- a/zscript/Monsters/ZombieMen/ZombieManDeath.zc
+++ b/zscript/Monsters/ZombieMen/ZombieManDeath.zc
@@ -568,7 +568,7 @@ class HeadlessZombieScientist : HeadlessZombieMan
 				A_SpawnProjectile ("PB_SquirtingBloodTrail", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			}
 			LP07 BC 8;
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_StartSound("BODYF",6);
 			LP07 EEEEEEEEEEEEEEEEEEEEEEEEEEEEEE 2 A_SpawnProjectile ("PB_SquirtingBloodTrail", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			TNT1 A 0 A_SpawnItem ("GrowingBloodPool");

--- a/zscript/Monsters/ZombieMen/ZombieManHelmet.zc
+++ b/zscript/Monsters/ZombieMen/ZombieManHelmet.zc
@@ -6,7 +6,7 @@ Class PB_HelmetZombieman: PB_Zombieman //Replaces ZombieMan
 		//$Category Project Brutality - Monsters/Former Humans/Zombiemen
 		//$Sprite ZIV1A1
 		damagefactor "Head", 0.60;
-		DropItem "PB_DMR";
+		DropItem "PB_ZombieManDrop1";
 		PB_Monster.MonDMGMult 1.25, 1.25, 0.8, 1.0, 0.95, 0.7;
 	}
 	States

--- a/zscript/Monsters/ZombieMen/ZombieManHelmetPistol.zc
+++ b/zscript/Monsters/ZombieMen/ZombieManHelmetPistol.zc
@@ -6,7 +6,7 @@ Class PB_PistolZombieman2: PB_Zombieman //Replaces ZombieMan
 		//$Category Project Brutality - Monsters/Former Humans/Zombiemen
 		//$Sprite 9OS2B1
 		damagefactor "Head", 0.60;
-		DropItem "PB_Pistol";
+		DropItem "PB_PistolGuyDrop";
 		PB_Monster.MonDMGMult 1.25, 1.25, 0.8, 1.0, 0.95, 0.7;
 
 		PB_Monster.TailPitch 0.8;

--- a/zscript/Monsters/ZombieMen/ZombieManPistol.zc
+++ b/zscript/Monsters/ZombieMen/ZombieManPistol.zc
@@ -5,7 +5,7 @@ Class PB_PistolZombieman1: PB_Zombieman //Replaces ZombieMan
 		//$Title Pistol Zombieman
 		//$Category Project Brutality - Monsters/Former Humans/Zombiemen
 		//$Sprite PSPOB1
-		DropItem "PB_Pistol";
+		DropItem "PB_PistolGuyDrop";
 
 		PB_Monster.TailPitch 0.8;
 	}

--- a/zscript/Monsters/ZombieMen/ZombieManPlasma.zc
+++ b/zscript/Monsters/ZombieMen/ZombieManPlasma.zc
@@ -6,7 +6,7 @@ Class PB_PlasmaZombie : PB_Zombieman
 			//$Category Project Brutality - Monsters/Former Humans/Zombiemen
 			//$Sprite ZMAYB1
 			Health 110;
-			DropItem "Cell";
+			DropItem "PB_PlasmaZombieDrop";
 			DropItem "StunGrenadeAmmo", 15;
 			Painchance "Head", 256;
 			damagefactor "Head", 0.70;

--- a/zscript/Monsters/ZombieMen/ZombieScientist.zc
+++ b/zscript/Monsters/ZombieMen/ZombieScientist.zc
@@ -292,7 +292,7 @@ Class PB_ZombieScientist : PB_Monster
 			FS11 H 2 {
 				A_StartSound("BODYF",6);
 				A_SpawnItem ("GrowingBloodPool");
-				A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_SpawnItem ("DeadFormerScientist");
 			}
 			Stop;
@@ -438,7 +438,7 @@ Class PB_ZombieScientist : PB_Monster
 			FSMS K 5;
 			TNT1 A 0 A_SpawnItem ("GrowingBloodPool");
 			TNT1 A 0 A_StartSound("BODYF",6);
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_SpawnItem ("DeadFormerScientist");
 			Stop;
 		
@@ -449,7 +449,7 @@ Class PB_ZombieScientist : PB_Monster
 			SCZA K 5;
 			TNT1 A 0 A_SpawnItem ("GrowingBloodPool");
 			TNT1 A 0 A_StartSound("BODYF",6);
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_SpawnItem ("DeadLabguySCZAL");
 			Stop;
 	
@@ -459,7 +459,7 @@ Class PB_ZombieScientist : PB_Monster
 			FSMS O 5 A_NoBlocking();
 			FSMS P 5;
 			TNT1 A 0 A_SpawnItem ("GrowingBloodPool");
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_StartSound("BODYF",6);
 			TNT1 A 0 A_SpawnItem ("DeadLabguyFSMSP");
 			Stop;
@@ -470,7 +470,7 @@ Class PB_ZombieScientist : PB_Monster
 			TNT1 AAA 0 A_SpawnProjectile ("Instestin", 28, 0, random (150, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			FSMS H 5;
 			SCZA H 5 A_Scream();
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_NoBlocking();
 			TNT1 A 0 A_SpawnItem ("GrowingBloodPool");
 			TNT1 A 0 A_StartSound("BODYF",6);
@@ -484,7 +484,7 @@ Class PB_ZombieScientist : PB_Monster
 				A_SpawnProjectile ("PB_SmallGib", 35, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("PB_SmallGib", 35, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("PB_MuchBlood2", 35, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
-				A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_NoBlocking();
 				A_Scream();
 				}
@@ -516,7 +516,7 @@ Class PB_ZombieScientist : PB_Monster
 				A_SpawnProjectile ("PB_SquirtingBloodTrail", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			}
 			LP07 BC 8;
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_StartSound("BODYF",6);
 			LP07 DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD 2 A_SpawnProjectile ("PB_SquirtingBloodTrail", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			TNT1 A 0 A_SpawnItem ("GrowingBloodPool");
@@ -573,7 +573,7 @@ Class PB_ZombieScientist : PB_Monster
 			TNT1 A 0 A_Jump (256, "DeathMinorhead1", "DeathMinorhead2");
 		DeathMinorHead1:
 			TNT1 A 0 A_StartSound("MinorHeadshot", 0);
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			FSSH U 5 {
 				A_SpawnProjectile ("PB_MuchBlood2", 50, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("PB_SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (-10, 10));
@@ -599,7 +599,7 @@ Class PB_ZombieScientist : PB_Monster
 			TNT1 A 0 A_Jump(160, "DeathMinorHead2Short");
 			TNT1 A 0 A_SpawnItem ("GrowingBloodPool");
 			TNT1 A 0 A_SpawnItemEx ("DyingZombieScientistLostTeeth", 0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);
-			TNT1 A 1 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 1 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			Stop;
 			
 		DeathMinorHead2Short:
@@ -608,7 +608,7 @@ Class PB_ZombieScientist : PB_Monster
 			TNT1 A 0 A_StartSound("BODYF",6);
 			TNT1 A 0 A_SpawnItem ("GrowingBloodPool");
 			TNT1 A 0 A_SpawnItem ("DeadLabguySCZAL");
-			TNT1 A 1 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 1 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			Stop;
 					
 		HeadExplode:
@@ -616,7 +616,7 @@ Class PB_ZombieScientist : PB_Monster
 				A_Stop();
 				A_StartSound("gore/headshot", CHAN_BODY);
 				A_SpawnItem("LabguyHeadExplode", 0, 40);
-				A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_XScream();
 				A_SpawnItem("BloodSplasher2");
 				A_NoBlocking();
@@ -648,7 +648,7 @@ Class PB_ZombieScientist : PB_Monster
 				A_SpawnItem("BloodSplasher2");
 				bNOBLOCKMONST = true;
 				A_StartSound("misc/PB_XDeath4");
-				A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_FaceTarget();
 				A_XScream();
 				A_NoBlocking();
@@ -669,7 +669,7 @@ Class PB_ZombieScientist : PB_Monster
 		
 		Death.Decapitate:
 			TNT1 A 0 {
-				A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_Stop();
 				A_FaceTarget();
 				A_NoBlocking();
@@ -705,7 +705,7 @@ Class PB_ZombieScientist : PB_Monster
 			TNT1 A 0 {
 				A_Scream();
 				A_NoBlocking();
-				A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_SpawnProjectile ("XDeathSargeLeg1", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("XDeathSargeLeg1", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("PB_XDeath1", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
@@ -733,7 +733,7 @@ Class PB_ZombieScientist : PB_Monster
 				A_SpawnItem ("GrowingBloodPool");
 				A_NoBlocking();
 				A_Scream();
-				A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_SpawnItemEx ("DyingFormerScientistNoLeg",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);
 				}
 			Stop;
@@ -743,7 +743,7 @@ Class PB_ZombieScientist : PB_Monster
 					bNODROPOFF = false;
 					ThrustThingZ(0,30,0,1);
 					A_FaceTarget();
-					A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+					A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			}
 			TNT1 A 0 A_JumpIf(angle < 180, "IsFacingNorth");
 			TNT1 A 0 A_JumpIf(Vel.X < 0, "BlownAwayRight");
@@ -860,7 +860,7 @@ Class PB_ZombieScientist : PB_Monster
 			TNT1 AAAA 0 A_SpawnProjectile ("PB_BloodmistLarge", 50, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 A 0 A_SpawnProjectile ("XDeathLabGuyArm", 35, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 A 0 A_SpawnProjectile ("XDeathSargeLeg1", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 ThrustThingZ(0,30,0,1);
 			FS14 AB 5;
 			FS14 CDEF 5 A_CheckFloor ("Dead.ExplosiveImpact");
@@ -1154,7 +1154,7 @@ Class PB_ZombieScientist : PB_Monster
 				A_FaceTarget();
 				A_Recoil(30);
 			}
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			LPO4 U 5 A_SpawnProjectile ("PB_SquirtingBloodTrail", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			TNT1 A 0 A_JumpIf((Vel.Y == 0), "PinToWall");
 			LPO4 U 5 A_SpawnProjectile ("PB_SquirtingBloodTrail", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
@@ -1181,7 +1181,7 @@ Class PB_ZombieScientist : PB_Monster
 		Naildeath2:
 			TNT1 A 0 A_XScream();
 			TNT1 A 0 A_NoBlocking();
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_FaceTarget();
 			TNT1 AAA 0 A_SpawnProjectile ("PB_Intestine", 32, 0, random (150, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			TNT1 AAA 0 A_SpawnProjectile ("PB_XDeath1", 32, 0, random (150, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
@@ -1206,7 +1206,7 @@ Class PB_ZombieScientist : PB_Monster
 		NailDeath3:
 			TNT1 A 0 A_XScream();
 			TNT1 A 0 A_NoBlocking();
-			TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_FaceTarget();
 			TNT1 AAA 0 A_SpawnProjectile ("PB_XDeath1", 32, 0, random (150, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			TNT1 AA 0 A_SpawnProjectile ("PB_Xdeath2", 16, 0, random (130, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
@@ -1332,7 +1332,7 @@ Class PB_ZombieScientist : PB_Monster
 			A_SpawnProjectile ("PB_SquirtingBloodTrail", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 		}
 		LP07 BC 8;
-		TNT1 A 0 A_SpawnProjectile("DroppedPB_Axe", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+		TNT1 A 0 A_SpawnProjectile("PB_ScientistAxeDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 		TNT1 A 0 A_StartSound("BODYF",6);
 		LP07 DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD 2 A_SpawnProjectile ("PB_SquirtingBloodTrail", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 		TNT1 A 0 A_SpawnItem ("GrowingBloodPool");

--- a/zscript/Monsters/ZombieMen/ZombieScientistChainsaw.zc
+++ b/zscript/Monsters/ZombieMen/ZombieScientistChainsaw.zc
@@ -253,7 +253,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			5SMS L 2 {
 				A_StartSound("BODYF",6);
 				A_SpawnItem ("GrowingBloodPool");
-				A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_SpawnItem ("DeadFormerScientistChainsaw");
 			}
 			Stop;
@@ -398,7 +398,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 A 0 A_Jump(256, "DeathMirror", "Death2", "BaseDeath");
 		BaseDeath:
 			5SMS H 5;
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			5SMS I 5 A_Scream();
 			5SMS J 5 A_NoBlocking();
 			5SMS K 5;
@@ -409,7 +409,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 		
 		Death2:
 			5CZA J 5;
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			5CZA K 5 A_Scream();
 			5CZA L 5 A_NoBlocking();
 			5CZA M 5;
@@ -420,7 +420,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 	
 		DeathMirror:
 			5SMS M 5;
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			5SMS N 5 A_Scream();
 			5SMS O 5 A_NoBlocking();
 			5SMS P 5;
@@ -433,7 +433,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 A 0 A_SpawnProjectile ("MuchBlood", 30, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 AA 0 A_SpawnProjectile ("XDeath1", 30, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 AAA 0 A_SpawnProjectile ("Instestin", 28, 0, random (150, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			5SMS H 5 A_Scream();
 			TNT1 A 0 A_NoBlocking();
 			TNT1 A 0 A_SpawnItem ("GrowingBloodPool");
@@ -444,7 +444,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 		DeathAccident:
 			TNT1 A 0 A_Scream();
 			TNT1 A 0 A_NoBlocking();
-			//TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			//TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_SpawnItemEx ("DyingChainsawScientistAccident", 0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);
 			Stop;
 			
@@ -455,7 +455,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 				A_SpawnProjectile ("PB_SmallGib", 35, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("PB_SmallGib", 35, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("PB_MuchBlood2", 35, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
-				A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_NoBlocking();
 				A_Scream();
 			}
@@ -474,7 +474,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 A 0 A_SpawnProjectile ("PB_RipZombieScientistChainsaw", 0, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 A 0 A_XScream();
 			TNT1 O 0 A_NoBlocking();
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			LP07 A 1 {
 				A_FaceTarget();
 				for (int i = 0; i < 4; i++) {	
@@ -525,7 +525,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 A 0 A_SpawnProjectile ("PB_XDeath4", 40, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 AAA 0 A_SpawnProjectile ("PB_SmallGib", 42, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 A 0 A_SpawnProjectile ("PB_RipZombieScientistChainsaw2", 0, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			LP06 AB 6;
 			LP06 CCCCCCCCCCCCCCCCCC 1 A_SpawnProjectile ("PB_SquirtingBloodTrail", 30, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			LP06 D 8;
@@ -550,7 +550,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 A 0 A_Jump (256, "DeathMinorhead1", "DeathMinorhead2", "DeathMinorHead3");
 		DeathMinorHead1:
 			TNT1 A 0 A_StartSound("MinorHeadshot", 0);
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			CSSH U 5 {
 				A_SpawnProjectile ("PB_MuchBlood2", 50, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("PB_SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (-10, 10));
@@ -571,7 +571,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 AA 0 A_SpawnProjectile ("PB_Teeth", 50, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 AA 0 A_SpawnProjectile ("PB_TeethNoBounce", 50, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 AA 0 A_SpawnProjectile ("PB_SmallBrainPieceFast", random (45, 55), random (5, -5), random (170, 190), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (-10, 10));
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			CSD5 A 8 A_NoBlocking();
 			TNT1 A 0 A_SpawnProjectile ("PB_MuchBlood2", 40, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 A 0 A_Jump(200, "DeathMinorHead2Short");
@@ -594,7 +594,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 A 0 A_SpawnProjectile ("PB_SuperWallRedBlood", 46, 0, random (170, 190), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			TNT1 A 0 A_Pain();
 			TNT1 A 0 A_StartSound("MinorHeadshot", 0);
-			TNT1 A 1 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 1 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			CZD7 AB 4;
 			CZD7 C 6 A_NoBlocking();
 			CZD7 EF 6;
@@ -609,7 +609,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 				A_Stop();
 				A_StartSound("gore/headshot", CHAN_BODY);
 				A_SpawnItem("ChainsawZombieHeadExplode", 0, 40);
-				A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_XScream();
 				A_SpawnItem("BloodSplasher2");
 				A_NoBlocking();
@@ -642,7 +642,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 				A_SpawnItem("BloodSplasher2");
 				bNOBLOCKMONST = true;
 				A_StartSound("misc/PB_XDeath4");
-				A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_FaceTarget();
 				A_XScream();
 				A_NoBlocking();
@@ -663,7 +663,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 		
 		Death.Decapitate:
 			TNT1 A 0 {
-				A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_Stop();
 				A_FaceTarget();
 				A_NoBlocking();
@@ -700,7 +700,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 A 0 {
 				A_Scream();
 				A_NoBlocking();
-				A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_SpawnProjectile ("XDeathSargeLeg1", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("XDeathSargeLeg1", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 				A_SpawnProjectile ("PB_XDeath1", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
@@ -728,7 +728,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 				A_SpawnItem ("GrowingBloodPool");
 				A_NoBlocking();
 				A_Scream();
-				A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_SpawnItemEx ("DyingChainsawZombieNoLeg",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0);
 				}
 			Stop;
@@ -739,7 +739,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 					bNODROPOFF = false;
 					ThrustThingZ(0,30,0,1);
 					A_FaceTarget();
-					A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+					A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			}
 			TNT1 A 0 A_JumpIf(angle < 180, "IsFacingNorth");
 			TNT1 A 0 A_JumpIf(Vel.X < 0, "BlownAwayRight");
@@ -864,7 +864,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 AAAA 0 A_SpawnProjectile ("PB_BloodmistLarge", 50, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 A 0 A_SpawnProjectile ("XDeathLabGuyArm", 35, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
 			TNT1 A 0 A_SpawnProjectile ("XDeathSargeLeg1", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 160));
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 ThrustThingZ(0,30,0,1);
 			FS14 AB 5;
 			FS14 CDEF 5 A_CheckFloor ("Dead.ExplosiveImpact");
@@ -887,7 +887,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			TNT1 A 0 A_JumpIfInTargetInventory("HasIncendiaryWeapon",1,"Death.Incinerate");
 			TNT1 A 1 {
 				A_StopSound(CHAN_7);
-				A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+				A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 				A_ScreamAndUnblock();
 				A_SpawnItemEx("BurningLabGuy",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION);
 			}
@@ -1171,7 +1171,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 				A_FaceTarget();
 				A_Recoil(30);
 			}
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			5PO4 U 5 A_SpawnProjectile ("PB_SquirtingBloodTrail", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			TNT1 A 0 A_JumpIf((Vel.Y == 0), "PinToWall");
 			5PO4 U 5 A_SpawnProjectile ("PB_SquirtingBloodTrail", 15, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
@@ -1198,7 +1198,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 		Naildeath2:
 			TNT1 A 0 A_XScream();
 			TNT1 A 0 A_NoBlocking();
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_FaceTarget();
 			TNT1 AAA 0 A_SpawnProjectile ("PB_Intestine", 32, 0, random (150, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			TNT1 AAA 0 A_SpawnProjectile ("PB_XDeath1", 32, 0, random (150, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
@@ -1225,7 +1225,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 		NailDeath3:
 			TNT1 A 0 A_XScream();
 			TNT1 A 0 A_NoBlocking();
-			TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+			TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 			TNT1 A 0 A_FaceTarget();
 			TNT1 AAA 0 A_SpawnProjectile ("PB_XDeath1", 32, 0, random (150, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 			TNT1 AA 0 A_SpawnProjectile ("PB_Xdeath2", 16, 0, random (130, 210), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
@@ -1353,7 +1353,7 @@ Class PB_ZombieScientistChainsaw : PB_ZombieScientist
 			A_SpawnProjectile ("PB_SquirtingBloodTrail", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 		}
 		LP07 BC 8;
-		TNT1 A 0 A_SpawnProjectile("DroppedChainsaw", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
+		TNT1 A 0 A_SpawnProjectile("PB_ScientistSAWDrop", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (50, 130));
 		TNT1 A 0 A_StartSound("BODYF",6);
 		LP07 DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD 2 A_SpawnProjectile ("PB_SquirtingBloodTrail", 32, 0, random (0, 360), CMF_AIMDIRECTION|CMF_ABSOLUTEPITCH|CMF_OFFSETPITCH|CMF_BADPITCH|CMF_SAVEPITCH, random (0, 40));
 		TNT1 A 0 A_SpawnItem ("GrowingBloodPool");


### PR DESCRIPTION
- added an option to disable zombie weapon drops, they also now respect the disabled weapons (option located in the _Gameplay Settings_ submenu in _Project Brutality Settings_ menu, or by its cvar _PB_WeaponDrops_ )