### PR TITLE
More Fixes for UDB

### DIFF
--- a/CVARINFO
+++ b/CVARINFO
@@ -1,22 +1,22 @@
-server string pb_zombieman_override="Disabled";
-server string pb_sergeant_override="Disabled";
-server string pb_imp_override="Disabled";
-server string pb_chaingunner_override="Disabled";
-server string pb_pinky_override="Disabled";
-server string pb_spectre_override="Disabled";
-server string pb_cacodemon_override="Disabled";
-server string pb_painelemental_override="Disabled";
-server string pb_lostsoul_override="Disabled";
-server string pb_revenant_override="Disabled";
-server string pb_arachnotron_override="Disabled";
-server string pb_hellknight_override="Disabled";
-server string pb_baronofhell_override="Disabled";
-server string pb_mancubus_override="Disabled";
-server string pb_archvile_override="Disabled";
-server string pb_mastermind_override="Disabled";
-server string pb_cyberdemon_override="Disabled";
-server string pb_nazi_override="Disabled";
-server string pb_dog_override="Disabled";
+server string pb_zombieman_override = "Disabled";
+server string pb_sergeant_override = "Disabled";
+server string pb_imp_override = "Disabled";
+server string pb_chaingunner_override = "Disabled";
+server string pb_pinky_override = "Disabled";
+server string pb_spectre_override = "Disabled";
+server string pb_cacodemon_override = "Disabled";
+server string pb_painelemental_override = "Disabled";
+server string pb_lostsoul_override = "Disabled";
+server string pb_revenant_override = "Disabled";
+server string pb_arachnotron_override = "Disabled";
+server string pb_hellknight_override = "Disabled";
+server string pb_baronofhell_override = "Disabled";
+server string pb_mancubus_override = "Disabled";
+server string pb_archvile_override = "Disabled";
+server string pb_mastermind_override = "Disabled";
+server string pb_cyberdemon_override = "Disabled";
+server string pb_nazi_override = "Disabled";
+server string pb_dog_override = "Disabled";
 
 server bool pb_vanillamonster_override = false;
 
@@ -641,6 +641,6 @@ user int pb_gunsmoketype = 0;
 
 server bool PB_MP_MovementTesting = false;
 cheat server bool pb_forcespmovement = false;
-HandlerClass(PB_CallSignHandler) user string pb_mpcallsign = "PB3";
+user HandlerClass(PB_CallSignHandler) string pb_mpcallsign = "PB3";
 
 server int PB_PixelRenderingFix = 1;

--- a/DECORATE
+++ b/DECORATE
@@ -440,35 +440,55 @@ inventory.maxamount 1
 
 
 ACTOR CasingsJanitor: Inventory
-{Inventory.MaxAmount 1}
+{
+  Inventory.MaxAmount 1
+}
 
 //Monster Ability Toggles
 Actor NoZombieGrenade : Inventory
 {inventory.maxamount 1}
 
 Actor NoCeilingClimb : Inventory
-{inventory.maxamount 1}
+{
+  inventory.maxamount 1
+}
 
 Actor NoFoodHealth : Inventory
-{inventory.maxamount 1}
+{
+  inventory.maxamount 1
+}
 
 Actor NoJetpack : Inventory
-{inventory.maxamount 1}
+{
+  inventory.maxamount 1
+}
 
 Actor NoHellknightCharge : Inventory
-{inventory.maxamount 1}
+{
+  inventory.maxamount 1
+}
 
 Actor NoBaronBarrels : Inventory
-{inventory.maxamount 1}
+{
+  inventory.maxamount 1
+}
 
 Actor NoBigHeal : Inventory
-{inventory.maxamount 1}
+{
+  inventory.maxamount 1
+}
 
 Actor NoArchvileSummon : Inventory
-{inventory.maxamount 1}
+{
+  inventory.maxamount 1
+}
 
 Actor NoMancubusTorch : Inventory
-{inventory.maxamount 1}
+{
+  inventory.maxamount 1
+}
 
 Actor TurboReload : Inventory
-{inventory.maxamount 1}
+{
+  inventory.maxamount 1
+}

--- a/actors/Weapons/Slot3/QUADBARREL.dec
+++ b/actors/Weapons/Slot3/QUADBARREL.dec
@@ -41,7 +41,7 @@ States {
 		TNT1 A 1	A_CustomMissile("QuadFlameMissileCheaper", random(-22, 25),	random(-25, 25), random(-25, 25), CMF_AIMDIRECTION )
 		TNT1 A 2
 		Stop
-}
+	}
 }
 
 Actor QuadFlameSpawnerCheapest : QuadFlameSpawnerCheap {
@@ -51,7 +51,7 @@ Spawn:
 	TNT1 A 1	A_CustomMissile("QuadFlameMissileCheaper", random(-15, 18),	random(-15, 18), random(-22, 18), CMF_AIMDIRECTION )
 	TNT1 A 2
 	Stop 
-}
+ }
 }
 
 ACTOR QuadFlameMissileCheap : FlamethrowerMissile
@@ -107,7 +107,7 @@ States {
 		DB54 L 1 BRIGHT A_SpawnItem("RedFlare", 0, 0)
 		TNT1 A 0 A_Playsound("Afrit/Hellfire")
 		Stop
-}
+	}
 }
 
 ACTOR QuadDemonicBreath4Blast: FastProjectile
@@ -183,7 +183,7 @@ States
 			EXPL AAA 0 A_CustomMissile ("FlamethrowerFireParticles", 6, 0, random (0, 360), 2, random (0, 90))
 			TNT1 AAA 20 A_CustomMissile ("BigBlackSmoke", 0, 0, random (0, 360), 2, random (40, 160))
 			Stop
-}
+	}
 }
 
 ACTOR QuadDemonicBreathBlast: QuadDemonicBreath4Blast
@@ -232,7 +232,7 @@ States
 			TNT1 AAAAAA 0 A_CustomMissile ("FireworkSFXType2", 2, 0, random (0, 360), 2, random (10, 80))
 			TNT1 A 0 A_SpawnItemEx ("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 			Goto ExplosionEffect
-}
+	}
 }
 
 ACTOR QuadDemonicBreathOneBlast : QuadDemonicBreathBlast {
@@ -260,7 +260,7 @@ Death:
 			TNT1 AAAAAA 0 A_CustomMissile ("FireworkSFXType2", 2, 0, random (0, 360), 2, random (10, 80))
 			TNT1 A 0 A_SpawnItemEx ("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 			Goto ExplosionEffect
-}
+	}
 }
 
 ACTOR ShotgunDemonicBreathUpdated: QuadDemonicBreathOneBlast {

--- a/actors/Weapons/Slot8/CRYORIFLE.dec
+++ b/actors/Weapons/Slot8/CRYORIFLE.dec
@@ -1122,7 +1122,8 @@ Actor IceTracer {
 					A_FadeOut(0.04);
 					A_SetRoll(roll-frandom(-15,15));
 				}
-				Stop	}
+				Stop
+			}
 	}
 				
 Actor SmallIceTracer : IceTracer {
@@ -1133,7 +1134,8 @@ Actor SmallIceTracer : IceTracer {
 					A_FadeOut(0.04);
 					A_SetRoll(roll-frandom(-15,15));
 				}
-				Stop	}
+				Stop
+				}
 	}
 
 ACTOR CryoTrail {

--- a/actors/Weapons/Slot8/Flamethrower.dec
+++ b/actors/Weapons/Slot8/Flamethrower.dec
@@ -171,7 +171,7 @@ States {
 			A_SpawnItem("GreenTrailSparks");
 		}
 		Loop
-}
+	}
 }
 
 Actor PB_FlamethrowerUpgrade : CustomInventory
@@ -1390,18 +1390,18 @@ Damagetype "Fire"
 			TNT1 A 0 A_Explode(12, 36, 0, 0, 36)
 			TNT1 A 0 
 		{
-		if(GetCVar("pb_performance_fire") == false) 
-		{
-			A_SpawnItemEx("BurningEmberParticlesFloating_Bigger_Faster", random(-7,7), random(-7,-7), random(22,38), 0, 0, 0, 0, 128, 0);
-		}
+			if(GetCVar("pb_performance_fire") == false) 
+			{
+				A_SpawnItemEx("BurningEmberParticlesFloating_Bigger_Faster", random(-7,7), random(-7,-7), random(22,38), 0, 0, 0, 0, 128, 0);
+			}
 		}
 
 			TNT1 A 0 
 		{
-		if(GetCVar("pb_performance_fire") == false) 
-		{
-			A_SpawnItemEx("BigBlackSmokeMedium", random(-7,7), random(-7,7), random(12,24), 0, 0 , random(2,4));
-		}
+			if(GetCVar("pb_performance_fire") == false) 
+			{
+				A_SpawnItemEx("BigBlackSmokeMedium", random(-7,7), random(-7,7), random(12,24), 0, 0 , random(2,4));
+			}
 		}
 			TNT1 A 0 A_Jump(7, "StopBurning")
 			Loop
@@ -1443,10 +1443,10 @@ ACTOR FT_GroundFire
 			TNT1 A 0 
 				CFCF ABCDEFGHIJKLMABCDEFGHIJKLM 1 BRIGHT
 		{
-		if(GetCVar("pb_performance_fire") == false) 
-		{
-			A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire');
-		}
+			if(GetCVar("pb_performance_fire") == false) 
+			{
+				A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire');
+			}
 		}
 				CFCF A 1 A_Setscale(0.1)
 				CFCF B 1 A_Setscale(0.05)
@@ -1468,10 +1468,10 @@ ACTOR FT_GroundFire2
 			TNT1 A 0 
 				FLME ABCDEFGHIJKLMNABCDEFGHIJKLMN 1 BRIGHT
 		{
-		if(GetCVar("pb_performance_fire") == false) 
-		{
-			A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire');
-		}
+			if(GetCVar("pb_performance_fire") == false) 
+			{
+				A_AttachLightDef('FlamethrowerLight', 'FT_GroundFire');
+			}
 		}
 				FLME A 1 A_Setscale(0.3)
 				FLME B 1 A_Setscale(0.2)


### PR DESCRIPTION
Formatting stuff that threw UDB off.

Curly braces on the same line as Stop token.
CVARINFO needs spaces before and after the equals.

PB can now load as a resource with no errors.