### PR TITLE
Added a guard against NaN positions for projectiles

### DIFF
--- a/zscript/PBHandler.zc
+++ b/zscript/PBHandler.zc
@@ -370,11 +370,16 @@ class PB_EventHandler : EventHandler
 	
 	Override Void WorldThingSpawned(WorldEvent e)
 	{
-		// Guard against projectiles spawned at NaN positions (e.g. RevenantMissile
-		// fired by an incompatible enemy via third-party mods like Corruption Cards).
-		// A NaN position causes 3D audio of GZDoom to hang forever on the looping sound.
+		if (!e.Thing) return;
+
+		// Guard against projectiles spawned at NaN/infinite positions or velocities
+		// (e.g. RevenantMissile fired by an incompatible enemy via mods like Corruption
+		// Cards). A NaN position causes GZDoom's 3D audio to emit warnings; infinite
+		// velocity causes an int32 overflow in FastProjectile-derived Tick() loops that
+		// permanently stalls the game. !(v <= limit) catches both NaN and infinity.
 		let mo = e.Thing;
-		if (mo && (mo.pos.x != mo.pos.x || mo.pos.y != mo.pos.y || mo.pos.z != mo.pos.z))
+		if (mo && (!(mo.pos.x == mo.pos.x) || !(mo.pos.y == mo.pos.y) || !(mo.pos.z == mo.pos.z)
+			|| (mo.bMissile && !(Abs(mo.vel.x) <= 65535.0 && Abs(mo.vel.y) <= 65535.0 && Abs(mo.vel.z) <= 65535.0))))
 		{
 			mo.Destroy();
 			return;

--- a/zscript/PBHandler.zc
+++ b/zscript/PBHandler.zc
@@ -370,6 +370,16 @@ class PB_EventHandler : EventHandler
 	
 	Override Void WorldThingSpawned(WorldEvent e)
 	{
+		// Guard against projectiles spawned at NaN positions (e.g. RevenantMissile
+		// fired by an incompatible enemy via third-party mods like Corruption Cards).
+		// A NaN position causes 3D audio of GZDoom to hang forever on the looping sound.
+		let mo = e.Thing;
+		if (mo && (mo.pos.x != mo.pos.x || mo.pos.y != mo.pos.y || mo.pos.z != mo.pos.z))
+		{
+			mo.Destroy();
+			return;
+		}
+
 		if(!e.Thing.bCORPSE && !e.Thing.bFRIENDLY && e.thing is 'PB_Monster')
 		{
 			CVar HatsEnabled = Cvar.FindCvar("PB_HatExtravaganza");


### PR DESCRIPTION
Added a guard against NaN positions for projectiles that are spawned with 3rd party mods, e.g. with the Corruption Cards mod enabled, which can assign `RevenantMissile` as a random projectile to enemies that don't normally fire it.

The guard checks all spawned actors and any actor that spawns with a `NaN` position gets destroyed immediately, regardless of class.

This is an attempt to solve issue https://github.com/pa1nki113r/Project_Brutality/issues/1467.

Tested it the solution with assigning the cards with `ccards_debug 1` and `ccards_debugcardselect 1`, the issue appear to be gone.