### PR TITLE
Make PB's options hard to miss

### DIFF
--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -2,6 +2,11 @@ AddOptionMenu "OptionsMenu"
 {
 	Submenu "Project Brutality Settings", "PBSettings"
 }
+AddOptionMenu "OptionsMenuSimple"
+{
+	Submenu "Project Brutality Settings", "PBSettings"
+}
+
 
 //Key : Value
 //PB_<monster code name>, monster name


### PR DESCRIPTION
Yes, I know it's on the main menu, but if a Mod replaces the main menu, you won't see that entry. So, why not make it show up on the Simple Option Menu too?