### PR TITLE
Projectile Null Pointer Fix

### DIFF
--- a/zscript/Weapons/Projectiles/BulletProjectile.zsc
+++ b/zscript/Weapons/Projectiles/BulletProjectile.zsc
@@ -474,7 +474,7 @@ class PB_Projectile : FastProjectile abstract
 	void PB_HandleWhizby()
 	{
 		PB_PlayerPawn plr = PB_PlayerPawn(players[consoleplayer].mo);
-		if(!target || plr == target)
+		if(!target || plr == target || !plr)
 			return;
 		
 		if(alreadyWhizzedBy.Find(plr) != alreadyWhizzedBy.Size())		


### PR DESCRIPTION
As the name describes. Prevents a crash if the player isn't detected.