### PR TITLE
fix inconsistent dashjump behavior

### DIFF
--- a/zscript/Player/PlayerPawn.zc
+++ b/zscript/Player/PlayerPawn.zc
@@ -94,7 +94,7 @@ class PlayerPawnBase : PlayerPawn
 	int		JumpSoundCooler;
 	vector3	FloorNormal;
     uint8 coyoteTime;
-	int dashJumped;
+	bool dashJumped;
 	
 	//Double Jump
 	bool	BlockDoubleJump;
@@ -698,12 +698,14 @@ class PlayerPawnBase : PlayerPawn
 						waiting = true;
 						dashCharge = 0;
 					}
+					
+					SetOrigin((pos.x, pos.y, pos.z + 1), true);
 					dashTics = 0;
 					SetInventory("PlayerDashed", 0);
 					A_StartSound("JMPBOOT", 33);
-					JumpVelZ *= 2.0;
-					VelFromAngle(JumpVelZ * 5);
-					dashJumped = 2;
+					JumpVelZ *= 1.5;
+					VelFromAngle(JumpVelZ * 6.5);
+					dashJumped = true;
 				}
 				
 				Vel.Z = (- FloorNormal.XY dot SafeUnit2(Vel.XY) > 0 ? 1.f + sin(FloorAngle) : 1.f) * JumpVelZ; // - FloorNormal.XY dot SafeUnit2(Vel.XY) > 0 == going uphill on a slope
@@ -866,9 +868,7 @@ class PlayerPawnBase : PlayerPawn
 		let player = self.player;
 		UserCmd cmd = player.cmd;
 		
-		if(dashJumped) {
-			dashJumped--;
-		}
+		dashJumped = false;
 		
 		///////////////////////////////////////////
 		//Actual Movement


### PR DESCRIPTION
it turns out the player being on the ground for an extra tic after you jump made the dashjump sometimes fail to work properly. don't fully understand it but this seemed to fix the issue