### PR TITLE
Spider Tweaks Mostly

### DIFF
--- a/actors/Effects/TELEPORTS.dec
+++ b/actors/Effects/TELEPORTS.dec
@@ -10,6 +10,7 @@ Mass 999999
 +NOGRAVITY
 +DONTSPLASH
 +DONTBLAST //So that the teleports don't break.
++NOBLOCKMAP
 Renderstyle Add
 DamageFactor "CancelTeleportFog", 9999.0
 	States
@@ -36,6 +37,7 @@ DamageFactor "CancelTeleportFog", 9999.0
 //like Teleporters. Epic 2 Map 07 was known for this issue.
 //Fucking Mark's spaghetti mess... This will be removed once all corpses have
 //A_NoBlocking added.
+/*
 ACTOR BrutalTeleportDest: TeleportDest Replaces TeleportDest
 {
 	//$Sprite TFOGI0
@@ -106,3 +108,4 @@ ACTOR BrutalTeleportDest3 : BrutalTeleportDest Replaces TeleportDest3
 	//$Sprite UDBGR0
 	-NOGRAVITY
 }
+*/

--- a/actors/Monsters/T1-Grunts/AutoShottyGuy.dec
+++ b/actors/Monsters/T1-Grunts/AutoShottyGuy.dec
@@ -21,6 +21,7 @@ ACTOR ASGGuy : PB_Sergeant //Replaces ShotgunGuy
 	DropItem "PB_ASGGuyDrop"
 	DropItem "PB_GrenadeAmmo" 5
     BloodType "PB_GunshotBlood", "PB_SawBlood", "PB_SawBlood"
+	
 	PB_Monster.TailPitch 0.75
     States
     {

--- a/actors/Monsters/T1-Grunts/AutoShottyGuy.dec
+++ b/actors/Monsters/T1-Grunts/AutoShottyGuy.dec
@@ -23,6 +23,10 @@ ACTOR ASGGuy : PB_Sergeant //Replaces ShotgunGuy
     BloodType "PB_GunshotBlood", "PB_SawBlood", "PB_SawBlood"
 	
 	PB_Monster.TailPitch 0.75
+	PB_Monster.CanIFallback 1
+	PB_Monster.CanIReload 1
+	PB_Monster.CanIReload 1
+	PB_Monster.CanISuppress 0
     States
     {
 		

--- a/actors/Monsters/T1-Grunts/DemonTechTroop.dec
+++ b/actors/Monsters/T1-Grunts/DemonTechTroop.dec
@@ -99,6 +99,11 @@ ACTOR PB_DemonTechZombie : PB_Sergeant //Replaces ChaingunGuy
 	damagefactor "Taunt", 1.0
 	DropItem "LeechGrenade" 30
     BloodType "PB_GunshotBlood", "PB_SawBlood", "PB_SawBlood"
+
+	PB_Monster.CanIFallback 1
+	PB_Monster.CanIReload 1
+	PB_Monster.CanIRoll 1
+	PB_Monster.CanISuppress 0
 	States
 	{
 	

--- a/actors/Monsters/T1-Grunts/SergeantVariant.dec
+++ b/actors/Monsters/T1-Grunts/SergeantVariant.dec
@@ -192,6 +192,11 @@ Actor PB_PyroSergeant: PB_HelmetSergeant //Replaces ShotgunGuy
 	Tag "Pyro Sergeant"
 	+SLIDESONWALLS
 	+AVOIDMELEE
+
+	PB_Monster.CanIFallback 1
+	PB_Monster.CanIReload 1
+	PB_Monster.CanIRoll 1
+	PB_Monster.CanISuppress 0
 	States
 	{
 	

--- a/actors/Monsters/T1-Grunts/ZSpecOps.dec
+++ b/actors/Monsters/T1-Grunts/ZSpecOps.dec
@@ -44,7 +44,10 @@ Actor PB_ZSpecOps : PB_Monster //Replaces ChaingunGuy
 	  DropItem "PB_ZSpecSMGDrop"
 	 PB_Monster.PBMonSpeed 10, 12, 8, 8
 	 PB_Monster.MonDMGMult 0.8, 1.0, 0.9, 1.0, 1.0, 0.9
-	 PB_Monster.CanIRoll 0
+	PB_Monster.CanIFallback 1
+	PB_Monster.CanIReload 1
+	PB_Monster.CanIRoll 0
+	PB_Monster.CanISuppress 0
 	 PB_Monster.AttackRange 250
 	 PB_Monster.TailPitch 1.2
 	 

--- a/actors/Weapons/Throwables.dec
+++ b/actors/Weapons/Throwables.dec
@@ -221,17 +221,18 @@ Actor ThrownProxMine
 		{
 			if (waterlevel > 1)
 			{
-				ThrustThingZ(0,random(5,6),1,0);
+				ThrustThingZ(32,random(36,40),1,0);
 			}
 			else
 			{
-				ThrustThingZ(0,random(12,14),0,1);
+				ThrustThingZ(1,random(12,14),0,1);
 			}
 		}
 		TNT1 A 0 //A_SpawnItem ("RedFlareSpawn",0,5)
 		XPFP A 1
 		TNT1 A 0 A_ChangeFlag ("THRUACTORS",0)
-		Goto Spawn+1
+		TNT1 A 0 A_JumpIf(waterlevel > 1, "Spawn")
+		Goto Spawn+2
 	Death:
 	XDeath:
 		TNT1 A 0 A_SpawnItemEx("GroundProxMine", 0, 0, 0, 0, 0, 0, 0,SXF_NOCHECKPOSITION,0)

--- a/actors/Weapons/Throwables.dec
+++ b/actors/Weapons/Throwables.dec
@@ -215,12 +215,23 @@ Actor ThrownProxMine
 	{
 	Spawn:
 		TNT1 A 0 
-		TNT1 A 0 ThrustThingZ(0,random(12,14),0,1)
+		//TNT1 A 0 ThrustThingZ(0,random(12,14),0,1)
 		//TNT1 A 0 A_JumpIf(waterlevel > 1, "Death")
+		TNT1 A 0
+		{
+			if (waterlevel > 1)
+			{
+				ThrustThingZ(0,random(5,6),1,0);
+			}
+			else
+			{
+				ThrustThingZ(0,random(12,14),0,1);
+			}
+		}
 		TNT1 A 0 //A_SpawnItem ("RedFlareSpawn",0,5)
 		XPFP A 1
 		TNT1 A 0 A_ChangeFlag ("THRUACTORS",0)
-		Goto Spawn+2
+		Goto Spawn+1
 	Death:
 	XDeath:
 		TNT1 A 0 A_SpawnItemEx("GroundProxMine", 0, 0, 0, 0, 0, 0, 0,SXF_NOCHECKPOSITION,0)
@@ -329,7 +340,7 @@ States	{
 		XPFP A 1 A_LookEx(LOF_NOSOUNDCHECK,0,160,0,0,"Death")
 		TNT1 A 0 A_SpawnItem ("RedFlareSpawn",0,6)
 		XPFP A 1 A_LookEx(LOF_NOSOUNDCHECK,0,160,0,0,"Death")
-		Goto Spawn+3
+		Goto Spawn+2
 		
 	
 	Death:

--- a/zscript/Monsters/Arachnotrons/Arachnotron.zc
+++ b/zscript/Monsters/Arachnotrons/Arachnotron.zc
@@ -118,6 +118,7 @@ Class PB_Arachnotron1 : PB_Monster
 			}
 			return ResolveState(null);
 		}
+		TNT1 A 0 A_SpidRefire();
 		Loop;
 	
 	Pain:

--- a/zscript/Monsters/Arachnotrons/Arachnotron.zc
+++ b/zscript/Monsters/Arachnotrons/Arachnotron.zc
@@ -44,7 +44,10 @@ Class PB_Arachnotron1 : PB_Monster
 		DropItem "Demonpickup2", 255;
 		DropItem "Demonpickup", 55;
 
-		PB_Monster.CanISuppress false; // Will use A_Chase.
+		PB_Monster.CanIFallback false;
+		PB_Monster.CanIReload false;
+		PB_Monster.CanIRoll false;
+		PB_Monster.CanISuppress false;
 	}
 
 	States
@@ -89,19 +92,9 @@ Class PB_Arachnotron1 : PB_Monster
 
 	See:
 		BSPI A 1 {A_StartSound("baby/walk", 1); plasmaBallCounter = 0; }
-		BSPI AABBBCCC 1 {
-			if (canSuppress)
-				A_CustomChase();
-			else
-				A_Chase();
-			}
+		BSPI AABBBCCC 1 A_SmartChase();
 		BSPI D 1;
-		BSPI DDDEEEFFF 1 {
-			if (canSuppress)
-				A_CustomChase();
-			else
-				A_Chase();
-			}
+		BSPI DDDEEEFFF 1 A_SmartChase();
 		Loop;
 
 	Missile:
@@ -528,9 +521,9 @@ Class PB_Arachnotron1Buffed : PB_Arachnotron1
 		Goto See;
 	FrontMove:
 		BSPI A 2 {Thrust(1); }
-		BSPI AABBBCCC 2 {Thrust(1); A_CustomChase(); }
+		BSPI AABBBCCC 2 {Thrust(1); A_SmartChase(); }
 		BSPI D 2 ;
-		BSPI DDDEEEFFF 2 {Thrust(1); A_CustomChase();}
+		BSPI DDDEEEFFF 2 {Thrust(1); A_SmartChase();}
 		Goto See;
 
 	SuppressiveFire:

--- a/zscript/Monsters/Arachnotrons/Arachnotron.zc
+++ b/zscript/Monsters/Arachnotrons/Arachnotron.zc
@@ -100,10 +100,10 @@ Class PB_Arachnotron1 : PB_Monster
 	Missile:
 		BSPI A 2 BRIGHT A_FaceTarget;
 		// Just a simple state jump. Less complex than buffed spider, but may add another attack later.
-		Goto PlasmaBallAttack;
+		Goto ClassicPlasma;
 
-	PlasmaBallAttack:
-		BSPI G 4;
+	ClassicPlasma:
+		BSPI G 8;
 		BSPI H 2 BRIGHT 			
 		{
 			if (plasmaBallCounter <= 10)
@@ -118,7 +118,6 @@ Class PB_Arachnotron1 : PB_Monster
 			}
 			return ResolveState(null);
 		}
-
 		Loop;
 	
 	Pain:
@@ -436,14 +435,27 @@ Class PB_Arachnotron1Buffed : PB_Arachnotron1
 	States
 	{
 	Missile:
-		TNT1 A 0 A_JumpIf(random(0, 100) < 80 && FirstTime, "Shield");
+		BSPI A 2 BRIGHT A_FaceTarget();
 //		TNT1 A 0 {{SetState(FindState("Arty"));}}   /// Setting direct state is for debugging a state/projectile
-		BSPI A 2 BRIGHT A_FaceTarget;
-		TNT1 A 0 A_JumpIf(random(0, 99) < 40 , "RailGun");
-		TNT1 A 0 {SetState(FindState("PlasmaBallAttack"));}
+		TNT1 A 0 {
+			if (random(0,100) < 80 && FirstTime)
+			{
+				// [DarynS] Since this will only run once, we don't need a dedicated State for it.
+				// So we can handle the toggling of the variable, spawning the shield, and jumping to the attack state.
+				FirstTime = false;
+				A_SpawnItemEx("Shield",pos.x,pos.y,pos.z,flags: SXF_SETMASTER);	
+				return ResolveState("Arty");
+			}
+			else if (random(0, 99) > 50)
+				return ResolveState("ClassicPlasma");
+			else if (random(0, 99) < 40)
+				return ResolveState("RailGun");
+			else
+				return ResolveState("PlasmaBallAttack");
+		}
 
 /* 		BSPI H 2 BRIGHT {					/// Will keep just in case
-			int allowedChance = 0 ;
+			int allowedChance = 0;
 			double chance = random(0, 100);
 			if (chance > allowedChance)
 			{A_DropAdjust2("ArachnoPlasma_Ball","ArachnoPlasma_Ball", 0, 0, 25, speedmult: 1.0, minRange: 0, maxRange: 1200, shootDownward: false);}
@@ -461,38 +473,33 @@ Class PB_Arachnotron1Buffed : PB_Arachnotron1
 				if (plasmaBallCounter <= 14 && HasClearShotIgnoringShield(self,target) )
 				{
 					A_FaceTarget();
-					A_DropAdjust2("ArachnoPlasma_Ball","ArachnoPlasma_Ball", 0, 0, 25, speedmult: 1.0, minRange: 0, maxRange: 1200, shootDownward: false); plasmaBallCounter += 1;
+					A_DropAdjust2("ArachnoPlasma_Ball","ArachnoPlasma_Ball", 0, 0, 25, speedmult: 1.0, minRange: 0, maxRange: 1200, shootDownward: false);
+					plasmaBallCounter++;
 				//	bool collisionCheck = CanReachTarget("ArachnoPlasma_Ball",30,0,25, tolerance:1, debug : true);
 					
 					int ArtyChance = 92 ; //92
 					double chance = random(0, 100);
 					if (chance > ArtyChance)
 					{
-						artyCounter = 0; SetState(FindState("Arty"));
+						artyCounter = 0;
+						return ResolveState("Arty");
 					}
 					else
-						SetState(FindState("PlasmaBallAttack"));
+						return ResolveState("PlasmaBallAttack");
 				}
 				else if (plasmaBallCounter > 14 && HasClearShotIgnoringShield(self,target))
 				{
-					SetState(FindState("RailGun")); 
+					return ResolveState("RailGun");
 				}
 				else if (plasmaBallCounter <= 14 && !HasClearShotIgnoringShield(self,target) )
 				{
-					SetState(FindState("RailGun")); 
+					return ResolveState("RailGun");
 				}
-				else
-				{
-					SetState(FindState("See")); 
-				}
+				return ResolveState(null);
 			}
 		Goto See;
 	
-	Shield:
-		TNT1 A 0 {FirstTime = false; A_SpawnItemEx("Shield",pos.x,pos.y,pos.z,flags: SXF_SETMASTER); }
-		Goto Arty;
 	Arty:
-		
 		BSPI A 3 BRIGHT {A_FaceTarget(); plasmaBallCounter = 0; if(target && Distance3d(target) > 1800) { SetState(FindState("Missile"));  } }
 		BSPI G 6 A_FaceTarget;
 		BSPI H 2 BRIGHT {A_SpawnProjectile("ArachnoArtyPlasmaBall", 25, 0, 0, 0);  artyCounter += 1; }
@@ -502,7 +509,6 @@ Class PB_Arachnotron1Buffed : PB_Arachnotron1
 		BSPI H 2 BRIGHT {A_SpawnProjectile("ArachnoArtyPlasmaBall", 25, 0, 0, 0);  artyCounter += 1; }
 		BSPI G 6 A_FaceTarget;
 		BSPI H 2 BRIGHT {A_SpawnProjectile("ArachnoArtyPlasmaBall", 25, 0, 0, 0);  artyCounter += 1; }
-		
 		Goto Missile;
 		
 	RailGun:
@@ -547,20 +553,20 @@ Class PB_Arachnotron1Buffed : PB_Arachnotron1
 	SuppressiveFire2:
 		TNT1 A 0 { self.inSuppressiveFire = true; if (CheckSight(target)) SetState(FindState("See")); } 
 	    BSPI G 10;
-		BSPI H 2 BRIGHT{ 
-						  self.suppressiveOffZ = 25; self.suppressiveOffXY = 0; self.suppressiveMissile = "ArachnoPlasma_Ball";  A_SuppressiveFire(pitchOffset:50);
-						  suppressCount2 += 1;
-						  if (suppressCount2 < suppressLimit2)
-						  {
-								SetState(FindState("SuppressiveFire2"));
-								self.inSuppressiveFire = false;
-						  }
-						  else if (suppressCount2 >= suppressLimit2)
-						  {
-								SetState(FindState("See"));
-								self.inSuppressiveFire = false;
-						  }
-					   }
+		BSPI H 2 BRIGHT {
+				self.suppressiveOffZ = 25; self.suppressiveOffXY = 0; self.suppressiveMissile = "ArachnoPlasma_Ball";  A_SuppressiveFire(pitchOffset:50);
+				suppressCount2 += 1;
+				if (suppressCount2 < suppressLimit2)
+				{
+					SetState(FindState("SuppressiveFire2"));
+					self.inSuppressiveFire = false;
+				}
+				else if (suppressCount2 >= suppressLimit2)
+				{
+					SetState(FindState("See"));
+					self.inSuppressiveFire = false;
+				}
+			}
 		GoTo See;
 	}
 }
@@ -1302,12 +1308,10 @@ class Shield : Actor
         if (ownerActor)
         {
             SetOrigin(ownerActor.Pos, false);
-
         }
         else
         {
             Destroy(); // If the owner is gone, remove the shield
-
         }
     }
 	

--- a/zscript/Monsters/Cacodemons/Cacodemon.zc
+++ b/zscript/Monsters/Cacodemons/Cacodemon.zc
@@ -81,13 +81,20 @@ Class PB_Cacodemon : PB_Monster
 	
 	States
 	{	
-		// TODO: convert
 		Execution:
-			TNT1 A 1 A_Die("Execution");
-			Stop;
+			//TNT1 A 1 A_Die("Execution");
+			//Stop;
 		Death.Execution:
-			TNT1 A 0 A_Stopsound();
-			Stop;
+			TNT1 A 0 {
+				A_Stopsound();
+				A_FaceTarget();
+				A_NoBlocking(false);
+			}
+			HEAD BC 4;
+			TNT1 A 0 A_Pain();
+			HEAD E 21;
+			TNT1 A 0 A_Recoil(4);
+			Goto Death.SSG;
 		
 		Spawn:
 			HEAD A 10 A_Look();

--- a/zscript/Monsters/Cacodemons/Cacodemon.zc
+++ b/zscript/Monsters/Cacodemons/Cacodemon.zc
@@ -122,17 +122,7 @@ Class PB_Cacodemon : PB_Monster
 					//This is to prevent it from floating off into infinity
 					//due to being thrusted and has no gravity or friction
 				}
-				// [DarynS] Use Smart or CustomChase based on which variant is in play.
-				// Don't want Suppress on the base Caco, so we use CustomChase for the buffed variant.
-				// Likely going to end up making a merged, multi-purpose chase eventually.
-				if (canSuppress)
-				{
-					A_CustomChase(UseASmartChase : true); // This will make sure the A_CustomChase goes back to A_SmartChase instead of A_Chase
-				}
-				else
-				{
-					A_SmartChase();
-				}
+				A_SmartChase();
 			}
 			Loop;
 			
@@ -144,7 +134,7 @@ Class PB_Cacodemon : PB_Monster
 				else if (jawDetached)
 					return ResolveState("Missile_NoJaw");
 				// Using the canSuppress variable to temporarily turn off Special attack Cacocola Classic.
-				else if (canSuppress && random(0,100) > 50)
+				else if (GetClassName() == "PB_CacodemonBuffed" && random(0,100) > 50)
 					return ResolveState("Missile_Special");
 				return ResolveState(null);
 			}
@@ -154,7 +144,7 @@ Class PB_Cacodemon : PB_Monster
 		//	HEAD D 5 BRIGHT A_HeadAttack(); 
 			HEAD D 5 {
 				// Different attack based on the canSuppress variable. Base Caco will act more vanilla.
-				if (canSuppress)
+				if (GetClassName() == "PB_CacodemonBuffed")
 					A_DropAdjust2("PB_CacodemonBall","PB_CacodemonBall", 0, 0, 32, minRange: 0, maxRange: 1000, shootDownward: false);
 				else
 					A_SpawnProjectile("PB_CacodemonBall");
@@ -778,7 +768,7 @@ Class PB_CacodemonBuffed : PB_Cacodemon
 		PB_Monster.MonPosHB 0.7, 0.5, 0.38, 0.40;
 		PB_Monster.ignoreDickDamage true;
 		PB_Monster.CanIFallback false;
-		PB_Monster.CanIRoll true;
+		PB_Monster.CanIRoll false;
 		PB_Monster.CanIReload false;
 		PB_Monster.CanISuppress true;
 	}

--- a/zscript/Monsters/Cacodemons/Cacodemon.zc.old
+++ b/zscript/Monsters/Cacodemons/Cacodemon.zc.old
@@ -1,4 +1,4 @@
-Class PB_Cacodemon : PB_Monster
+Class PB_Cacodemon : PB_Monster //
 {
 	bool jawDetached;
 	bool monsterActivated;

--- a/zscript/Monsters/Chaingunner/Commando.zc
+++ b/zscript/Monsters/Chaingunner/Commando.zc
@@ -59,8 +59,10 @@ Class PB_Chaingunguy : PB_Monster
 		Species "Former_Human";
 		
 		PB_Monster.PBMonSpeed 3, 2.5, 1, 2;
+		PB_Monster.CanIFallback true;
+		PB_Monster.CanIReload true;
 		PB_Monster.CanIRoll false;
-		PB_Monster.CanIFallback false;
+		PB_Monster.CanISuppress false;
 		PB_Monster.AttackRange 10000;
 	}
 		

--- a/zscript/Monsters/Chaingunner/HelmetCommando.zc
+++ b/zscript/Monsters/Chaingunner/HelmetCommando.zc
@@ -60,8 +60,10 @@ Class PB_MinigunGuy : PB_Monster
 		
 		PB_Monster.MonDMGMult 1.25, 1.5, 0.70, 1.0, 1.25, 0.80;
 		PB_Monster.PBMonSpeed 3, 2.5, 1, 2;
-		PB_Monster.CanIRoll false;
 		PB_Monster.CanIFallback false;
+		PB_Monster.CanIReload true;
+		PB_Monster.CanIRoll false;
+		PB_Monster.CanISuppress false;
 		PB_Monster.AttackRange 10000;
 	}
 		

--- a/zscript/Monsters/Imps/Imp.zc
+++ b/zscript/Monsters/Imps/Imp.zc
@@ -55,6 +55,9 @@ Class PB_Imp1 : PB_Monster// Replaces DoomImp
 		Species "Imp";
 		
 		PB_Monster.CanIFallback false;
+		PB_Monster.CanIReload false;
+		PB_Monster.CanIRoll true;
+		PB_Monster.CanISuppress false;
 		PB_Monster.PBMonSpeed 5, 4, 2, 2.5;
 	}
 	

--- a/zscript/Monsters/Knights/BaronOfHell.zc
+++ b/zscript/Monsters/Knights/BaronOfHell.zc
@@ -58,6 +58,11 @@ class PB_Baron1 : PB_Monster
 
         DropItem "Demonpickup2", 76;
         DropItem "Demonpickup2", 76;
+
+        PB_Monster.CanIFallback false;
+        PB_Monster.CanIReload false;
+        PB_Monster.CanIRoll false;
+        PB_Monster.CanISuppress true;
     }
 
 	override void BeginPlay()
@@ -127,25 +132,25 @@ class PB_Baron1 : PB_Monster
 //            TNT1 A 0 A_GiveInventory("EnemyMemory", 1);
 //            TNT1 A 0 A_JumpIfInventory("EnemyMemory", 20, "ForgetTarget");
             BOSS A 0 A_CheckSight("SEE3");
-            BOSS AA 2 A_CustomChase;
+            BOSS AA 2 A_SmartChase();
             TNT1 A 0;
-            BOSS AA 2 A_CustomChase;
+            BOSS AA 2 A_SmartChase();
             TNT1 A 0;
-            BOSS AA 2 A_CustomChase;
+            BOSS AA 2 A_SmartChase();
             TNT1 A 0 A_StartSound("baron/step", 5);
             TNT1 A 0;
-            BOSS B 4 A_CustomChase;
+            BOSS B 4 A_SmartChase();
             TNT1 A 0;
-            BOSS BB 2 A_CustomChase;
+            BOSS BB 2 A_SmartChase();
             TNT1 A 0;
-            BOSS CC 2 A_CustomChase;
+            BOSS CC 2 A_SmartChase();
             TNT1 A 0;
-            BOSS CC 2 A_CustomChase;
+            BOSS CC 2 A_SmartChase();
             TNT1 A 0 A_StartSound("baron/step", 5);
             TNT1 A 0;
-            BOSS DD 2 A_CustomChase;
+            BOSS DD 2 A_SmartChase();
             TNT1 A 0;
-            BOSS DD 2 A_CustomChase;
+            BOSS DD 2 A_SmartChase();
             TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat");
             TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat");
             Loop;
@@ -211,11 +216,11 @@ class PB_Baron1 : PB_Monster
             Loop;
 
         See3:
-            BOSS AA 3 A_CustomChase;
+            BOSS AA 3 A_SmartChase();
             TNT1 A 0 A_StartSound("baron/step", 5);
-            BOSS BBCC 3 A_CustomChase;
+            BOSS BBCC 3 A_SmartChase();
             TNT1 A 0 A_StartSound("baron/step", 5);
-            BOSS DD 3 A_CustomChase;
+            BOSS DD 3 A_SmartChase();
             Goto See4;
 
         Idle:

--- a/zscript/Monsters/Mancubi/Mancubus.zc
+++ b/zscript/Monsters/Mancubi/Mancubus.zc
@@ -77,6 +77,11 @@ class PB_Mancubus1 : PB_Monster
 
 		DropItem "Demonpickup2", 60;
 		DropItem "Demonpickup2", 250;
+
+        PB_Monster.CanIFallback false;
+        PB_Monster.CanIReload false;
+        PB_Monster.CanIRoll false;
+        PB_Monster.CanISuppress true;
 	}
 
 	override void BeginPlay()
@@ -171,14 +176,14 @@ class PB_Mancubus1 : PB_Monster
     See:
         TNT1 A 0;
         TNT1 A 0 A_StartSound("knight/step", 5);
-        FATT AA 4 A_CustomChase();
+        FATT AA 4 A_SmartChase();
         TNT1 A 0 A_StartSound("knight/step", 5);
-        FATT BB 4 A_CustomChase();
-        FATT CC 4 A_CustomChase();
+        FATT BB 4 A_SmartChase();
+        FATT CC 4 A_SmartChase();
         TNT1 A 0 A_StartSound("knight/step", 5);
-        FATT DD 4 A_CustomChase();
-        FATT EE 4 A_CustomChase();
-        FATT FF 4 A_CustomChase();
+        FATT DD 4 A_SmartChase();
+        FATT EE 4 A_SmartChase();
+        FATT FF 4 A_SmartChase();
         Goto See;
 
 	SuppressiveFire:
@@ -225,9 +230,9 @@ class PB_Mancubus1 : PB_Monster
 		FATT AA 2 {Thrust(1); }
 		FATT BB 2 {Thrust(1); }
 		FATT CC 2 ;
-		FATT DD 2 {Thrust(1); A_CustomChase();}
-		FATT EE 2 A_CustomChase();
-		FATT FF 2 A_CustomChase();
+		FATT DD 2 {Thrust(1); A_SmartChase();}
+		FATT EE 2 A_SmartChase();
+		FATT FF 2 A_SmartChase();
 		Goto See;
 
     Missile:

--- a/zscript/Monsters/PBMonster.zsc
+++ b/zscript/Monsters/PBMonster.zsc
@@ -21,7 +21,6 @@ class PB_Monster : Actor abstract
 	vector3 lastPlayerPos;
 	const PI = 3.141592653589793;
 	
-
 	double lastSeenPosX;
 	double lastSeenPosY;
 	double lastSeenPosZ;
@@ -29,7 +28,6 @@ class PB_Monster : Actor abstract
 	vector3 targetHistory[20];
 	int historyIndex;
 	array <String> frames;
-
 	
 	int	HitBoxTimerNew;
 	int HitBoxTimerOld;
@@ -133,7 +131,6 @@ class PB_Monster : Actor abstract
 	// seeAllAround - Set whether a monster can look all around. Might be needed in some cases.
 	void A_SmartChase(statelabel s1 = "_a_chase_default", statelabel s2 = "_a_chase_default", int flags = 0, bool seeAllaround = false)
 	{
-		
 		// Decrement the skips counter. When we reach 0 we Look for a new Target.
 		if (retargetSkips > 0) retargetSkips--;
 		//console.Printf("RetargetSkips: %i", retargetSkips);
@@ -196,6 +193,75 @@ class PB_Monster : Actor abstract
 		if (Target)
 		{
 			Double Dist = Distance3DSquared (Target);
+			
+			// [DarynS] Merging in the A_CustomChase Suppression logic and tying it to the canSuppress variable.
+			if (canSuppress)
+			{
+				double corpseDistance = 999999; // Filling this with an arbitrary value temporarily.
+
+				if (lastSeenCorpse)
+				{
+					// If we've seen our Empty Corpse, how far was it?
+					corpseDistance = Distance3DSquared(lastSeenCorpse);
+				}
+
+				if (CheckSight(target))
+				{
+					suppress = true;
+					suppressCount = 0;
+					suppressCount2 = 0;
+					//A_Chase(s2, s1, flags);
+
+					if (lastSeenCorpse)
+					{
+						lastSeenCorpse.Destroy();
+						lastSeenCorpse = null;
+					}
+				}
+				else
+				{
+					vector3 delayedPosition = targetHistory[(historyIndex + 1) % 20];
+
+					if (!lastSeenCorpse)
+					{
+						lastSeenCorpse = Spawn("EmptyTarget", (delayedPosition.x, delayedPosition.y, delayedPosition.z + 8), ALLOW_REPLACE);
+					}
+
+					if (Dist < 300*300)
+					{
+						suppress = false;
+						//A_Chase(s2, s1, flags);
+						//return;
+					}
+
+					if (suppress)
+					{
+						if (suppressCount < suppressLimit)
+						{
+							if (ShouldDoSuppressiveFire())
+							{
+								SetStateLabel("SuppressiveFire");
+								return;
+							}
+						}
+						
+						else if (suppressCount >= suppressLimit && suppressCount2 < suppressLimit2)
+						{
+							if (ShouldDoSuppressiveFire())
+							{
+								SetStateLabel("SuppressiveFire2");
+								return;
+							}
+						}
+						
+						else
+						{
+						//	Console.Printf("\cgSuppressiveFire limit reached!");
+							suppress = false;
+						}
+					}
+				}
+			}
 			
 			// No need for a sight check here. If the player is within 150mu, make note of the time.
 			if (Dist <= 150*150)
@@ -399,7 +465,7 @@ class PB_Monster : Actor abstract
 		return diff;
 	}
 
-
+/* Disabling this since function is merged into SmartChase
 	void A_CustomChase(bool UseASmartChase = false)
 	{
 		if (target)
@@ -494,7 +560,7 @@ class PB_Monster : Actor abstract
 		//	A_Chase();
 		}
 	}
-
+*/
 
 	override void Tick()
 	{
@@ -599,7 +665,6 @@ bool CanReachTarget(class<Actor> missileType, double offsetX = 1, double offsetY
 		float offsetSide = dy + offsetY; 
 		float offsetZ = offsetZ + dz;
 
-
 		if (debug)
 		{
 		 traceHit = Line3d.LineTraceVisual(
@@ -652,18 +717,11 @@ bool CanReachTarget(class<Actor> missileType, double offsetX = 1, double offsetY
 				}
 			}
         }
-
     }
 
   //  Console.Printf(overallSuccess ? "\cdSuccess: All hit locations within threshold." : "\cjFailure: At least one hit outside threshold.");
     return overallSuccess;
 }
-
-
-
-
-
-
 
 	// Returns true if the line trace from the projectile's spawn position hits near the dummy corpse.
 	bool ShouldDoSuppressiveFire()
@@ -1862,9 +1920,6 @@ bool CanReachTarget(class<Actor> missileType, double offsetX = 1, double offsetY
 		// **Direct return of the boolean value**
 		return tracer.HasClearShot();
 	}
-
-
-
 	
 	Default
 	{
@@ -1882,9 +1937,13 @@ bool CanReachTarget(class<Actor> missileType, double offsetX = 1, double offsetY
 		//-MISSILEEVENMORE;
 		MissileChanceMult 1.0;
 		BloodType "PB_GunshotBlood", "PB_SawBlood", "PB_SawBlood";
-		PB_Monster.CanIRoll true;
-		PB_Monster.CanIFallback true;
-		PB_Monster.CanIReload true;
+
+		// [DarynS] Defaulting these flags to false for A_SmartChase failsafe.
+		PB_Monster.CanIRoll false;
+		PB_Monster.CanIFallback false;
+		PB_Monster.CanIReload false;
+		PB_Monster.CanISuppress false;
+
 		PB_Monster.MonDMGMult 2.0, 1.5, 0.70, 1.0, 1.25, 0.80;
 		PB_Monster.MonPosHB 0.8, 0.65, 0.38, 0.40;
 		PB_Monster.AttackRange 5000;

--- a/zscript/Monsters/Pinkies/PinkyDemon.zs
+++ b/zscript/Monsters/Pinkies/PinkyDemon.zs
@@ -30,6 +30,7 @@ class PB_Demon : PB_Monster
 		PB_Monster.CanIFallback false;
 		PB_Monster.CanIRoll false;
 		PB_Monster.CanIReload false;
+        PB_Monster.CanISuppress false;
     }
 
     States

--- a/zscript/Monsters/Sergeants/ZombieSergeant.zc
+++ b/zscript/Monsters/Sergeants/ZombieSergeant.zc
@@ -54,6 +54,11 @@ Class PB_ShotgunGuy : PB_Monster
 		+DOHARMSPECIES;
 		+HARMFRIENDS;
 		Species "Former_Human";
+
+		PB_Monster.CanIFallback true;
+		PB_Monster.CanIReload true;
+		PB_Monster.CanIRoll true;
+		PB_Monster.CanISuppress false;
 		
 		PB_Monster.AttackRange 1000;
 		PB_Monster.PBMonSpeed 4, 3, 1.5, 2;

--- a/zscript/Monsters/Special/CyberDemon.zc
+++ b/zscript/Monsters/Special/CyberDemon.zc
@@ -68,7 +68,10 @@ class PB_Cyberdemon1 : PB_Monster
 		DropItem "Demonpickup2", 255;
 		DropItem "Demonpickup2", 255;
 		
-
+		PB_Monster.CanIFallback false;
+		PB_Monster.CanIReload false;
+		PB_Monster.CanIRoll false;
+		PB_Monster.CanISuppress true;
     }
 	
 	override void BeginPlay()
@@ -119,22 +122,22 @@ class PB_Cyberdemon1 : PB_Monster
             TNT1 A 0 A_JumpIfTargetInLOS("Stomp", 0, JLOSF_DEADNOJUMP, 95);
             CYBR A 3;
             TNT1 A 0;
-            CYBR AA 2 A_CustomChase;
+            CYBR AA 2 A_SmartChase();
             TNT1 A 0 A_JumpIfTargetInLOS("Stomp", 0, JLOSF_DEADNOJUMP, 95);
-            CYBR BB 2 A_CustomChase;
+            CYBR BB 2 A_SmartChase();
             TNT1 A 0;
-            CYBR BBC 2 A_CustomChase;
+            CYBR BBC 2 A_SmartChase();
             TNT1 A 0 A_JumpIfTargetInLOS("Stomp", 0, JLOSF_DEADNOJUMP, 95);
             TNT1 A 0;
-            CYBR C 2 A_CustomChase;
+            CYBR C 2 A_SmartChase();
             CYBR C 2;
             CYBR C 2 A_StartSound ("cyber/metal", 6);
             TNT1 A 0;
-            CYBR D 2 A_CustomChase;
-            CYBR D 2 A_CustomChase;
+            CYBR D 2 A_SmartChase();
+            CYBR D 2 A_SmartChase();
             TNT1 A 0 A_JumpIfTargetInLOS("Stomp", 0, JLOSF_DEADNOJUMP, 95);
             TNT1 A 0;
-            CYBR DD 2 A_CustomChase;
+            CYBR DD 2 A_SmartChase();
             Loop;
         
         BossPossession: 

--- a/zscript/Monsters/ZombieMen/ZombieMan.zc
+++ b/zscript/Monsters/ZombieMen/ZombieMan.zc
@@ -59,6 +59,11 @@ Class PB_ZombieMan : PB_Monster
 		Species "Former_Human";
 		
 		PB_Monster.PBMonSpeed 4, 3, 1.5, 2;
+
+		PB_Monster.CanIFallback true;
+		PB_Monster.CanIReload true;
+		PB_Monster.CanIRoll true;
+		PB_Monster.CanISuppress false;
 	}
 		
 	int movement_direction;

--- a/zscript/Monsters/ZombieMen/ZombieScientist.zc
+++ b/zscript/Monsters/ZombieMen/ZombieScientist.zc
@@ -56,6 +56,9 @@ Class PB_ZombieScientist : PB_Monster
 		+HARMFRIENDS;
 		Species "Former_Human"; 
 		PB_Monster.CanIFallback false; //[inkoalawetrust] Why not a flag ?
+		PB_Monster.CanIReload false;
+		PB_Monster.CanIRoll true;
+		PB_Monster.CanISuppress false;
 	}
 	
 	int movement_direction;

--- a/zscript/Monsters/cacodemons/Cacodemon.zc
+++ b/zscript/Monsters/cacodemons/Cacodemon.zc
@@ -81,13 +81,20 @@ Class PB_Cacodemon : PB_Monster
 	
 	States
 	{	
-		// TODO: convert
 		Execution:
-			TNT1 A 1 A_Die("Execution");
-			Stop;
+			//TNT1 A 1 A_Die("Execution");
+			//Stop;
 		Death.Execution:
-			TNT1 A 0 A_Stopsound();
-			Stop;
+			TNT1 A 0 {
+				A_Stopsound();
+				A_FaceTarget();
+				A_NoBlocking(false);
+			}
+			HEAD BC 4;
+			TNT1 A 0 A_Pain();
+			HEAD E 21;
+			TNT1 A 0 A_Recoil(4);
+			Goto Death.SSG;
 		
 		Spawn:
 			HEAD A 10 A_Look();

--- a/zscript/Monsters/cacodemons/Cacodemon.zc
+++ b/zscript/Monsters/cacodemons/Cacodemon.zc
@@ -122,17 +122,7 @@ Class PB_Cacodemon : PB_Monster
 					//This is to prevent it from floating off into infinity
 					//due to being thrusted and has no gravity or friction
 				}
-				// [DarynS] Use Smart or CustomChase based on which variant is in play.
-				// Don't want Suppress on the base Caco, so we use CustomChase for the buffed variant.
-				// Likely going to end up making a merged, multi-purpose chase eventually.
-				if (canSuppress)
-				{
-					A_CustomChase(UseASmartChase : true); // This will make sure the A_CustomChase goes back to A_SmartChase instead of A_Chase
-				}
-				else
-				{
-					A_SmartChase();
-				}
+				A_SmartChase();
 			}
 			Loop;
 			
@@ -144,7 +134,7 @@ Class PB_Cacodemon : PB_Monster
 				else if (jawDetached)
 					return ResolveState("Missile_NoJaw");
 				// Using the canSuppress variable to temporarily turn off Special attack Cacocola Classic.
-				else if (canSuppress && random(0,100) > 50)
+				else if (GetClassName() == "PB_CacodemonBuffed" && random(0,100) > 50)
 					return ResolveState("Missile_Special");
 				return ResolveState(null);
 			}
@@ -154,7 +144,7 @@ Class PB_Cacodemon : PB_Monster
 		//	HEAD D 5 BRIGHT A_HeadAttack(); 
 			HEAD D 5 {
 				// Different attack based on the canSuppress variable. Base Caco will act more vanilla.
-				if (canSuppress)
+				if (GetClassName() == "PB_CacodemonBuffed")
 					A_DropAdjust2("PB_CacodemonBall","PB_CacodemonBall", 0, 0, 32, minRange: 0, maxRange: 1000, shootDownward: false);
 				else
 					A_SpawnProjectile("PB_CacodemonBall");
@@ -778,7 +768,7 @@ Class PB_CacodemonBuffed : PB_Cacodemon
 		PB_Monster.MonPosHB 0.7, 0.5, 0.38, 0.40;
 		PB_Monster.ignoreDickDamage true;
 		PB_Monster.CanIFallback false;
-		PB_Monster.CanIRoll true;
+		PB_Monster.CanIRoll false;
 		PB_Monster.CanIReload false;
 		PB_Monster.CanISuppress true;
 	}


### PR DESCRIPTION
+ Slowed the base Arachnotron's fire rate a bit.
+ Added Classic non-tracking fire mode to the Buffed Arachnotron's firing routines.
+ Put back Caco's Execution, though if there are special sprite-sets for this I don't have them.
+ Disabled BD's Teleport Destinations.
    - If this proves problematic, let me know.
+ Merged A_CustomChase logic into A_SmartChase. 
    - Engages when monsters have a target and the CanISuppress property is True.