### PR TITLE
add null check to upgraded weapon pickup

### DIFF
--- a/zscript/Weapons/BaseWeapon.zc
+++ b/zscript/Weapons/BaseWeapon.zc
@@ -94,7 +94,7 @@ class PB_WeaponBase : DoomWeapon
 					owner.FindInventory(AmmoType2).amount -= 1;
 					owner.FindInventory(AmmoType1).amount += self.ReserveToMagAmmoFactor;
 				}
-				while(owner.FindInventory(AmmoTypeLeft).amount > 0 && owner.CountInv(GetClassName()) > 1){
+				while(AmmoTypeLeft && owner.FindInventory(AmmoTypeLeft).amount > 0 && owner.CountInv(GetClassName()) > 1){
 					owner.FindInventory(AmmoTypeLeft).amount -= 1;
 					owner.FindInventory(AmmoType1).amount += self.ReserveToMagAmmoFactor;
 				}


### PR DESCRIPTION
fixes abort when a weapon with dual wielding is upgraded by a weapon without it